### PR TITLE
Fix missing variable OPEX in greenfield NPV calculation

### DIFF
--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -8624,6 +8624,7 @@ class Environment:
             bom_dict["materials"][feedstock] = {
                 "demand": material_demand,
                 "total_cost": material_cost,
+                "total_material_cost": material_cost,  # Required by calculate_variable_opex
                 "unit_cost": float(unit_cost),
                 "unit_material_cost": float(unit_cost),  # Same as unit_cost for avg_boms
                 "product_volume": capacity,  # Output volume for this furnace
@@ -8648,6 +8649,7 @@ class Environment:
                     "demand": energy_demand,
                     "total_cost": total_energy_cost,
                     "unit_cost": total_energy_cost / energy_demand if energy_demand > 0 else float("inf"),
+                    "product_volume": capacity,  # Required by calculate_variable_opex
                 }
 
         utilization = (


### PR DESCRIPTION
get_bom_from_avg_boms() produced BOM dicts missing keys required by calculate_variable_opex(): energy dict lacked product_volume, materials dict lacked total_material_cost. This caused variable OPEX to silently return 0, so NPV only included fixed OPEX (~$69/t instead of ~$350/t).