### PR TITLE
48 tariffs to material cost

### DIFF
--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -17,8 +17,8 @@ from steelo.utilities.utils import normalize_name
 
 class TM_PAM_connector:
     """
-    class to connect the trade module with the PAM model - containing various methods to extract data from the trade module and update
-    the unit production costs and utilisation rates of the furnace groups
+    Connects the trade module with the PAM model — extracts data from the
+    trade module and updates unit production costs and utilisation rates.
     """
 
     def __init__(
@@ -125,6 +125,32 @@ class TM_PAM_connector:
         """
         key = (from_iso, to_iso, commodity.lower())
         return self.transport_costs.get(key, 0.0)  # Default to 0 if not found
+
+    def get_tariff_cost(self, from_iso: str, to_iso: str, commodity: str) -> float:
+        """Retrieve tariff cost between two countries for a specific commodity.
+
+        Supports wildcard keys: checks exact match first, then wildcard source,
+        wildcard destination, and wildcard commodity. All matching tariffs are summed,
+        mirroring the LP's ``return_potential_tariff_keys`` logic.
+
+        Args:
+            from_iso: Source country ISO3 code.
+            to_iso: Destination country ISO3 code.
+            commodity: Commodity name (case-insensitive).
+
+        Returns:
+            Tariff cost per ton in USD. Returns 0.0 if no tariffs apply.
+        """
+        comm = commodity.lower()
+        total = 0.0
+        for key in [
+            (from_iso, to_iso, comm),
+            ("*", to_iso, comm),
+            (from_iso, "*", comm),
+            (from_iso, to_iso, "*"),
+        ]:
+            total += self.tariff_taxes.get(key, 0.0)
+        return total
 
     def process_energy_cost(
         self,
@@ -247,6 +273,12 @@ class TM_PAM_connector:
         - Uses `self.processing_energy_cost` to fetch energy costs per process.
         - Uses `self.flat_feedstocks_dict` to lookup primary outputs and efficiencies.
         """
+        logger = logging.getLogger(f"{__name__}.create_graph")
+
+        # Store tariff taxes for edge attribute lookup
+        self.tariff_taxes: dict[tuple[str, str, str], float] = solved_trade_allocations.tariff_taxes or {}
+        logger.debug("[TARIFF] Loaded %d tariff entries", len(self.tariff_taxes))
+
         # Initialize an empty directed multigraph
         self.G = nx.MultiDiGraph()
 
@@ -283,19 +315,21 @@ class TM_PAM_connector:
                 "volume": alloc_value,
                 # 2. Transport cost from TransportKPI data
                 "transport_cost": self.get_transport_cost(from_pc.location.iso3, to_pc.location.iso3, commodity),
-                # 3. Processing energy cost, if defined for this destination
+                # 3. Tariff cost from LP tariff taxes (import/export duties)
+                "tariff_cost": self.get_tariff_cost(from_pc.location.iso3, to_pc.location.iso3, commodity),
+                # 4. Processing energy cost, if defined for this destination
                 "processing_energy_cost": total_energy_cost,
                 "processing_energy_breakdown": energy_breakdown,
-                # 4. Process identifier and commodity tag
+                # 5. Process identifier and commodity tag
                 "process": process,
                 "commodity": commodity,
-                # 5. Primary output of this process, if in the flat feedstocks map
+                # 6. Primary output of this process, if in the flat feedstocks map
                 "output": (
                     next(iter(self.flat_feedstocks_dict[process].get_primary_outputs()), None)
                     if process in self.flat_feedstocks_dict
                     else None
                 ),
-                # 6. Process efficiency (required quantity per ton of product)
+                # 7. Process efficiency (required quantity per ton of product)
                 "process_efficiency": (
                     self.flat_feedstocks_dict[process].required_quantity_per_ton_of_product
                     if process in self.flat_feedstocks_dict
@@ -329,6 +363,15 @@ class TM_PAM_connector:
 
             # Finally, add the directed edge with all computed attributes
             self.G.add_edge(from_name, to_name, key=commodity, **edge_attrs)  # allow parallel edges keyed by commodity
+
+            if edge_attrs["tariff_cost"] > 0:
+                logger.debug(
+                    "[TARIFF] %s -> %s (%s): tariff=$%.2f/t",
+                    from_name,
+                    to_name,
+                    commodity,
+                    edge_attrs["tariff_cost"],
+                )
 
     def propage_cost_forward_by_layers_and_normalize(
         self,
@@ -450,12 +493,27 @@ class TM_PAM_connector:
                     # print(f"Skipping sink node {v} with no outgoing edges")
                     continue
                 # Calculate cost components separately
-                # Material cost includes upstream material + all upstream energy + all transport
+                # Material cost includes upstream material + all upstream energy + transport + tariffs
                 # We want to track the material cost EXCLUDING the current step's energy
                 volume = edata.get(volume_attr, 0.0)
-                material_and_transport_cost = (per_unit_base + edata.get(transport_attr, 0.0)) * volume
+                material_tariff_transportation_cost = (
+                    per_unit_base + edata.get(transport_attr, 0.0) + edata.get("tariff_cost", 0.0)
+                ) * volume
                 current_step_energy_cost = edata.get(process_attr, 0.0) * volume
-                edge_cost = material_and_transport_cost + current_step_energy_cost
+                edge_cost = material_tariff_transportation_cost + current_step_energy_cost
+
+                tariff_unit = edata.get("tariff_cost", 0.0)
+                if tariff_unit > 0:
+                    logger.debug(
+                        "[COST PROP] %s -> %s (%s): base=$%.2f transport=$%.2f tariff=$%.2f energy=$%.2f",
+                        u,
+                        v,
+                        comm,
+                        per_unit_base,
+                        edata.get(transport_attr, 0.0),
+                        tariff_unit,
+                        edata.get(process_attr, 0.0),
+                    )
 
                 if (
                     diag.diagnostics_enabled()
@@ -467,7 +525,7 @@ class TM_PAM_connector:
                     transport_unit = edata.get(transport_attr, 0.0)
                     energy_unit = edata.get(process_attr, 0.0)
                     base_unit = per_unit_base
-                    total_unit = base_unit + transport_unit + energy_unit
+                    total_unit = base_unit + transport_unit + tariff_unit + energy_unit
                     delta = total_unit - base_unit
                     delta_pct = (delta / base_unit * 100) if base_unit else None
                     if delta > 500 or (delta_pct is not None and delta_pct > 100):
@@ -475,14 +533,17 @@ class TM_PAM_connector:
                         diag.append_text(
                             f"cost_propagation/{self.current_year}.txt",
                             [
-                                "node={node}, source={src}, commodity={comm}, base={base:.2f}, "
-                                "transport={transport:.2f}, energy={energy:.2f}, total={total:.2f}, "
-                                "delta={delta:.2f}, delta_pct={delta_pct}".format(
+                                "node={node}, source={src}, commodity={comm}, "
+                                "base={base:.2f}, transport={transport:.2f}, "
+                                "tariff={tariff:.2f}, energy={energy:.2f}, "
+                                "total={total:.2f}, delta={delta:.2f}, "
+                                "delta_pct={delta_pct}".format(
                                     node=v,
                                     src=u,
                                     comm=comm,
                                     base=base_unit,
                                     transport=transport_unit,
+                                    tariff=tariff_unit,
                                     energy=energy_unit,
                                     total=total_unit,
                                     delta=delta,
@@ -498,11 +559,12 @@ class TM_PAM_connector:
 
                 # Accumulate cost and volume
                 # Store both total cost and material cost (excluding current step's energy)
-                # MaterialCost includes upstream material + ALL upstream costs (including upstream energy) + current transport
+                # MaterialCost includes upstream material + ALL upstream costs
+                # (including upstream energy) + current transport + tariffs
                 # EXCLUDES the current step's processing energy
                 prev = G.nodes[v][allocation_attr].get(comm, {"Cost": 0.0, "MaterialCost": 0.0, "Volume": 0.0})
                 prev["Cost"] += edge_cost  # Total cost including current step's energy
-                prev["MaterialCost"] += material_and_transport_cost  # Excludes current step's energy only
+                prev["MaterialCost"] += material_tariff_transportation_cost  # Excludes current step's energy only
                 prev["Volume"] += volume
                 G.nodes[v][allocation_attr][comm] = prev
                 G.nodes[v][source_attr][comm] = prev["Cost"]
@@ -807,9 +869,16 @@ class TM_PAM_connector:
         # Create a custom logger specifically for this function
         logger = logging.getLogger("steelo.domain.trade_modelling.TM_PAM_connector.update_bill_of_materials")
 
-        logger.debug(f"[BOM] Starting update_bill_of_materials for {len(furnace_groups)} furnace groups")
+        logger.debug(
+            "[BOM] Starting update_bill_of_materials for %d furnace groups",
+            len(furnace_groups),
+        )
         if self.G is not None:
-            logger.debug(f"[BOM] Graph has {len(self.G.nodes)} nodes and {len(self.G.edges)} edges")
+            logger.debug(
+                "[BOM] Graph has %d nodes and %d edges",
+                len(self.G.nodes),
+                len(self.G.edges),
+            )
         else:
             logger.debug("[BOM] Graph is None!")
 
@@ -922,6 +991,16 @@ class TM_PAM_connector:
                     }
                     if product_volume <= 0 and volume > 0:
                         collect["materials"][comm]["product_volume"] = volume
+
+                    if material_cost > 0 and material_cost != cost:
+                        logger.debug(
+                            "[BOM] FG %s: %s total_material_cost=$%.2f (total_cost=$%.2f, diff=$%.2f incl. tariffs)",
+                            fg.furnace_group_id,
+                            comm,
+                            material_cost,
+                            cost,
+                            cost - material_cost,
+                        )
 
             logger.debug(f"[BOM] FG {fg.furnace_group_id}: Final BOM materials = {list(collect['materials'].keys())}")
 

--- a/src/steelo/domain/trade_modelling/trade_lp_modelling.py
+++ b/src/steelo/domain/trade_modelling/trade_lp_modelling.py
@@ -221,15 +221,19 @@ class Allocations:
     Attributes:
         allocations: Dict mapping (from, to, commodity) → flow quantity (tons/year)
         allocation_costs: Optional dict mapping (from, to, commodity) → total cost
+        tariff_taxes: Optional dict mapping (from_iso3, to_iso3, commodity) → tariff cost per unit.
+            Passed through to TM_PAM_connector so tariffs can be propagated into BOM material costs.
     """
 
     def __init__(
         self,
         allocations: dict[Tuple[ProcessCenter, ProcessCenter, Commodity], float],
         allocation_costs: dict[Tuple[ProcessCenter, ProcessCenter, Commodity], float] | None = None,
+        tariff_taxes: dict[tuple[str, str, str], float] | None = None,
     ):
         self.allocations = allocations
         self.allocation_costs = allocation_costs
+        self.tariff_taxes = tariff_taxes
 
     def get_allocation(
         self, from_processcenter: ProcessCenter, to_processcenter: ProcessCenter, commodity: Commodity
@@ -1599,7 +1603,11 @@ class TradeLPModel:
                     from_pc_name, to_pc_name, commodity_name
                 ]
 
-        self.allocations = Allocations(allocations=allocations, allocation_costs=allocation_costs)
+        self.allocations = Allocations(
+            allocations=allocations,
+            allocation_costs=allocation_costs,
+            tariff_taxes=dict(self.tariff_taxes_by_iso3) if self.tariff_taxes_by_iso3 else None,
+        )
         # self.allocations.validate_allocations()
 
     def get_solution_for_warm_start(self) -> dict[tuple[str, str, str], float]:

--- a/tests/unit/test_tm_pam_connector_tariff_propagation.py
+++ b/tests/unit/test_tm_pam_connector_tariff_propagation.py
@@ -1,0 +1,365 @@
+"""
+Test suite for tariff cost propagation through TM_PAM_connector.
+
+Verifies that tariff costs from the LP model flow correctly through
+the trade graph into BOM total_material_cost, matching the same
+propagation path as transport costs.
+"""
+
+import pytest
+from steelo.domain.trade_modelling.TM_PAM_connector import TM_PAM_connector
+from steelo.domain.trade_modelling import trade_lp_modelling as tlp
+from steelo.adapters.repositories.in_memory_repository import PlantInMemoryRepository
+
+
+class DummyLocation:
+    """Mock location for testing."""
+
+    def __init__(self, iso3="USA", country="United States", lat=40.0, lon=-74.0):
+        self.iso3 = iso3
+        self.country = country
+        self.lat = lat
+        self.lon = lon
+
+
+def _make_supplier(name, iso3, commodity_name, cost, capacity=1000.0):
+    """Create a supplier ProcessCenter with given parameters."""
+    process = tlp.Process(
+        name=f"{commodity_name}_supply",
+        type=tlp.ProcessType.SUPPLY,
+        bill_of_materials=[],
+    )
+    return tlp.ProcessCenter(
+        name=name,
+        process=process,
+        capacity=capacity,
+        location=DummyLocation(iso3=iso3),
+        production_cost=cost,
+    )
+
+
+def _make_furnace(name, iso3, process_name="bf", capacity=500.0):
+    """Create a furnace ProcessCenter."""
+    process = tlp.Process(
+        name=process_name,
+        type=tlp.ProcessType.PRODUCTION,
+        bill_of_materials=[],
+    )
+    return tlp.ProcessCenter(
+        name=name,
+        process=process,
+        capacity=capacity,
+        location=DummyLocation(iso3=iso3),
+        production_cost=0.0,
+    )
+
+
+def _make_demand(name, iso3, capacity=1000.0):
+    """Create a demand ProcessCenter."""
+    process = tlp.Process(
+        name="demand",
+        type=tlp.ProcessType.DEMAND,
+        bill_of_materials=[],
+    )
+    return tlp.ProcessCenter(
+        name=name,
+        process=process,
+        capacity=capacity,
+        location=DummyLocation(iso3=iso3),
+        production_cost=0.0,
+    )
+
+
+def _make_connector():
+    """Create a TM_PAM_connector with empty repositories."""
+    plants_repo = PlantInMemoryRepository()
+    return TM_PAM_connector(
+        dynamic_feedstocks_classes={},
+        plants=plants_repo,
+        transport_kpis=None,
+    )
+
+
+def test_tariff_stored_as_edge_attribute():
+    """Tariff taxes from Allocations are stored as edge attributes on the graph."""
+    supplier_pc = _make_supplier("sup_aus", "AUS", "io_low", cost=70.0)
+    furnace_pc = _make_furnace("plant_deu_bf", "DEU")
+    commodity = tlp.Commodity(name="io_low")
+
+    tariff_taxes = {("AUS", "DEU", "io_low"): 10.0}
+
+    allocations = tlp.Allocations(
+        allocations={(supplier_pc, furnace_pc, commodity): 100.0},
+        tariff_taxes=tariff_taxes,
+    )
+
+    connector = _make_connector()
+    connector.create_graph(allocations)
+
+    edge_data = connector.G["sup_aus"]["plant_deu_bf"]["io_low"]
+    assert edge_data["tariff_cost"] == 10.0, "Tariff should be stored as edge attribute"
+
+
+def test_tariff_zero_when_no_tariff_applies():
+    """Edges without matching tariffs get tariff_cost=0."""
+    supplier_pc = _make_supplier("sup_aus", "AUS", "io_low", cost=70.0)
+    furnace_pc = _make_furnace("plant_chn_bf", "CHN")
+    commodity = tlp.Commodity(name="io_low")
+
+    # Tariff only on AUS->DEU, not AUS->CHN
+    tariff_taxes = {("AUS", "DEU", "io_low"): 10.0}
+
+    allocations = tlp.Allocations(
+        allocations={(supplier_pc, furnace_pc, commodity): 100.0},
+        tariff_taxes=tariff_taxes,
+    )
+
+    connector = _make_connector()
+    connector.create_graph(allocations)
+
+    edge_data = connector.G["sup_aus"]["plant_chn_bf"]["io_low"]
+    assert edge_data["tariff_cost"] == 0.0, "No tariff should apply on this route"
+
+
+def test_tariff_wildcard_source():
+    """Wildcard '*' in from_iso3 matches any source country."""
+    supplier_pc = _make_supplier("sup_bra", "BRA", "io_low", cost=60.0)
+    furnace_pc = _make_furnace("plant_deu_bf", "DEU")
+    commodity = tlp.Commodity(name="io_low")
+
+    tariff_taxes = {("*", "DEU", "io_low"): 15.0}
+
+    allocations = tlp.Allocations(
+        allocations={(supplier_pc, furnace_pc, commodity): 100.0},
+        tariff_taxes=tariff_taxes,
+    )
+
+    connector = _make_connector()
+    connector.create_graph(allocations)
+
+    edge_data = connector.G["sup_bra"]["plant_deu_bf"]["io_low"]
+    assert edge_data["tariff_cost"] == 15.0, "Wildcard source tariff should match any origin"
+
+
+def test_tariff_wildcard_destination():
+    """Wildcard '*' in to_iso3 matches any destination country."""
+    supplier_pc = _make_supplier("sup_aus", "AUS", "io_low", cost=70.0)
+    furnace_pc = _make_furnace("plant_chn_bf", "CHN")
+    commodity = tlp.Commodity(name="io_low")
+
+    tariff_taxes = {("AUS", "*", "io_low"): 8.0}
+
+    allocations = tlp.Allocations(
+        allocations={(supplier_pc, furnace_pc, commodity): 100.0},
+        tariff_taxes=tariff_taxes,
+    )
+
+    connector = _make_connector()
+    connector.create_graph(allocations)
+
+    edge_data = connector.G["sup_aus"]["plant_chn_bf"]["io_low"]
+    assert edge_data["tariff_cost"] == 8.0, "Wildcard destination tariff should match any destination"
+
+
+def test_tariff_wildcard_commodity():
+    """Wildcard '*' in commodity matches any commodity."""
+    supplier_pc = _make_supplier("sup_aus", "AUS", "io_low", cost=70.0)
+    furnace_pc = _make_furnace("plant_deu_bf", "DEU")
+    commodity = tlp.Commodity(name="io_low")
+
+    tariff_taxes = {("AUS", "DEU", "*"): 5.0}
+
+    allocations = tlp.Allocations(
+        allocations={(supplier_pc, furnace_pc, commodity): 100.0},
+        tariff_taxes=tariff_taxes,
+    )
+
+    connector = _make_connector()
+    connector.create_graph(allocations)
+
+    edge_data = connector.G["sup_aus"]["plant_deu_bf"]["io_low"]
+    assert edge_data["tariff_cost"] == 5.0, "Wildcard commodity tariff should match any commodity"
+
+
+def test_multiple_wildcard_tariffs_are_summed():
+    """Multiple matching wildcard tariffs are summed together."""
+    supplier_pc = _make_supplier("sup_aus", "AUS", "io_low", cost=70.0)
+    furnace_pc = _make_furnace("plant_deu_bf", "DEU")
+    commodity = tlp.Commodity(name="io_low")
+
+    tariff_taxes = {
+        ("AUS", "DEU", "io_low"): 10.0,  # Exact match
+        ("*", "DEU", "io_low"): 5.0,  # Wildcard source
+        ("AUS", "*", "io_low"): 3.0,  # Wildcard destination
+        ("AUS", "DEU", "*"): 2.0,  # Wildcard commodity
+    }
+
+    allocations = tlp.Allocations(
+        allocations={(supplier_pc, furnace_pc, commodity): 100.0},
+        tariff_taxes=tariff_taxes,
+    )
+
+    connector = _make_connector()
+    connector.create_graph(allocations)
+
+    edge_data = connector.G["sup_aus"]["plant_deu_bf"]["io_low"]
+    assert edge_data["tariff_cost"] == pytest.approx(20.0), "All matching tariffs should be summed: 10 + 5 + 3 + 2 = 20"
+
+
+def test_tariff_propagates_into_material_cost():
+    """
+    Tariff cost propagates into MaterialCost on the destination node.
+
+    Verifies the full chain: edge tariff_cost -> material_tariff_transportation_cost
+    -> node allocations MaterialCost.
+    """
+    supplier_pc = _make_supplier("sup_aus", "AUS", "io_low", cost=70.0)
+    furnace_pc = _make_furnace("plant_deu_bf", "DEU")
+    demand_pc = _make_demand("deu_demand", "DEU")
+    commodity = tlp.Commodity(name="io_low")
+    steel = tlp.Commodity(name="steel")
+
+    tariff_taxes = {("AUS", "DEU", "io_low"): 15.0}
+
+    allocations = tlp.Allocations(
+        allocations={
+            (supplier_pc, furnace_pc, commodity): 100.0,
+            (furnace_pc, demand_pc, steel): 100.0,
+        },
+        tariff_taxes=tariff_taxes,
+    )
+
+    connector = _make_connector()
+    connector.create_graph(allocations)
+    connector.propage_cost_forward_by_layers_and_normalize()
+
+    furnace_node = connector.G.nodes["plant_deu_bf"]
+    alloc = furnace_node["allocations"]["io_low"]
+
+    # MaterialCost = (base + transport + tariff) * volume
+    # base = 70.0 (supplier cost), transport = 0.0 (no TransportKPIs), tariff = 15.0
+    # MaterialCost = (70 + 0 + 15) * 100 = 8500
+    assert alloc["MaterialCost"] == pytest.approx(8_500.0), (
+        "MaterialCost should include tariff: (70 + 0 + 15) * 100 = 8500"
+    )
+
+    # Cost = MaterialCost + energy = 8500 + 0 = 8500 (no energy cost configured)
+    assert alloc["Cost"] == pytest.approx(8_500.0), (
+        "Cost should equal MaterialCost when no processing energy is configured"
+    )
+
+
+def test_tariff_excluded_from_no_tariff_route():
+    """
+    Only the route with a tariff gets the extra cost; other routes are unaffected.
+    """
+    supplier_aus = _make_supplier("sup_aus", "AUS", "io_low", cost=70.0)
+    supplier_bra = _make_supplier("sup_bra", "BRA", "io_low", cost=60.0)
+    furnace_pc = _make_furnace("plant_deu_bf", "DEU")
+    demand_pc = _make_demand("deu_demand", "DEU")
+    commodity = tlp.Commodity(name="io_low")
+    steel = tlp.Commodity(name="steel")
+
+    # Tariff only on AUS->DEU, not BRA->DEU
+    tariff_taxes = {("AUS", "DEU", "io_low"): 15.0}
+
+    allocations = tlp.Allocations(
+        allocations={
+            (supplier_aus, furnace_pc, commodity): 100.0,
+            (supplier_bra, furnace_pc, commodity): 200.0,
+            (furnace_pc, demand_pc, steel): 300.0,
+        },
+        tariff_taxes=tariff_taxes,
+    )
+
+    connector = _make_connector()
+    connector.create_graph(allocations)
+    connector.propage_cost_forward_by_layers_and_normalize()
+
+    furnace_node = connector.G.nodes["plant_deu_bf"]
+    alloc = furnace_node["allocations"]["io_low"]
+
+    # AUS: (70 + 0 + 15) * 100 = 8500 (with tariff)
+    # BRA: (60 + 0 + 0)  * 200 = 12000 (no tariff)
+    # MaterialCost = 8500 + 12000 = 20500
+    assert alloc["MaterialCost"] == pytest.approx(20_500.0), "MaterialCost should be AUS(8500) + BRA(12000) = 20500"
+
+
+def test_no_tariff_taxes_defaults_to_zero():
+    """When Allocations has no tariff_taxes, all edges get tariff_cost=0."""
+    supplier_pc = _make_supplier("sup_aus", "AUS", "io_low", cost=70.0)
+    furnace_pc = _make_furnace("plant_deu_bf", "DEU")
+    commodity = tlp.Commodity(name="io_low")
+
+    allocations = tlp.Allocations(
+        allocations={(supplier_pc, furnace_pc, commodity): 100.0},
+        tariff_taxes=None,
+    )
+
+    connector = _make_connector()
+    connector.create_graph(allocations)
+
+    edge_data = connector.G["sup_aus"]["plant_deu_bf"]["io_low"]
+    assert edge_data["tariff_cost"] == 0.0, "No tariff_taxes means zero tariff on all edges"
+
+
+def test_tariff_cascades_through_multi_step_supply_chain():
+    """
+    Tariff on io_low cascades through BF -> BOF supply chain.
+
+    The tariff enters at the supplier->BF edge, gets incorporated into
+    BF's MaterialCost, then propagates further when BF's output (hot_metal)
+    flows to the BOF.
+    """
+
+    class StubFeedstock:
+        """Minimal feedstock stub for process efficiency lookup."""
+
+        def __init__(self):
+            self.required_quantity_per_ton_of_product = 1.0
+
+        def get_primary_outputs(self, primary_products=None):
+            return {"hot_metal": 1.0}
+
+    supplier_pc = _make_supplier("sup_aus", "AUS", "io_low", cost=70.0)
+    bf_pc = _make_furnace("plant_deu_bf", "DEU", process_name="bf")
+    bof_pc = _make_furnace("plant_deu_bof", "DEU", process_name="bof")
+    demand_pc = _make_demand("deu_demand", "DEU")
+
+    io_low = tlp.Commodity(name="io_low")
+    hot_metal = tlp.Commodity(name="hot_metal")
+    steel = tlp.Commodity(name="steel")
+
+    tariff_taxes = {("AUS", "DEU", "io_low"): 15.0}
+
+    allocations = tlp.Allocations(
+        allocations={
+            (supplier_pc, bf_pc, io_low): 100.0,
+            (bf_pc, bof_pc, hot_metal): 100.0,
+            (bof_pc, demand_pc, steel): 100.0,
+        },
+        tariff_taxes=tariff_taxes,
+    )
+
+    connector = _make_connector()
+    connector.flat_feedstocks_dict["bf_io_low"] = StubFeedstock()
+    connector.create_graph(allocations)
+    connector.propage_cost_forward_by_layers_and_normalize()
+
+    # BF node: io_low MaterialCost = (70 + 0 + 15) * 100 = 8500
+    bf_node = connector.G.nodes["plant_deu_bf"]
+    assert bf_node["allocations"]["io_low"]["MaterialCost"] == pytest.approx(8_500.0), (
+        "BF should accumulate tariff in io_low MaterialCost"
+    )
+
+    # BOF node: hot_metal cost should carry the upstream tariff
+    # per_unit_base at BF = 8500 / 100 (export volume) = 85.0
+    # hot_metal MaterialCost at BOF = 85.0 * 100 = 8500
+    bof_node = connector.G.nodes["plant_deu_bof"]
+    assert bof_node["allocations"]["hot_metal"]["MaterialCost"] == pytest.approx(8_500.0), (
+        "BOF should receive upstream tariff via hot_metal cost propagation"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Tariffs previously only influenced LP flow optimisation but were discarded
  after solving — they never reached the BOM or unit_production_cost
- The post-processed column "material cost (incl. transport and tariffs)" was
  misleading: it included transport but not tariffs
- This PR passes tariff_taxes through the Allocations object to TM_PAM_connector,
  stores them as edge attributes, and includes them in the cost propagation
  formula alongside transport costs

## What this covers

**Upstream commodity tariffs** (e.g. io_low, scrap, hot_metal) now flow through
the graph into `total_material_cost` → VOPEX → `unit_production_cost`. Verified
with a $15/t io_low tariff on imports to DEU — shows up correctly in the
post-processed CSV with amplification from process efficiency (~$22.74/t output).

## What this doesn't cover (yet)

**Output commodity tariffs** (e.g. steel) sit on edges to demand sink nodes,
which are skipped during cost propagation. These need a different approach —
likely a separate `output_tariff_per_unit` field on the furnace group, similar
to how carbon cost is handled.

## Test plan

- 10 new unit tests covering edge storage, wildcard matching, propagation,
  multi-step cascade
- Simulation run with test tariffs confirmed propagation in logs and
  post-processed CSV
