### PR TITLE
Opening renovation balance & Electron app fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ from typing import Any
 project = "Steel Model"
 author = "Steel Model Team"
 copyright = "2025, Steel Model Team"
-version = "1.2.0"  # Can be automated from pyproject.toml later
+version = "2.0.0"  # Can be automated from pyproject.toml later
 release = version
 
 # Track whether we are building the public site (set via `-t public`)

--- a/docs/domain_simulation_logic/plant_agent_model/economic_considerations.md
+++ b/docs/domain_simulation_logic/plant_agent_model/economic_considerations.md
@@ -315,6 +315,48 @@ This ordering prevents double-counting and ensures energy subsidies affect all c
 
 ---
 
+## 8. Opening Renovation Balance
+
+### Purpose
+
+The simulation start year is arbitrary — real-world plants would have accumulated working capital over their operating history. To reflect this, each initial plant's balance is seeded before the first simulation year with the sum of renovation costs across its active furnace groups, scaled by a configurable multiplier:
+
+```
+Plant.balance = Σ (greenfield_capex × renovation_share × capacity × equity_share × multiplier)
+```
+
+Where:
+- `greenfield_capex`: CAPEX per tonne for the FG's technology and region
+- `renovation_share`: fraction of greenfield CAPEX needed for renovation
+- `capacity`: FG capacity in tonnes
+- `equity_share`: equity financing fraction (default 20%)
+- `multiplier`: `opening_balance_multiplier` config parameter (default 1.0)
+
+### Eligible FGs
+
+Only FGs satisfying all of these conditions contribute to the plant's opening balance:
+- Not created by PAM (`created_by_PAM == False`)
+- Active status (operating, operating pre-retirement, operating switching technology)
+- Capacity > 0
+- Technology is not "other"
+
+### What is NOT seeded
+
+- `FG.historic_balance` stays at 0 — it tracks real simulation performance only
+- `FG.balance` is an annual scratch-pad, reset after aggregation
+
+### Configuration
+
+```python
+opening_balance_multiplier: float = 1.0
+```
+
+- `1.0`: plant can afford one renovation per FG (default)
+- `0.5`: half renovation cost, forcing prioritisation
+- `0.0`: disabled (legacy behaviour)
+
+---
+
 ## Interaction Effects
 
 ### Price × Carbon Cost

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "steel-model"
-version = "1.2.0"
-description = "Add your description here"
+version = "2.0.0"
+description = "Steel decarbonisation model"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "django",
     "django-environ",
     "django-htmx",
-    "django-tasks>=0.9.0",
+    "django-tasks>=0.9.0,<0.12",
     "whitenoise",
     "rioxarray>=0.19.0",
     "pydeck>=0.9.1",

--- a/src/electron/build-django.js
+++ b/src/electron/build-django.js
@@ -992,7 +992,19 @@ print("[OK] All NetCDF4 and HDF5 packages are installed")
       }
       
       console.log('[OK] Complete python-build-standalone copied');
-      
+
+      // Remove GNU libiconv from python-build-standalone on macOS.
+      // It exports _libiconv (GNU names) but pyogrio/fiona's libgdal expects _iconv (POSIX names)
+      // from the system /usr/lib/libiconv.2.dylib. DYLD_LIBRARY_PATH causes the bundled GNU version
+      // to shadow the system one, breaking geopandas shapefile reading.
+      if (IS_MAC) {
+        const gnuLibiconv = path.join(pythonDir, 'lib', 'libiconv.2.dylib');
+        if (fs.existsSync(gnuLibiconv)) {
+          fs.unlinkSync(gnuLibiconv);
+          console.log('[OK] Removed GNU libiconv.2.dylib (system libiconv will be used instead)');
+        }
+      }
+
       // CRITICAL: Verify bundled libpython shared library exists
       const libDir = path.join(pythonDir, 'lib');
       let libpythonFound = false;

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -470,7 +470,7 @@ function getPythonEnv(djangoBundlePath, pythonPathEnv) {
   // Get app version for database isolation
   // Using require (created via createRequire) for JSON file
   const packageJson = require('./package.json');
-  const appVersion = packageJson.version || '1.2.0';
+  const appVersion = packageJson.version || '2.0.0';
 
   const env = {
     ...process.env,

--- a/src/electron/package.json
+++ b/src/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steelo-electron",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "type": "module",
   "productName": "STEEL-IQ",
   "description": "STEEL-IQ Desktop Application",

--- a/src/steelo/data/manifest.json
+++ b/src/steelo/data/manifest.json
@@ -98,11 +98,11 @@
     },
     {
       "name": "master-input",
-      "version": "1.2.0",
-      "url": "https://steelo-data.s3.eu-north-1.amazonaws.com/master_input_vlive_1.2.xlsx",
-      "size_mb": 60.9,
-      "checksum": "aed20912c9c6146a2ce62b0bd484fed455edc9ec61e91679d061fbb2419f4f81",
-      "description": "Master input Excel file containing all simulation input data - Updated 2025-12-17 (vlive 1.2)",
+      "version": "1.3.0",
+      "url": "https://steelo-data.s3.eu-north-1.amazonaws.com/master_input_v1.3.0.xlsx",
+      "size_mb": 56.4,
+      "checksum": "42bf1a5bcda8e13039110214ca51b656fb03cd15cb7ea422634ce13815c592ef",
+      "description": "Master input Excel file containing all simulation input data - Updated 2026-04-10 (v1.3.0)",
       "required": false,
       "files": ["master_input.xlsx"]
     }

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -3965,6 +3965,10 @@ class Plant:
                 logger.debug(f"[FG STRATEGY]   - Capacity: {furnace_group.capacity * T_TO_KT:,.0f} kt")
                 logger.debug(f"[FG STRATEGY]   - Equity share: {furnace_group.equity_share:.1%}")
                 logger.debug(f"[FG STRATEGY]   - Total cost: ${renovate_cost:,.2f}")
+                logger.info(
+                    f"[FG STRATEGY]   - Plant balance: ${self.balance:,.2f}, "
+                    f"headroom: ${self.balance - renovate_cost:,.2f}"
+                )
 
                 # Check affordability
                 if renovate_cost > self.balance:
@@ -4017,6 +4021,9 @@ class Plant:
         logger.debug(f"[FG STRATEGY]   - Capacity: {furnace_group.capacity * T_TO_KT:,.0f} kt")
         logger.debug(f"[FG STRATEGY]   - Equity share: {furnace_group.equity_share:.1%}")
         logger.debug(f"[FG STRATEGY]   - Total cost: ${switch_cost:,.2f}")
+        logger.info(
+            f"[FG STRATEGY]   - Plant balance: ${self.balance:,.2f}, headroom: ${self.balance - switch_cost:,.2f}"
+        )
 
         # Check affordability
         if switch_cost > self.balance:

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -340,6 +340,9 @@ class SimulationConfig:
     equity_share: float = 0.2  # 20%
     global_risk_free_rate: float = 0.0209  # 2.09% risk-free rate
 
+    # Multiplier on renovation cost used to seed initial plant balances
+    opening_balance_multiplier: float = 1.0  # 1.0 = can afford one renovation per FG, 0.0 = disabled
+
     # Price increase when demand exceeds supply
     steel_price_buffer: float = 200.0  # USD/tonne - buffer above highest cost curve price when demand exceeds supply
     iron_price_buffer: float = 200.0  # USD/tonne - buffer above highest cost curve price when demand exceeds supply
@@ -536,6 +539,9 @@ class SimulationConfig:
                 self.technology_settings["BFBOF"] = TechnologySettings(
                     allowed=False, from_year=start_year_int, to_year=None
                 )
+
+        if self.opening_balance_multiplier < 0:
+            raise ValueError("opening_balance_multiplier must be >= 0.0")
 
         # Convert strings to Path objects if needed
         self.output_dir = Path(self.output_dir)
@@ -892,6 +898,95 @@ class Progress:
     current_year: Year | None = None
 
 
+def _seed_opening_balances(
+    plants: list,
+    env: Any,
+    multiplier: float,
+    active_statuses: list[str],
+) -> None:
+    """Seed Plant.balance for initial plants to represent pre-simulation capital.
+
+    Args:
+        plants: All plants loaded from input data.
+        env: Environment with CAPEX and renovation share data.
+        multiplier: Fraction of renovation cost to seed. 0.0 = disabled, 1.0 = full.
+        active_statuses: FG statuses eligible for inclusion.
+    """
+    seed_logger = logging.getLogger(f"{__name__}._seed_opening_balances")
+    iso3_to_region = env.country_mappings.iso3_to_region()
+    active_lower = [s.lower() for s in active_statuses]
+
+    for plant in plants:
+        plant_opening = 0.0
+        for fg in plant.furnace_groups:
+            if (
+                fg.created_by_PAM
+                or fg.capacity == 0
+                or fg.status.lower() not in active_lower
+                or fg.technology.name.lower() == "other"
+            ):
+                continue
+
+            region = iso3_to_region.get(plant.location.iso3)
+            if region is None:
+                seed_logger.warning(
+                    "[OPENING BALANCE] No region mapping for %s, skipping FG %s",
+                    plant.location.iso3,
+                    fg.furnace_group_id,
+                )
+                continue
+
+            greenfield_capex = (
+                env.name_to_capex.get(
+                    "greenfield",
+                    {},
+                )
+                .get(region, {})
+                .get(fg.technology.name)
+            )
+            if greenfield_capex is None:
+                seed_logger.warning(
+                    "[OPENING BALANCE] No greenfield CAPEX for %s in %s, skipping FG %s",
+                    fg.technology.name,
+                    region,
+                    fg.furnace_group_id,
+                )
+                continue
+
+            renovation_share = env.capex_renovation_share.get(fg.technology.name)
+            if renovation_share is None:
+                seed_logger.warning(
+                    "[OPENING BALANCE] No renovation share for %s, skipping FG %s",
+                    fg.technology.name,
+                    fg.furnace_group_id,
+                )
+                continue
+
+            renovation_cost = greenfield_capex * renovation_share * fg.capacity * fg.equity_share
+            opening = renovation_cost * multiplier
+            plant_opening += opening
+
+            seed_logger.debug(
+                "[OPENING BALANCE] FG %s (%s): $%s (CAPEX=$%s/t x share=%.2f x cap=%st x equity=%.2f x mult=%s)",
+                fg.furnace_group_id,
+                fg.technology.name,
+                f"{opening:,.2f}",
+                f"{greenfield_capex:,.2f}",
+                renovation_share,
+                f"{fg.capacity:,.0f}",
+                fg.equity_share,
+                multiplier,
+            )
+
+        plant.balance = plant_opening
+        if plant_opening > 0:
+            seed_logger.info(
+                "[OPENING BALANCE] Plant %s: $%s",
+                plant.plant_id,
+                f"{plant_opening:,.2f}",
+            )
+
+
 class SimulationRunner:
     """
     A class that orchestrates the full simulation process.
@@ -966,6 +1061,15 @@ class SimulationRunner:
             new_plant_group = PlantGroup(plant_group_id=pg_id, plants=plants)
             bus.uow.plant_groups.add(new_plant_group)
 
+        # Seed opening balances for initial plants
+        if self.config.opening_balance_multiplier > 0:
+            _seed_opening_balances(
+                plants=bus.uow.plants.list(),
+                env=bus.env,
+                multiplier=self.config.opening_balance_multiplier,
+                active_statuses=self.config.active_statuses,
+            )
+
         # Report initial progress before processing any simulation year
         progress = Progress(start_year=start_year, end_year=end_year, current_year=start_year - 1)
         self.progress_callback(progress)
@@ -1005,6 +1109,19 @@ class SimulationRunner:
 
             # Set the environment year to match the loop iteration
             bus.env.year = Year(i)
+
+            # Log plant balance distribution in early years for opening balance verification
+            if i <= start_year + 4:
+                balances = [p.balance for p in bus.uow.plants.list()]
+                logger.debug(
+                    "[OPENING BALANCE] Year %d plant balances: min=$%s, max=$%s, mean=$%s, positive=%d/%d",
+                    i,
+                    f"{min(balances):,.0f}",
+                    f"{max(balances):,.0f}",
+                    f"{sum(balances) / len(balances):,.0f}",
+                    sum(1 for b in balances if b > 0),
+                    len(balances),
+                )
 
             # Set demand and plant costs for the year
             bus.env.calculate_demand()

--- a/src/steeloweb/forms.py
+++ b/src/steeloweb/forms.py
@@ -205,6 +205,28 @@ class ModelRunCreateForm(forms.ModelForm):
         widget=forms.NumberInput(attrs={"class": "form-control field-connected", "step": "0.1"}),
     )
 
+    peg_iron_to_steel_price = forms.BooleanField(
+        label="Peg iron price to steel price",
+        initial=False,
+        required=False,
+        help_text="When enabled, iron price is floored at a percentage of the steel price instead of following cost curves alone",
+        widget=forms.CheckboxInput(
+            attrs={"class": "form-check-input field-connected", "id": "id_peg_iron_to_steel_price"}
+        ),
+    )
+
+    iron_to_steel_price_ratio = forms.DecimalField(
+        label="Iron-to-steel price ratio",
+        initial=0.8,
+        min_value=0.0,
+        max_value=1.0,
+        max_digits=3,
+        decimal_places=2,
+        required=False,
+        help_text="Ratio of steel price used as iron price floor when pegging is enabled (0.8 = 80% of steel price)",
+        widget=forms.NumberInput(attrs={"class": "form-control field-connected", "step": "0.01"}),
+    )
+
     opening_balance_multiplier = forms.DecimalField(
         label="Plant opening balance multiplier",
         initial=1.0,
@@ -352,6 +374,14 @@ class ModelRunCreateForm(forms.ModelForm):
         initial=True,
         required=False,
         help_text="Include tariffs in trade calculations",
+        widget=forms.CheckboxInput(attrs={"class": "form-check-input field-connected"}),
+    )
+
+    enable_furnace_group_clustering = forms.BooleanField(
+        label="Enable furnace group clustering",
+        initial=False,
+        required=False,
+        help_text="Speed up trade calculations by grouping similar furnace groups (same technology, reductant, and country) into clusters",
         widget=forms.CheckboxInput(attrs={"class": "form-check-input field-connected"}),
     )
 
@@ -637,6 +667,8 @@ class ModelRunCreateForm(forms.ModelForm):
             "global_risk_free_rate",
             "steel_price_buffer",
             "iron_price_buffer",
+            "peg_iron_to_steel_price",
+            "iron_to_steel_price_ratio",
             "opening_balance_multiplier",
             "construction_time",
             "consideration_time",
@@ -655,6 +687,7 @@ class ModelRunCreateForm(forms.ModelForm):
             # Policy Settings
             "use_iron_ore_premiums",
             "include_tariffs",
+            "enable_furnace_group_clustering",
             # Demand and Circularity
             "total_steel_demand_scenario",
             "green_steel_demand_scenario",

--- a/src/steeloweb/forms.py
+++ b/src/steeloweb/forms.py
@@ -205,6 +205,18 @@ class ModelRunCreateForm(forms.ModelForm):
         widget=forms.NumberInput(attrs={"class": "form-control field-connected", "step": "0.1"}),
     )
 
+    opening_balance_multiplier = forms.DecimalField(
+        label="Plant opening balance multiplier",
+        initial=1.0,
+        min_value=0.0,
+        max_value=100.0,
+        max_digits=5,
+        decimal_places=2,
+        required=False,
+        help_text="Scales the opening cash balance for plants at simulation start: 1.0 gives each furnace group enough to fund one renovation, 0.0 starts with empty balances",
+        widget=forms.NumberInput(attrs={"class": "form-control field-connected", "step": "0.01"}),
+    )
+
     construction_time = forms.IntegerField(
         initial=4,
         min_value=1,
@@ -625,6 +637,7 @@ class ModelRunCreateForm(forms.ModelForm):
             "global_risk_free_rate",
             "steel_price_buffer",
             "iron_price_buffer",
+            "opening_balance_multiplier",
             "construction_time",
             "consideration_time",
             # Plant Construction Settings

--- a/src/steeloweb/models.py
+++ b/src/steeloweb/models.py
@@ -627,6 +627,8 @@ class ModelRun(models.Model):
             "global_risk_free_rate",
             "steel_price_buffer",
             "iron_price_buffer",
+            "peg_iron_to_steel_price",
+            "iron_to_steel_price_ratio",
             "opening_balance_multiplier",
             # Output paths (optional, will be derived from output_dir if not provided)
             "plots_dir",
@@ -664,6 +666,7 @@ class ModelRun(models.Model):
             "chosen_grid_emissions_scenario",
             "use_iron_ore_premiums",
             "green_steel_emissions_limit",
+            "enable_furnace_group_clustering",
             # Feature flags
             "include_infrastructure_cost",
             "include_transport_cost",

--- a/src/steeloweb/models.py
+++ b/src/steeloweb/models.py
@@ -627,6 +627,7 @@ class ModelRun(models.Model):
             "global_risk_free_rate",
             "steel_price_buffer",
             "iron_price_buffer",
+            "opening_balance_multiplier",
             # Output paths (optional, will be derived from output_dir if not provided)
             "plots_dir",
             "geo_plots_dir",

--- a/src/steeloweb/templates/steeloweb/create_modelrun.html
+++ b/src/steeloweb/templates/steeloweb/create_modelrun.html
@@ -69,6 +69,7 @@ function resetEconomicParameters() {
     document.getElementById('id_global_risk_free_rate').value = '0.0209';
     document.getElementById('id_steel_price_buffer').value = '200.0';
     document.getElementById('id_iron_price_buffer').value = '200.0';
+    document.getElementById('id_opening_balance_multiplier').value = '1.0';
 }
 
 function resetPolicySettings() {
@@ -959,6 +960,19 @@ document.head.appendChild(style);
                                         </div>
                                         {% endif %}
                                         <small class="form-text text-muted">{{ form.iron_price_buffer.help_text }}</small>
+                                    </div>
+                                </div>
+
+                                <div class="mb-3 row">
+                                    <label for="{{ form.opening_balance_multiplier.id_for_label }}" class="col-sm-3 col-form-label">{{ form.opening_balance_multiplier.label }}:</label>
+                                    <div class="col-sm-9">
+                                        {{ form.opening_balance_multiplier }}
+                                        {% if form.opening_balance_multiplier.errors %}
+                                        <div class="invalid-feedback d-block">
+                                            {{ form.opening_balance_multiplier.errors }}
+                                        </div>
+                                        {% endif %}
+                                        <small class="form-text text-muted">{{ form.opening_balance_multiplier.help_text }}</small>
                                     </div>
                                 </div>
 

--- a/src/steeloweb/templates/steeloweb/create_modelrun.html
+++ b/src/steeloweb/templates/steeloweb/create_modelrun.html
@@ -69,13 +69,18 @@ function resetEconomicParameters() {
     document.getElementById('id_global_risk_free_rate').value = '0.0209';
     document.getElementById('id_steel_price_buffer').value = '200.0';
     document.getElementById('id_iron_price_buffer').value = '200.0';
+    document.getElementById('id_peg_iron_to_steel_price').checked = false;
+    document.getElementById('id_iron_to_steel_price_ratio').value = '0.8';
     document.getElementById('id_opening_balance_multiplier').value = '1.0';
+    // Trigger change to update ratio field disabled state
+    document.getElementById('id_peg_iron_to_steel_price').dispatchEvent(new Event('change'));
 }
 
 function resetPolicySettings() {
     // Reset policy settings
     document.getElementById('id_use_iron_ore_premiums').checked = true;
     document.getElementById('id_include_tariffs').checked = true;
+    document.getElementById('id_enable_furnace_group_clustering').checked = false;
 }
 
 function resetDemandSettings() {
@@ -272,6 +277,26 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Add change event listener
     probabilisticCheckbox.addEventListener('change', updateProbabilityFields);
+});
+
+// Toggle iron_to_steel_price_ratio based on peg_iron_to_steel_price checkbox
+document.addEventListener('DOMContentLoaded', function() {
+    var pegCheckbox = document.getElementById('id_peg_iron_to_steel_price');
+    var ratioRow = document.getElementById('iron_to_steel_price_ratio_row');
+    var ratioInput = document.getElementById('id_iron_to_steel_price_ratio');
+
+    function updateRatioField() {
+        if (pegCheckbox.checked) {
+            ratioInput.disabled = false;
+            ratioRow.style.opacity = '1';
+        } else {
+            ratioInput.disabled = true;
+            ratioRow.style.opacity = '0.5';
+        }
+    }
+
+    updateRatioField();
+    pegCheckbox.addEventListener('change', updateRatioField);
 });
 
 // Ensure native browser validation runs even if fields still have focus
@@ -964,6 +989,36 @@ document.head.appendChild(style);
                                 </div>
 
                                 <div class="mb-3 row">
+                                    <label for="{{ form.peg_iron_to_steel_price.id_for_label }}" class="col-sm-3 col-form-label">{{ form.peg_iron_to_steel_price.label }}:</label>
+                                    <div class="col-sm-9">
+                                        <div class="form-check">
+                                            {{ form.peg_iron_to_steel_price }}
+                                            <label class="form-check-label" for="{{ form.peg_iron_to_steel_price.id_for_label }}">
+                                                {{ form.peg_iron_to_steel_price.help_text }}
+                                            </label>
+                                        </div>
+                                        {% if form.peg_iron_to_steel_price.errors %}
+                                        <div class="invalid-feedback d-block">
+                                            {{ form.peg_iron_to_steel_price.errors }}
+                                        </div>
+                                        {% endif %}
+                                    </div>
+                                </div>
+
+                                <div class="mb-3 row" id="iron_to_steel_price_ratio_row">
+                                    <label for="{{ form.iron_to_steel_price_ratio.id_for_label }}" class="col-sm-3 col-form-label">{{ form.iron_to_steel_price_ratio.label }}:</label>
+                                    <div class="col-sm-9">
+                                        {{ form.iron_to_steel_price_ratio }}
+                                        {% if form.iron_to_steel_price_ratio.errors %}
+                                        <div class="invalid-feedback d-block">
+                                            {{ form.iron_to_steel_price_ratio.errors }}
+                                        </div>
+                                        {% endif %}
+                                        <small class="form-text text-muted">{{ form.iron_to_steel_price_ratio.help_text }}</small>
+                                    </div>
+                                </div>
+
+                                <div class="mb-3 row">
                                     <label for="{{ form.opening_balance_multiplier.id_for_label }}" class="col-sm-3 col-form-label">{{ form.opening_balance_multiplier.label }}:</label>
                                     <div class="col-sm-9">
                                         {{ form.opening_balance_multiplier }}
@@ -1022,12 +1077,29 @@ document.head.appendChild(style);
                                     </div>
                                 </div>
 
+                                <div class="mb-3 row">
+                                    <label for="{{ form.enable_furnace_group_clustering.id_for_label }}" class="col-sm-3 col-form-label">{{ form.enable_furnace_group_clustering.label }}:</label>
+                                    <div class="col-sm-9">
+                                        <div class="form-check">
+                                            {{ form.enable_furnace_group_clustering }}
+                                            <label class="form-check-label" for="{{ form.enable_furnace_group_clustering.id_for_label }}">
+                                                {{ form.enable_furnace_group_clustering.help_text }}
+                                            </label>
+                                        </div>
+                                        {% if form.enable_furnace_group_clustering.errors %}
+                                        <div class="invalid-feedback d-block">
+                                            {{ form.enable_furnace_group_clustering.errors }}
+                                        </div>
+                                        {% endif %}
+                                    </div>
+                                </div>
+
                                 <div class="text-end">
                                     <button type="button" class="btn btn-sm btn-outline-secondary" onclick="resetPolicySettings()">Return to default settings</button>
                                 </div>
                             </div>
                         </div>
-                        
+
                         <!-- Demand and Circularity section - commented out as requested -->
                         <!--
                         <div class="card mb-4">

--- a/src/steeloweb/views.py
+++ b/src/steeloweb/views.py
@@ -659,6 +659,12 @@ def create_modelrun(request):
                     if form.cleaned_data.get("iron_price_buffer") is not None
                     else 200.0
                 ),
+                "peg_iron_to_steel_price": form.cleaned_data.get("peg_iron_to_steel_price", False),
+                "iron_to_steel_price_ratio": float(
+                    form.cleaned_data.get("iron_to_steel_price_ratio")
+                    if form.cleaned_data.get("iron_to_steel_price_ratio") is not None
+                    else 0.8
+                ),
                 "opening_balance_multiplier": float(
                     form.cleaned_data.get("opening_balance_multiplier")
                     if form.cleaned_data.get("opening_balance_multiplier") is not None
@@ -688,6 +694,7 @@ def create_modelrun(request):
                 "use_iron_ore_premiums": form.cleaned_data.get("use_iron_ore_premiums", True),
                 "green_steel_emissions_limit": 0.4,  # Hardcoded - no longer user-configurable
                 "include_tariffs": form.cleaned_data.get("include_tariffs", True),
+                "enable_furnace_group_clustering": form.cleaned_data.get("enable_furnace_group_clustering", False),
                 "output_file": output_file,
                 # Add new demand and circularity fields
                 "total_steel_demand_scenario": form.cleaned_data.get(

--- a/src/steeloweb/views.py
+++ b/src/steeloweb/views.py
@@ -659,6 +659,11 @@ def create_modelrun(request):
                     if form.cleaned_data.get("iron_price_buffer") is not None
                     else 200.0
                 ),
+                "opening_balance_multiplier": float(
+                    form.cleaned_data.get("opening_balance_multiplier")
+                    if form.cleaned_data.get("opening_balance_multiplier") is not None
+                    else 1.0
+                ),
                 "construction_time": form.cleaned_data.get("construction_time", 4),
                 "probabilistic_agents": form.cleaned_data.get("probabilistic_agents", True),
                 "probability_of_announcement": float(form.cleaned_data.get("probability_of_announcement") or 0.7),

--- a/tests/unit/test_allocation_model.py
+++ b/tests/unit/test_allocation_model.py
@@ -15,7 +15,7 @@ from steelo.domain.events import SteelAllocationsCalculated
 class TestAllocationModelBusinessLogic:
     """Test core business logic of AllocationModel."""
 
-    def test_tariff_handling_with_tariffs_enabled(self):
+    def test_tariff_handling_with_tariffs_enabled(self, tmp_path):
         """Test that tariff handling works when include_tariffs is True."""
         # Setup
         mock_bus = MagicMock()
@@ -28,7 +28,7 @@ class TestAllocationModelBusinessLogic:
         mock_bus.env.secondary_feedstock_constraints = []
         mock_bus.env.aggregated_metallic_charge_constraints = []
         mock_bus.env.transport_kpis = []
-        mock_bus.env.output_dir = Path("/test/output")
+        mock_bus.env.output_dir = tmp_path
         mock_bus.uow.repository = MagicMock()
 
         # Mock the trade tariff calculation
@@ -46,8 +46,9 @@ class TestAllocationModelBusinessLogic:
                 mock_solve.return_value = {}
 
                 with patch("steelo.economic_models.plant_agent.export_commodity_allocations_to_csv"):
-                    # Act
-                    AllocationModel.run(mock_bus)
+                    with patch("steelo.economic_models.plant_agent.plot_process_graph"):
+                        # Act
+                        AllocationModel.run(mock_bus)
 
         # Assert
         mock_bus.env.get_active_trade_tariffs.assert_called_once()
@@ -56,7 +57,7 @@ class TestAllocationModelBusinessLogic:
         assert "active_trade_tariffs" in call_kwargs
         assert len(call_kwargs["active_trade_tariffs"]) == 1
 
-    def test_tariff_handling_with_tariffs_disabled(self):
+    def test_tariff_handling_with_tariffs_disabled(self, tmp_path):
         """Test that tariff handling is skipped when include_tariffs is False."""
         # Setup
         mock_bus = MagicMock()
@@ -68,7 +69,7 @@ class TestAllocationModelBusinessLogic:
         mock_bus.env.secondary_feedstock_constraints = []
         mock_bus.env.aggregated_metallic_charge_constraints = []
         mock_bus.env.transport_kpis = []
-        mock_bus.env.output_dir = Path("/test/output")
+        mock_bus.env.output_dir = tmp_path
         mock_bus.uow.repository = MagicMock()
 
         mock_bus.env.get_active_trade_tariffs = MagicMock()
@@ -83,8 +84,9 @@ class TestAllocationModelBusinessLogic:
                 mock_solve.return_value = {}
 
                 with patch("steelo.economic_models.plant_agent.export_commodity_allocations_to_csv"):
-                    # Act
-                    AllocationModel.run(mock_bus)
+                    with patch("steelo.economic_models.plant_agent.plot_process_graph"):
+                        # Act
+                        AllocationModel.run(mock_bus)
 
         # Assert - tariffs should not be fetched
         mock_bus.env.get_active_trade_tariffs.assert_not_called()
@@ -350,7 +352,7 @@ class TestAllocationModelVisualization:
 class TestAllocationModelEventHandling:
     """Test event handling and state management."""
 
-    def test_steel_allocations_calculated_event_published(self):
+    def test_steel_allocations_calculated_event_published(self, tmp_path):
         """Test that SteelAllocationsCalculated event is published when allocations exist."""
         # Setup
         mock_bus = MagicMock()
@@ -362,7 +364,7 @@ class TestAllocationModelEventHandling:
         mock_bus.env.secondary_feedstock_constraints = []
         mock_bus.env.aggregated_metallic_charge_constraints = []
         mock_bus.env.transport_kpis = []
-        mock_bus.env.output_dir = Path("/test/output")
+        mock_bus.env.output_dir = tmp_path
         mock_bus.uow.repository = MagicMock()
 
         mock_allocations = {"test": "allocation_data"}
@@ -378,10 +380,11 @@ class TestAllocationModelEventHandling:
                 mock_solve.return_value = {}
 
                 with patch("steelo.economic_models.plant_agent.export_commodity_allocations_to_csv"):
-                    with patch("builtins.open", create=True):
-                        with patch("steelo.economic_models.plant_agent.pickle.dump"):
-                            # Act
-                            AllocationModel.run(mock_bus)
+                    with patch("steelo.economic_models.plant_agent.plot_process_graph"):
+                        with patch("builtins.open", create=True):
+                            with patch("steelo.economic_models.plant_agent.pickle.dump"):
+                                # Act
+                                AllocationModel.run(mock_bus)
 
         # Assert
         mock_bus.handle.assert_called()
@@ -389,7 +392,7 @@ class TestAllocationModelEventHandling:
         assert isinstance(event, SteelAllocationsCalculated)
         assert event.trade_allocations == mock_allocations
 
-    def test_steel_allocations_calculated_event_not_published_when_no_allocations(self):
+    def test_steel_allocations_calculated_event_not_published_when_no_allocations(self, tmp_path):
         """Test that event is not published when allocations don't exist."""
         # Setup
         mock_bus = MagicMock()
@@ -401,7 +404,7 @@ class TestAllocationModelEventHandling:
         mock_bus.env.secondary_feedstock_constraints = []
         mock_bus.env.aggregated_metallic_charge_constraints = []
         mock_bus.env.transport_kpis = []
-        mock_bus.env.output_dir = Path("/test/output")
+        mock_bus.env.output_dir = tmp_path
         mock_bus.uow.repository = MagicMock()
 
         with patch("steelo.economic_models.plant_agent.set_up_steel_trade_lp") as mock_setup:
@@ -415,8 +418,9 @@ class TestAllocationModelEventHandling:
                 mock_solve.return_value = {}
 
                 with patch("steelo.economic_models.plant_agent.export_commodity_allocations_to_csv"):
-                    # Act
-                    AllocationModel.run(mock_bus)
+                    with patch("steelo.economic_models.plant_agent.plot_process_graph"):
+                        # Act
+                        AllocationModel.run(mock_bus)
 
         # Assert
         mock_bus.handle.assert_not_called()
@@ -490,7 +494,7 @@ class TestAllocationModelErrorHandling:
 class TestAllocationModelIntegrationPoints:
     """Test integration with other components."""
 
-    def test_secondary_feedstock_constraints_processing(self):
+    def test_secondary_feedstock_constraints_processing(self, tmp_path):
         """Test that secondary feedstock constraints are processed correctly."""
         # Setup
         mock_bus = MagicMock()
@@ -507,7 +511,7 @@ class TestAllocationModelIntegrationPoints:
         ]
         mock_bus.env.aggregated_metallic_charge_constraints = []
         mock_bus.env.transport_kpis = []
-        mock_bus.env.output_dir = Path("/test/output")
+        mock_bus.env.output_dir = tmp_path
         mock_bus.uow.repository = MagicMock()
 
         mock_filtered_constraints = [mock_bus.env.secondary_feedstock_constraints[1]]
@@ -529,8 +533,9 @@ class TestAllocationModelIntegrationPoints:
                 mock_solve.return_value = {}
 
                 with patch("steelo.economic_models.plant_agent.export_commodity_allocations_to_csv"):
-                    # Act
-                    AllocationModel.run(mock_bus)
+                    with patch("steelo.economic_models.plant_agent.plot_process_graph"):
+                        # Act
+                        AllocationModel.run(mock_bus)
 
         # Assert
         mock_bus.env.relevant_secondary_feedstock_constraints.assert_called_once()
@@ -540,7 +545,7 @@ class TestAllocationModelIntegrationPoints:
         call_kwargs = mock_setup.call_args.kwargs
         assert call_kwargs["secondary_feedstock_constraints"] == mock_filtered_constraints
 
-    def test_aggregated_metallic_charge_constraints(self):
+    def test_aggregated_metallic_charge_constraints(self, tmp_path):
         """Test that aggregated metallic charge constraints are passed correctly."""
         # Setup
         mock_bus = MagicMock()
@@ -556,7 +561,7 @@ class TestAllocationModelIntegrationPoints:
             MagicMock(name="constraint2"),
         ]
         mock_bus.env.transport_kpis = []
-        mock_bus.env.output_dir = Path("/test/output")
+        mock_bus.env.output_dir = tmp_path
         mock_bus.uow.repository = MagicMock()
 
         mock_bus.env.get_active_trade_tariffs = MagicMock()
@@ -575,8 +580,9 @@ class TestAllocationModelIntegrationPoints:
                 mock_solve.return_value = {}
 
                 with patch("steelo.economic_models.plant_agent.export_commodity_allocations_to_csv"):
-                    # Act
-                    AllocationModel.run(mock_bus)
+                    with patch("steelo.economic_models.plant_agent.plot_process_graph"):
+                        # Act
+                        AllocationModel.run(mock_bus)
 
         # Assert
         mock_setup.assert_called_once()

--- a/tests/unit/test_opening_balance.py
+++ b/tests/unit/test_opening_balance.py
@@ -1,0 +1,316 @@
+"""Tests for _seed_opening_balances and opening_balance_multiplier config."""
+
+import pytest
+from datetime import date
+from types import SimpleNamespace
+
+from steelo.domain.models import (
+    FurnaceGroup,
+    Location,
+    Plant,
+    PointInTime,
+    ProductCategory,
+    Technology,
+    TimeFrame,
+    Volumes,
+    Year,
+)
+from steelo.simulation import SimulationConfig, _seed_opening_balances
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ACTIVE_STATUSES = ["operating", "operating pre-retirement", "operating switching technology"]
+
+
+def _make_fg(
+    fg_id: str = "fg-1",
+    tech_name: str = "BF",
+    product: str = "iron",
+    capacity: float = 1_000_000.0,
+    status: str = "operating",
+    equity_share: float = 0.2,
+    created_by_PAM: bool = False,
+) -> FurnaceGroup:
+    """Create a minimal FurnaceGroup for testing."""
+    return FurnaceGroup(
+        furnace_group_id=fg_id,
+        capacity=Volumes(capacity),
+        status=status,
+        last_renovation_date=date(2020, 1, 1),
+        technology=Technology(name=tech_name, product=product),
+        historical_production={},
+        utilization_rate=0.8,
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2005), end=Year(2045)),
+            plant_lifetime=20,
+        ),
+        equity_share=equity_share,
+        created_by_PAM=created_by_PAM,
+    )
+
+
+def _make_plant(
+    plant_id: str = "plant-1",
+    iso3: str = "DEU",
+    furnace_groups: list[FurnaceGroup] | None = None,
+) -> Plant:
+    """Create a minimal Plant for testing."""
+    return Plant(
+        plant_id=plant_id,
+        location=Location(lat=50.0, lon=8.0, country="Germany", region="Europe", iso3=iso3),
+        furnace_groups=furnace_groups or [],
+        power_source="grid",
+        soe_status="private",
+        parent_gem_id="gem-1",
+        workforce_size=500,
+        certified=False,
+        category_steel_product={ProductCategory("Flat")},
+        technology_unit_fopex={},
+    )
+
+
+def _make_env(
+    greenfield_capex: dict | None = None,
+    renovation_share: dict | None = None,
+    iso3_to_region: dict | None = None,
+) -> SimpleNamespace:
+    """Create a minimal env mock with CAPEX data."""
+    if iso3_to_region is None:
+        iso3_to_region = {"DEU": "Europe"}
+    if greenfield_capex is None:
+        greenfield_capex = {"Europe": {"BF": 800.0, "EAF": 600.0}}
+    if renovation_share is None:
+        renovation_share = {"BF": 0.45, "EAF": 0.35}
+
+    country_mappings = SimpleNamespace(
+        iso3_to_region=lambda: iso3_to_region,
+    )
+    return SimpleNamespace(
+        name_to_capex={"greenfield": greenfield_capex},
+        capex_renovation_share=renovation_share,
+        country_mappings=country_mappings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _seed_opening_balances tests
+# ---------------------------------------------------------------------------
+
+
+def test_single_fg_balance_calculation():
+    """Plant balance = greenfield_capex * renovation_share * capacity * equity_share * multiplier."""
+    fg = _make_fg(capacity=1_000_000.0, equity_share=0.2)
+    plant = _make_plant(furnace_groups=[fg])
+    env = _make_env()
+
+    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    # 800 * 0.45 * 1_000_000 * 0.2 * 1.0 = 72_000_000
+    expected = 800.0 * 0.45 * 1_000_000.0 * 0.2 * 1.0
+    assert plant.balance == pytest.approx(expected)
+
+
+def test_multi_fg_plant_sums_all():
+    """Plant balance is the sum across all eligible FGs."""
+    fg1 = _make_fg(fg_id="fg-1", tech_name="BF", capacity=500_000.0)
+    fg2 = _make_fg(fg_id="fg-2", tech_name="EAF", capacity=300_000.0, product="steel")
+    plant = _make_plant(furnace_groups=[fg1, fg2])
+    env = _make_env()
+
+    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    bf_cost = 800.0 * 0.45 * 500_000.0 * 0.2
+    eaf_cost = 600.0 * 0.35 * 300_000.0 * 0.2
+    assert plant.balance == pytest.approx(bf_cost + eaf_cost)
+
+
+def test_multiplier_scales_balance():
+    """Multiplier scales the seeded balance linearly."""
+    fg = _make_fg(capacity=1_000_000.0)
+    env = _make_env()
+
+    for mult in [0.5, 1.0, 2.0]:
+        plant = _make_plant(furnace_groups=[fg])
+        _seed_opening_balances([plant], env, multiplier=mult, active_statuses=ACTIVE_STATUSES)
+        expected = 800.0 * 0.45 * 1_000_000.0 * 0.2 * mult
+        assert plant.balance == pytest.approx(expected), f"Failed for multiplier={mult}"
+
+
+def test_multiplier_zero_disables_seeding():
+    """Multiplier of 0.0 results in zero balance."""
+    fg = _make_fg(capacity=1_000_000.0)
+    plant = _make_plant(furnace_groups=[fg])
+    env = _make_env()
+
+    _seed_opening_balances([plant], env, multiplier=0.0, active_statuses=ACTIVE_STATUSES)
+
+    assert plant.balance == 0.0
+
+
+def test_skip_created_by_pam():
+    """FGs created by PAM are excluded from opening balance."""
+    fg = _make_fg(created_by_PAM=True, capacity=1_000_000.0)
+    plant = _make_plant(furnace_groups=[fg])
+    env = _make_env()
+
+    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    assert plant.balance == 0.0
+
+
+def test_skip_inactive_status():
+    """FGs with non-active statuses are excluded."""
+    for status in ["announced", "construction", "closed", "discarded"]:
+        fg = _make_fg(status=status)
+        plant = _make_plant(furnace_groups=[fg])
+        env = _make_env()
+
+        _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+        assert plant.balance == 0.0, f"Expected 0 for status={status}"
+
+
+def test_skip_zero_capacity():
+    """FGs with zero capacity are excluded."""
+    fg = _make_fg(capacity=0.0)
+    plant = _make_plant(furnace_groups=[fg])
+    env = _make_env()
+
+    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    assert plant.balance == 0.0
+
+
+def test_skip_other_technology():
+    """FGs with 'other' technology are excluded."""
+    fg = _make_fg(tech_name="other")
+    plant = _make_plant(furnace_groups=[fg])
+    env = _make_env(
+        greenfield_capex={"Europe": {"other": 500.0}},
+        renovation_share={"other": 0.3},
+    )
+
+    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    assert plant.balance == 0.0
+
+
+def test_skip_missing_region_mapping(caplog):
+    """FGs whose plant ISO3 has no region mapping are skipped with warning."""
+    fg = _make_fg(capacity=1_000_000.0)
+    plant = _make_plant(iso3="ZZZ", furnace_groups=[fg])
+    env = _make_env(iso3_to_region={"DEU": "Europe"})  # ZZZ not mapped
+
+    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    assert plant.balance == 0.0
+    assert "No region mapping for ZZZ" in caplog.text
+
+
+def test_skip_missing_greenfield_capex(caplog):
+    """FGs whose tech has no greenfield CAPEX in the region are skipped with warning."""
+    fg = _make_fg(tech_name="DRI", capacity=1_000_000.0)
+    plant = _make_plant(furnace_groups=[fg])
+    env = _make_env(
+        greenfield_capex={"Europe": {"BF": 800.0}},  # no DRI
+        renovation_share={"DRI": 0.4},
+    )
+
+    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    assert plant.balance == 0.0
+    assert "No greenfield CAPEX for DRI" in caplog.text
+
+
+def test_skip_missing_renovation_share(caplog):
+    """FGs whose tech has no renovation share are skipped with warning."""
+    fg = _make_fg(tech_name="BF", capacity=1_000_000.0)
+    plant = _make_plant(furnace_groups=[fg])
+    env = _make_env(
+        greenfield_capex={"Europe": {"BF": 800.0}},
+        renovation_share={},  # empty
+    )
+
+    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    assert plant.balance == 0.0
+    assert "No renovation share for BF" in caplog.text
+
+
+def test_mixed_eligible_and_ineligible_fgs():
+    """Only eligible FGs contribute; ineligible ones are silently skipped."""
+    eligible = _make_fg(fg_id="fg-ok", capacity=1_000_000.0)
+    pam_created = _make_fg(fg_id="fg-pam", capacity=1_000_000.0, created_by_PAM=True)
+    zero_cap = _make_fg(fg_id="fg-zero", capacity=0.0)
+    other_tech = _make_fg(fg_id="fg-other", tech_name="other")
+    inactive = _make_fg(fg_id="fg-closed", status="closed")
+
+    plant = _make_plant(furnace_groups=[eligible, pam_created, zero_cap, other_tech, inactive])
+    env = _make_env(
+        greenfield_capex={"Europe": {"BF": 800.0, "other": 500.0}},
+        renovation_share={"BF": 0.45, "other": 0.3},
+    )
+
+    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    expected = 800.0 * 0.45 * 1_000_000.0 * 0.2
+    assert plant.balance == pytest.approx(expected)
+
+
+def test_active_statuses_case_insensitive():
+    """Status matching is case-insensitive."""
+    fg = _make_fg(status="Operating", capacity=1_000_000.0)
+    plant = _make_plant(furnace_groups=[fg])
+    env = _make_env()
+
+    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    assert plant.balance > 0
+
+
+def test_historic_balance_untouched():
+    """FG.historic_balance is not modified by seeding."""
+    fg = _make_fg(capacity=1_000_000.0)
+    plant = _make_plant(furnace_groups=[fg])
+    env = _make_env()
+
+    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    assert fg.historic_balance == 0.0
+
+
+def test_multiple_plants():
+    """Each plant gets its own independent opening balance."""
+    fg1 = _make_fg(fg_id="fg-1", capacity=1_000_000.0)
+    fg2 = _make_fg(fg_id="fg-2", capacity=500_000.0)
+    plant1 = _make_plant(plant_id="p1", furnace_groups=[fg1])
+    plant2 = _make_plant(plant_id="p2", furnace_groups=[fg2])
+    env = _make_env()
+
+    _seed_opening_balances([plant1, plant2], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    expected1 = 800.0 * 0.45 * 1_000_000.0 * 0.2
+    expected2 = 800.0 * 0.45 * 500_000.0 * 0.2
+    assert plant1.balance == pytest.approx(expected1)
+    assert plant2.balance == pytest.approx(expected2)
+
+
+# ---------------------------------------------------------------------------
+# SimulationConfig validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_negative_multiplier_raises():
+    """Negative opening_balance_multiplier raises ValueError."""
+    with pytest.raises(ValueError, match="opening_balance_multiplier must be >= 0.0"):
+        SimulationConfig(
+            start_year=Year(2025),
+            end_year=Year(2050),
+            master_excel_path="dummy.xlsx",
+            output_dir="/tmp/test_output",
+            opening_balance_multiplier=-0.1,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -442,12 +442,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/08/52f06ff2f04d376f9cd2c211aefcf2b37f1978e43289341f362fc99f6a0e/cftime-1.6.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e02a1d80ffc33fe469c7db68aa24c4a87f01da0c0c621373e5edadc92964900b", size = 1633625, upload-time = "2025-10-13T18:56:15.745Z" },
     { url = "https://files.pythonhosted.org/packages/cf/33/03e0b23d58ea8fab94ecb4f7c5b721e844a0800c13694876149d98830a73/cftime-1.6.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:18ab754805233cdd889614b2b3b86a642f6d51a57a1ec327c48053f3414f87d8", size = 1684269, upload-time = "2025-10-13T18:56:17.04Z" },
     { url = "https://files.pythonhosted.org/packages/a4/60/a0cfba63847b43599ef1cdbbf682e61894994c22b9a79fd9e1e8c7e9de41/cftime-1.6.5-cp313-cp313-win_amd64.whl", hash = "sha256:6c27add8f907f4a4cd400e89438f2ea33e2eb5072541a157a4d013b7dbe93f9c", size = 465364, upload-time = "2025-10-13T18:56:18.05Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e8/ec32f2aef22c15604e6fda39ff8d581a00b5469349f8fba61640d5358d2c/cftime-1.6.5-cp313-cp313-win_arm64.whl", hash = "sha256:31d1ff8f6bbd4ca209099d24459ec16dea4fb4c9ab740fbb66dd057ccbd9b1b9", size = 450468, upload-time = "2026-01-02T21:16:50.193Z" },
     { url = "https://files.pythonhosted.org/packages/ea/6c/a9618f589688358e279720f5c0fe67ef0077fba07334ce26895403ebc260/cftime-1.6.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c69ce3bdae6a322cbb44e9ebc20770d47748002fb9d68846a1e934f1bd5daf0b", size = 502725, upload-time = "2025-10-13T18:56:19.424Z" },
     { url = "https://files.pythonhosted.org/packages/d8/e3/da3c36398bfb730b96248d006cabaceed87e401ff56edafb2a978293e228/cftime-1.6.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e62e9f2943e014c5ef583245bf2e878398af131c97e64f8cd47c1d7baef5c4e2", size = 485445, upload-time = "2025-10-13T18:56:20.853Z" },
     { url = "https://files.pythonhosted.org/packages/32/93/b05939e5abd14bd1ab69538bbe374b4ee2a15467b189ff895e9a8cdaddf6/cftime-1.6.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7da5fdaa4360d8cb89b71b8ded9314f2246aa34581e8105c94ad58d6102d9e4f", size = 1584434, upload-time = "2025-10-13T19:39:17.084Z" },
     { url = "https://files.pythonhosted.org/packages/7f/89/648397f9936e0b330999c4e776ebf296ec3c6a65f9901687dbca4ab820da/cftime-1.6.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bff865b4ea4304f2744a1ad2b8149b8328b321dd7a2b9746ef926d229bd7cd49", size = 1609812, upload-time = "2025-10-13T18:56:21.971Z" },
     { url = "https://files.pythonhosted.org/packages/e7/0f/901b4835aa67ad3e915605d4e01d0af80a44b114eefab74ae33de6d36933/cftime-1.6.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e552c5d1c8a58f25af7521e49237db7ca52ed2953e974fe9f7c4491e95fdd36c", size = 1669768, upload-time = "2025-10-13T18:56:24.027Z" },
     { url = "https://files.pythonhosted.org/packages/22/d5/e605e4b28363e7a9ae98ed12cabbda5b155b6009270e6a231d8f10182a17/cftime-1.6.5-cp314-cp314-win_amd64.whl", hash = "sha256:e645b095dc50a38ac454b7e7f0742f639e7d7f6b108ad329358544a6ff8c9ba2", size = 463818, upload-time = "2025-10-13T18:56:25.376Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/89/a8f85ae697ff10206ec401c2621f5ca9f327554f586d62f244739ceeb347/cftime-1.6.5-cp314-cp314-win_arm64.whl", hash = "sha256:b9044d7ac82d3d8af189df1032fdc871bbd3f3dd41a6ec79edceb5029b71e6e0", size = 459862, upload-time = "2026-01-02T20:45:02.625Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/05/7410e12fd03a0c52717e74e6a1b49958810807dda212e23b65d43ea99676/cftime-1.6.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9ef56460cb0576e1a9161e1428c9e1a633f809a23fa9d598f313748c1ae5064e", size = 533781, upload-time = "2026-01-02T20:45:04.818Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ba/10e3546426d3ed9f9cc82e4a99836bb6fac1642c7830f7bdd0ac1c3f0805/cftime-1.6.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4f4873d38b10032f9f3111c547a1d485519ae64eee6a7a2d091f1f8b08e1ba50", size = 515218, upload-time = "2026-01-02T20:45:06.788Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/68/efa11eae867749e921bfec6a865afdba8166e96188112dde70bb8bb49254/cftime-1.6.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ccce0f4c9d3f38dd948a117e578b50d0e0db11e2ca9435fb358fd524813e4b61", size = 1579932, upload-time = "2026-01-02T20:45:11.194Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6c/0971e602c1390a423e6621dfbad9f1d375186bdaf9c9c7f75e06f1fbf355/cftime-1.6.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19cbfc5152fb0b34ce03acf9668229af388d7baa63a78f936239cb011ccbe6b1", size = 1555894, upload-time = "2026-01-02T20:45:16.351Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fc/8475a15b7c3209a4a68b563dfc5e01ce74f2d8b9822372c3d30c68ab7f39/cftime-1.6.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4470cd5ef3c2514566f53efbcbb64dd924fa0584637d90285b2f983bd4ee7d97", size = 513027, upload-time = "2026-01-02T20:45:20.023Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/80/4ecbda8318fbf40ad4e005a4a93aebba69e81382e5b4c6086251cd5d0ee8/cftime-1.6.5-cp314-cp314t-win_arm64.whl", hash = "sha256:034c15a67144a0a5590ef150c99f844897618b148b87131ed34fda7072614662", size = 469065, upload-time = "2026-01-02T20:45:23.398Z" },
 ]
 
 [[package]]
@@ -3745,7 +3753,7 @@ requires-dist = [
     { name = "django" },
     { name = "django-environ" },
     { name = "django-htmx" },
-    { name = "django-tasks", specifier = ">=0.9.0" },
+    { name = "django-tasks", specifier = ">=0.9.0,<0.12" },
     { name = "fiona" },
     { name = "folium" },
     { name = "geopandas" },


### PR DESCRIPTION
## Summary

- Seed plants with an opening renovation balance proportional to their furnace groups' renovation cost, controlled by `opening_balance_multiplier`. Prevents unrealistic early-simulation behaviour where established plants couldn't afford renovations.
- Add debug logging for FG strategy decisions (plant balance, headroom).
- Expose new economic / policy parameters in the standalone app UI: `opening_balance_multiplier`, `peg_iron_to_steel_price`, `iron_to_steel_price_ratio`, `enable_furnace_group_clustering`.
- Update master-input manifest to `master_input_v1.3.0.xlsx` (the v1.2 file lacked the new subsidy columns: `Location`, `Subsidy type`, `Subsidy amount`).
- Bump app version to 2.0.0.

## Electron build fixes

- Pin `django-tasks<0.12` — v0.12 introduced a breaking change that broke the Electron build.
- Remove GNU `libiconv.2.dylib` from python-build-standalone on macOS builds. It exports `_libiconv` (GNU names) but pyogrio/fiona's libgdal expects `_iconv` (POSIX names) from the system `/usr/lib/libiconv.2.dylib`. `DYLD_LIBRARY_PATH` causes the bundled GNU version to shadow the system one, breaking geopandas shapefile reads (geospatial model crashed during simulation/data prep on macOS).

## Other fixes

- Fix `test_allocation_model` writing to read-only filesystem — switch to `tmp_path`.