### PR TITLE
Centralise random seed via SimulationConfig.random_seed and expose in UI

### DIFF
--- a/src/steelo/bootstrap.py
+++ b/src/steelo/bootstrap.py
@@ -1,8 +1,11 @@
 import inspect
 import logging
+import random
 
 from pathlib import Path
 from typing import Optional, TYPE_CHECKING
+
+import numpy as np
 from .service_layer import handlers, UnitOfWork, MessageBus, SimulationCheckpoint
 from .domain.models import Environment, PlantGroup
 from .adapters.repositories import JsonRepository, InMemoryRepository, Repository
@@ -225,6 +228,11 @@ def bootstrap_simulation(
         LoggingConfig.configure_from_yaml(str(yaml_path), config.log_level)
     else:
         LoggingConfig.configure_base_loggers()
+
+    # Seed Python and NumPy global RNGs. LP solver reads the same seed at solve time.
+    random.seed(config.random_seed)
+    np.random.seed(config.random_seed)
+    logger.info(f"Seeded RNGs with random_seed={config.random_seed}")
 
     # If no repository is provided, create one from JSON files (production behavior)
     repository_json = None

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -49,8 +49,6 @@ from steelo.domain.constants import (
 if TYPE_CHECKING:
     from steelo.simulation import SimulationConfig
 
-random.seed(42)  # For reproducibility # TODO: Replace by seed from SimulationConfig
-
 
 class UnknownTechnologyError(KeyError):
     """Raised when checking unknown technology."""

--- a/src/steelo/domain/trade_modelling/set_up_steel_trade_lp.py
+++ b/src/steelo/domain/trade_modelling/set_up_steel_trade_lp.py
@@ -892,7 +892,7 @@ def set_up_steel_trade_lp(
     """
     logger = logging.getLogger(f"{__name__}.set_up_steel_trade_lp")
     repository = message_bus.uow.repository
-    lp_model = tlp.TradeLPModel(lp_epsilon=config.lp_epsilon)
+    lp_model = tlp.TradeLPModel(lp_epsilon=config.lp_epsilon, random_seed=config.random_seed)
     modelled_products = config.primary_products
 
     logger.info(f"Setting up LP model with PRIMARY_PRODUCTS: {modelled_products}")

--- a/src/steelo/domain/trade_modelling/trade_lp_modelling.py
+++ b/src/steelo/domain/trade_modelling/trade_lp_modelling.py
@@ -347,7 +347,7 @@ class TradeLPModel:
         soft_minimum_capacity_slack_cost: High cost for under-utilization (100k)
     """
 
-    def __init__(self, lp_epsilon: float = 1e-3):
+    def __init__(self, lp_epsilon: float, random_seed: int):
         self.process_centers: list[ProcessCenter] = []
         self.process_connectors: list[ProcessConnector] = []
         self.commodities: list[Commodity] = []
@@ -367,6 +367,7 @@ class TradeLPModel:
         self.transportation_costs: list[TransportationCost] = []
         self._transportation_cost_lookup: dict[tuple[str, str, str], float] = {}
         self.lp_epsilon = lp_epsilon
+        self.random_seed = random_seed
 
         # Solver options for performance tuning (OPT-4)
         # Default to IPM - equivalent runtime to Simplex but uses ~5GB less memory
@@ -1634,14 +1635,14 @@ class TradeLPModel:
         Notes:
             - Uses solver_options for configuration (default: IPM for memory efficiency)
             - Supports warm-starting from previous_solution (simplex only)
-            - Random seed fixed (1337) for reproducibility
+            - Random seed from SimulationConfig.random_seed for reproducibility
             - Does not automatically load solution (call extract_solution() after)
             - Logs detailed diagnostics if model is infeasible
         """
         logger = logging.getLogger(f"{__name__}.solve_lp_model")
         start_time = time.time()
         solver = pyo.SolverFactory("appsi_highs")
-        solver.options["random_seed"] = 1337
+        solver.options["random_seed"] = self.random_seed
 
         # Use configurable solver options for performance tuning (OPT-4)
         solver.options.update(self.solver_options)

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -419,6 +419,11 @@ class SimulationConfig:
     # These carriers keep their raw Excel sign instead of being negated via -abs()
     disposal_cost_outputs: frozenset[str] = field(default_factory=lambda: frozenset({"ironmaking_slag"}))
 
+    # === Randomness ===
+    # Single seed shared by Plant Agent, Geospatial, and Trade LP modules.
+    # Propagated to geo_config.random_seed in __post_init__.
+    random_seed: int = 42
+
     # === Other ===
     # Verbosity
     log_level: int = logging.DEBUG
@@ -511,6 +516,9 @@ class SimulationConfig:
         # Ensure technology_settings is always available (required for the system to function)
         if self.technology_settings is None:
             self.technology_settings = get_default_technology_settings()
+
+        # Single source of truth: propagate top-level seed into nested GeoConfig.
+        self.geo_config.random_seed = self.random_seed
 
         # Handle deprecated parameter - preserve semantics by translating to technology_settings
         if global_bf_ban is not None:

--- a/src/steeloweb/forms.py
+++ b/src/steeloweb/forms.py
@@ -99,7 +99,10 @@ class ModelRunCreateForm(forms.ModelForm):
         initial=42,
         min_value=0,
         required=False,
-        help_text="Seed shared by the Plant Agent, Geospatial, and Trade LP modules. Ignored when 'Randomise seed' is ticked.",
+        help_text=(
+            "Seed shared by the Plant Agent, Geospatial, and Trade LP modules. "
+            "Auto-filled with a fresh value when 'Randomise seed' is ticked."
+        ),
         widget=forms.NumberInput(attrs={"class": "form-control field-connected", "id": "id_random_seed"}),
     )
 
@@ -710,15 +713,16 @@ class ModelRunCreateForm(forms.ModelForm):
             if end_year < start_year:
                 raise forms.ValidationError("End year must be after start year.")
 
-        # Randomise seed handling: when the checkbox is ticked, draw a fresh seed;
-        # otherwise keep the user-provided value (default 42). `randomise_seed` is
-        # a UI-only flag and is not part of SimulationConfig, so it is removed here.
+        # Randomise seed handling: client-side JS draws the seed and writes it into
+        # `random_seed` when the box is ticked, so the user sees the value being used.
+        # We trust whatever value arrives, falling back to a fresh seed only as a
+        # defence-in-depth for clients without JS. `randomise_seed` is a UI-only flag
+        # and is not part of SimulationConfig, so it is removed here.
         import secrets
 
-        if cleaned_data.pop("randomise_seed", False):
-            cleaned_data["random_seed"] = secrets.randbelow(2**31)
-        elif cleaned_data.get("random_seed") is None:
-            cleaned_data["random_seed"] = 42
+        randomise = cleaned_data.pop("randomise_seed", False)
+        if cleaned_data.get("random_seed") is None:
+            cleaned_data["random_seed"] = secrets.randbelow(2**31) if randomise else 42
 
         # Set default values for fields that are not required but need values
         if not cleaned_data.get("scrap_generation_scenario"):

--- a/src/steeloweb/forms.py
+++ b/src/steeloweb/forms.py
@@ -80,6 +80,29 @@ class ModelRunCreateForm(forms.ModelForm):
         widget=forms.TextInput(attrs={"class": "form-control", "placeholder": "e.g., 'High renewable scenario 2030'"}),
     )
 
+    randomise_seed = forms.BooleanField(
+        label="Randomise seed",
+        initial=False,
+        required=False,
+        help_text=(
+            "Tick to draw a fresh random seed for this run. When unticked, the seed below is used "
+            "so results are reproducible. When ticked, results will vary slightly between runs due "
+            "to stochastic components in agent decisions and the trade LP."
+        ),
+        widget=forms.CheckboxInput(
+            attrs={"class": "form-check-input field-connected", "id": "id_randomise_seed"},
+        ),
+    )
+
+    random_seed = forms.IntegerField(
+        label="Random seed",
+        initial=42,
+        min_value=0,
+        required=False,
+        help_text="Seed shared by the Plant Agent, Geospatial, and Trade LP modules. Ignored when 'Randomise seed' is ticked.",
+        widget=forms.NumberInput(attrs={"class": "form-control field-connected", "id": "id_random_seed"}),
+    )
+
     # Helper method to create widget attrs for connected/unconnected fields
     @staticmethod
     def _connected_attrs(base_class="form-control"):
@@ -617,6 +640,9 @@ class ModelRunCreateForm(forms.ModelForm):
         fields = [
             # General
             "name",
+            # Simulation Parameters
+            "randomise_seed",
+            "random_seed",
             # Years
             "start_year",
             "end_year",
@@ -683,6 +709,16 @@ class ModelRunCreateForm(forms.ModelForm):
         if start_year and end_year:
             if end_year < start_year:
                 raise forms.ValidationError("End year must be after start year.")
+
+        # Randomise seed handling: when the checkbox is ticked, draw a fresh seed;
+        # otherwise keep the user-provided value (default 42). `randomise_seed` is
+        # a UI-only flag and is not part of SimulationConfig, so it is removed here.
+        import secrets
+
+        if cleaned_data.pop("randomise_seed", False):
+            cleaned_data["random_seed"] = secrets.randbelow(2**31)
+        elif cleaned_data.get("random_seed") is None:
+            cleaned_data["random_seed"] = 42
 
         # Set default values for fields that are not required but need values
         if not cleaned_data.get("scrap_generation_scenario"):

--- a/src/steeloweb/templates/steeloweb/create_modelrun.html
+++ b/src/steeloweb/templates/steeloweb/create_modelrun.html
@@ -631,6 +631,44 @@ document.head.appendChild(style);
                             </div>
                         </div>
                         
+                        <!-- Simulation Parameters section -->
+                        <div class="card mb-4">
+                            <div class="card-header bg-light">
+                                <h5 class="mb-0">Simulation Parameters</h5>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3 form-check">
+                                    {{ form.randomise_seed }}
+                                    <label for="{{ form.randomise_seed.id_for_label }}" class="form-check-label">
+                                        {{ form.randomise_seed.label }}
+                                    </label>
+                                    <small class="form-text text-muted d-block">{{ form.randomise_seed.help_text }}</small>
+                                </div>
+                                <div class="mb-3 row">
+                                    <label for="{{ form.random_seed.id_for_label }}" class="col-sm-3 col-form-label">Random seed:</label>
+                                    <div class="col-sm-9">
+                                        {{ form.random_seed }}
+                                        {% if form.random_seed.errors %}
+                                        <div class="invalid-feedback d-block">
+                                            {{ form.random_seed.errors }}
+                                        </div>
+                                        {% endif %}
+                                        <small class="form-text text-muted">{{ form.random_seed.help_text }}</small>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <script>
+                            (function () {
+                                const checkbox = document.getElementById('id_randomise_seed');
+                                const seedInput = document.getElementById('id_random_seed');
+                                if (!checkbox || !seedInput) return;
+                                const sync = () => { seedInput.disabled = checkbox.checked; };
+                                checkbox.addEventListener('change', sync);
+                                sync();
+                            })();
+                        </script>
+
                         <!-- Simulation Period section -->
                         <div class="card mb-4">
                             <div class="card-header bg-light">

--- a/src/steeloweb/templates/steeloweb/create_modelrun.html
+++ b/src/steeloweb/templates/steeloweb/create_modelrun.html
@@ -663,9 +663,32 @@ document.head.appendChild(style);
                                 const checkbox = document.getElementById('id_randomise_seed');
                                 const seedInput = document.getElementById('id_random_seed');
                                 if (!checkbox || !seedInput) return;
-                                const sync = () => { seedInput.disabled = checkbox.checked; };
-                                checkbox.addEventListener('change', sync);
-                                sync();
+                                const DEFAULT_SEED = 42;
+                                // Remember the user's last manually-entered seed so we can restore it on untick.
+                                let lastUserSeed = seedInput.value || String(DEFAULT_SEED);
+                                const drawSeed = () => Math.floor(Math.random() * 0x80000000); // [0, 2^31)
+                                const setLocked = (locked) => {
+                                    seedInput.readOnly = locked;
+                                    seedInput.classList.toggle('bg-light', locked);
+                                    seedInput.classList.toggle('text-muted', locked);
+                                    seedInput.style.cursor = locked ? 'not-allowed' : '';
+                                };
+                                const onChange = () => {
+                                    if (checkbox.checked) {
+                                        lastUserSeed = seedInput.value || lastUserSeed;
+                                        seedInput.value = drawSeed();
+                                        setLocked(true);
+                                    } else {
+                                        seedInput.value = lastUserSeed || String(DEFAULT_SEED);
+                                        setLocked(false);
+                                    }
+                                };
+                                seedInput.addEventListener('input', () => {
+                                    if (!checkbox.checked) lastUserSeed = seedInput.value;
+                                });
+                                checkbox.addEventListener('change', onChange);
+                                // Initial sync (e.g. after a failed POST that re-renders the form).
+                                if (checkbox.checked) setLocked(true);
                             })();
                         </script>
 

--- a/tests/unit/test_lp_trade_model.py
+++ b/tests/unit/test_lp_trade_model.py
@@ -254,7 +254,7 @@ def test_trade_lp_model_basic_build_and_solve(location_mock_factory):
     solves it, and checks that the solution is feasible.
     """
     # Create model
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
 
     # Create Commodities
     iron_ore = Commodity("iron_ore")
@@ -346,7 +346,7 @@ def test_trade_lp_model_infeasible_demand(location_mock_factory):
     Test that if we want more steel than we can possibly produce or supply,
     the solver doesn't fail with infeasibility (because of the demand slack).
     """
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
 
     # Create Commodities
     iron_ore = Commodity("iron_ore")
@@ -455,7 +455,7 @@ def test_tariff_info_injection(location_mock_factory):
     pc1 = ProcessCenter("PC1", process=None, capacity=10, location=location_mock_factory(1, 2, iso3="AAA"))
     pc2 = ProcessCenter("PC2", process=None, capacity=10, location=location_mock_factory(3, 4, iso3="BBB"))
 
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
     model.add_commodities([c])
     model.add_process_centers([pc1, pc2])
     model.process_connectors = []
@@ -486,7 +486,7 @@ def test_bom_parameters_are_added():
     proc = Process(name="Converter", type=ProcessType.PRODUCTION, bill_of_materials=[bom])
     pc = ProcessCenter(name="PC1", process=proc, capacity=100.0, location=None)
 
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
     model.add_commodities([com_input, com_output])
     model.add_bom_elements([bom])
     model.add_process_centers([pc])
@@ -503,7 +503,7 @@ def test_primary_output_of_feedstock_mapping():
     proc = Process("Melter", ProcessType.PRODUCTION, [bom])
     pc = ProcessCenter("PC1", proc, 100, location=None)
 
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
     model.add_commodities([com_input, com_output])
     model.add_process_centers([pc])
     model.add_bom_elements([bom])
@@ -518,7 +518,7 @@ def test_demand_slack_variable_creation():
     demand_proc = Process("Consumer", ProcessType.DEMAND, [])
     pc = ProcessCenter("PC_Demand", demand_proc, 60.0, location=None)
 
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
     model.add_process_centers([pc])
     model.lp_model = pyo.ConcreteModel()
     model.add_demand_slack_variables_to_lp()
@@ -532,7 +532,7 @@ def test_getters_from_model():
     p = Process("Smelter", ProcessType.PRODUCTION, [])
     bom = BOMElement("CopperBOM", c, c, {MaterialParameters.INPUT_RATIO: 1.1})
 
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
     model.add_commodities([c])
     model.add_processes([p])
     model.add_bom_elements([bom])
@@ -600,7 +600,7 @@ def test_transportation_cost_repr():
 
 def test_add_transportation_costs(location_mock_factory):
     """Test adding transportation costs to the model."""
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
 
     tc1 = TransportationCost(from_iso3="USA", to_iso3="CHN", commodity="steel", cost_per_ton=25.0)
     tc2 = TransportationCost(from_iso3="DEU", to_iso3="FRA", commodity="iron", cost_per_ton=15.0)
@@ -614,7 +614,7 @@ def test_add_transportation_costs(location_mock_factory):
 
 def test_get_transportation_cost(location_mock_factory):
     """Test retrieving transportation costs from the model."""
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
 
     tc1 = TransportationCost(from_iso3="USA", to_iso3="CHN", commodity="steel", cost_per_ton=25.0)
     tc2 = TransportationCost(from_iso3="DEU", to_iso3="FRA", commodity="iron", cost_per_ton=15.0)
@@ -635,7 +635,7 @@ def test_get_transportation_cost(location_mock_factory):
 
 def test_get_distance_haversine(location_mock_factory):
     """Test get_distance using haversine calculation."""
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
 
     loc1 = location_mock_factory(lat=10.0, lon=20.0, iso3="USA")
     loc2 = location_mock_factory(lat=10.5, lon=20.5, iso3="CHN")
@@ -659,7 +659,7 @@ def test_get_distance_haversine(location_mock_factory):
 
 def test_add_process_center_type_as_parameter():
     """Test adding process center type as parameter to LP model."""
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
 
     supply_proc = Process(name="Supply", type=ProcessType.SUPPLY, bill_of_materials=[])
     demand_proc = Process(name="Demand", type=ProcessType.DEMAND, bill_of_materials=[])
@@ -735,7 +735,7 @@ def test_allocations_validate_with_none_capacity():
 
 def test_tradelp_add_tariff_information():
     """Test adding tariff information to TradeLPModel."""
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
 
     quota_dict = {("USA", "CHN", "steel"): 1000.0}
     tax_dict = {("USA", "CHN", "steel"): 0.25}
@@ -748,7 +748,7 @@ def test_tradelp_add_tariff_information():
 
 def test_tradelp_add_processes_adds_implicit_commodities():
     """Test that add_processes adds products as commodities if not already present."""
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
     c_output = Commodity("steel")
 
     bom_elem = BOMElement(name="BOM1", commodity=Commodity("iron_ore"), output_commodities=[c_output], parameters={})
@@ -767,7 +767,7 @@ def test_tradelp_add_processes_adds_implicit_commodities():
 
 def test_tradelp_add_bom_elements_adds_implicit_commodities():
     """Test that add_bom_elements adds commodities if not already present."""
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
     c_input = Commodity("iron_ore")
 
     bom_elem = BOMElement(name="BOM1", commodity=c_input, output_commodities=[Commodity("steel")], parameters={})
@@ -784,7 +784,7 @@ def test_tradelp_add_bom_elements_adds_implicit_commodities():
 
 def test_get_distance_pref_economic(location_mock_factory):
     """Test get_distance with pref_economic type."""
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
 
     loc1 = location_mock_factory(lat=10.0, lon=20.0, iso3="USA")
     loc2 = location_mock_factory(lat=10.5, lon=20.5, iso3="CHN")
@@ -801,7 +801,7 @@ def test_get_distance_pref_economic(location_mock_factory):
 
 def test_get_distance_invalid_type_raises_error(location_mock_factory):
     """Test that get_distance raises ValueError for unknown distance type."""
-    model = TradeLPModel()
+    model = TradeLPModel(lp_epsilon=LP_EPSILON, random_seed=42)
 
     loc1 = location_mock_factory(lat=10.0, lon=20.0, iso3="USA")
     loc2 = location_mock_factory(lat=10.5, lon=20.5, iso3="CHN")

--- a/tests/unit/test_random_seed_config.py
+++ b/tests/unit/test_random_seed_config.py
@@ -95,12 +95,21 @@ def test_form_clean_keeps_user_seed_when_checkbox_unticked():
 
 
 @pytest.mark.django_db
-def test_form_clean_draws_fresh_seed_when_checkbox_ticked():
-    """When `randomise_seed` is ticked, `clean()` replaces `random_seed` with a fresh int."""
-    form = steeloweb_forms.ModelRunCreateForm(data=_form_data_with_seed(randomise=True, seed_value=42))
+def test_form_clean_trusts_client_provided_seed_when_checkbox_ticked():
+    """With JS enabled the client writes a fresh seed into `random_seed`; clean() trusts it."""
+    form = steeloweb_forms.ModelRunCreateForm(data=_form_data_with_seed(randomise=True, seed_value=987654321))
+    form.is_valid()
+    assert form.cleaned_data.get("random_seed") == 987654321
+    # `randomise_seed` is a UI-only flag — clean() should strip it.
+    assert "randomise_seed" not in form.cleaned_data
+
+
+@pytest.mark.django_db
+def test_form_clean_draws_fresh_seed_as_fallback_when_no_js():
+    """Defence-in-depth: if `randomise_seed` ticked but `random_seed` is missing (no JS), draw a fresh int."""
+    data = _form_data_with_seed(randomise=True, seed_value=None)
+    form = steeloweb_forms.ModelRunCreateForm(data=data)
     form.is_valid()
     seed = form.cleaned_data.get("random_seed")
     assert isinstance(seed, int)
     assert 0 <= seed < 2**31
-    # `randomise_seed` is a UI-only flag — clean() should strip it.
-    assert "randomise_seed" not in form.cleaned_data

--- a/tests/unit/test_random_seed_config.py
+++ b/tests/unit/test_random_seed_config.py
@@ -1,0 +1,106 @@
+# tests/unit/test_random_seed_config.py
+"""Tests for the centralised random-seed configuration (SimulationConfig.random_seed)."""
+
+import random
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from steelo.domain import Year
+from steelo.domain.trade_modelling import trade_lp_modelling
+from steelo.simulation import SimulationConfig
+from steelo.simulation_types import get_default_technology_settings
+from steeloweb import forms as steeloweb_forms
+
+
+@pytest.fixture
+def base_config_kwargs():
+    """Minimal SimulationConfig kwargs for construction in unit tests."""
+    return dict(
+        start_year=Year(2025),
+        end_year=Year(2050),
+        master_excel_path=Path("test.xlsx"),
+        output_dir=Path("/tmp/output_random_seed_test"),
+        technology_settings=get_default_technology_settings(),
+    )
+
+
+def test_simulation_config_random_seed_default(base_config_kwargs):
+    """`SimulationConfig.random_seed` defaults to 42."""
+    config = SimulationConfig(**base_config_kwargs)
+    assert config.random_seed == 42
+
+
+def test_simulation_config_random_seed_propagates_to_geo_config(base_config_kwargs):
+    """Top-level `random_seed` is propagated into `geo_config.random_seed` via __post_init__."""
+    config = SimulationConfig(**base_config_kwargs, random_seed=99)
+    assert config.random_seed == 99
+    assert config.geo_config.random_seed == 99
+
+
+def test_trade_lp_model_stores_random_seed():
+    """`TradeLPModel` stores the seed passed in for later use by the HiGHS solver."""
+    model = trade_lp_modelling.TradeLPModel(lp_epsilon=1e-3, random_seed=777)
+    assert model.random_seed == 777
+
+
+def test_python_random_is_deterministic_given_seed():
+    """After `random.seed(n)`, `random.random()` returns a deterministic value.
+
+    Guards the contract that `bootstrap_simulation` relies on when it calls
+    `random.seed(config.random_seed)`.
+    """
+    random.seed(123)
+    first = random.random()
+    random.seed(123)
+    second = random.random()
+    assert first == second
+
+
+def test_numpy_random_is_deterministic_given_seed():
+    """After `np.random.seed(n)`, `np.random.rand()` returns a deterministic value."""
+    np.random.seed(456)
+    first = np.random.rand()
+    np.random.seed(456)
+    second = np.random.rand()
+    assert first == second
+
+
+def _form_data_with_seed(randomise: bool, seed_value=42):
+    """Build a minimal valid ModelRunCreateForm payload for clean() testing.
+
+    Only the seed-related fields matter for these tests; everything else is left
+    blank or defaulted. The form's other `clean()` defaults handle the rest.
+    """
+    return {
+        "name": "test run",
+        "randomise_seed": "on" if randomise else "",
+        "random_seed": str(seed_value) if seed_value is not None else "",
+        "start_year": "2025",
+        "end_year": "2050",
+    }
+
+
+@pytest.mark.django_db
+def test_form_clean_keeps_user_seed_when_checkbox_unticked():
+    """When `randomise_seed` is unticked, the user's `random_seed` value is preserved."""
+    form = steeloweb_forms.ModelRunCreateForm(data=_form_data_with_seed(randomise=False, seed_value=7))
+    # Trigger validation. We only care about seed-related cleaned_data; ignore other
+    # validation errors from required fields that aren't relevant here.
+    form.is_valid()
+    assert form.cleaned_data.get("random_seed") == 7
+    # `randomise_seed` is a UI-only flag — clean() should strip it.
+    assert "randomise_seed" not in form.cleaned_data
+
+
+@pytest.mark.django_db
+def test_form_clean_draws_fresh_seed_when_checkbox_ticked():
+    """When `randomise_seed` is ticked, `clean()` replaces `random_seed` with a fresh int."""
+    form = steeloweb_forms.ModelRunCreateForm(data=_form_data_with_seed(randomise=True, seed_value=42))
+    form.is_valid()
+    seed = form.cleaned_data.get("random_seed")
+    assert isinstance(seed, int)
+    assert 0 <= seed < 2**31
+    # `randomise_seed` is a UI-only flag — clean() should strip it.
+    assert "randomise_seed" not in form.cleaned_data

--- a/tests/unit/test_setting_up_trade_lp.py
+++ b/tests/unit/test_setting_up_trade_lp.py
@@ -131,7 +131,7 @@ class DummyLPModel:
 
 # Dummy TradeLPModel that stores processes, bom_elements, process centers, connectors, etc.
 class DummyTradeLPModel:
-    def __init__(self, lp_epsilon=1e-3, year=None, solver_options=None):
+    def __init__(self, lp_epsilon=1e-3, year=None, solver_options=None, random_seed=42):
         self._processes = {}
         self.process_centers = []
         self.bom_elements = {}
@@ -437,6 +437,7 @@ def create_mock_config():
         closely_allocated_products: list[str] = field(default_factory=lambda: ["hot_metal"])
         distantly_allocated_products: list[str] = field(default_factory=lambda: ["pig_iron"])
         lp_epsilon: float = 1e-3
+        random_seed: int = 42
         start_year: Year = Year(2025)
         end_year: Year = Year(2050)
 
@@ -629,7 +630,7 @@ def test_set_up_steel_trade_lp(monkeypatch):
     # Patch DummyTradeLPModel.__init__ using monkeypatch.
     orig_init = ORIGINAL_DUMMY_TRADE_LP_MODEL_INIT
 
-    def init_with_processes(self, lp_epsilon=1e-3, year=None, solver_options=None):
+    def init_with_processes(self, lp_epsilon=1e-3, year=None, solver_options=None, random_seed=42):
         orig_init(self, lp_epsilon, year, solver_options)
         for proc_name in [
             "BF",
@@ -1238,7 +1239,7 @@ def test_set_up_steel_trade_lp_with_transport_kpis(monkeypatch):
     orig_init = ORIGINAL_DUMMY_TRADE_LP_MODEL_INIT
     transport_costs_added = []
 
-    def init_with_tracking(self, lp_epsilon=1e-3, year=None, solver_options=None):
+    def init_with_tracking(self, lp_epsilon=1e-3, year=None, solver_options=None, random_seed=42):
         orig_init(self, lp_epsilon, year, solver_options)
         original_add = self.add_transportation_costs
 
@@ -1316,7 +1317,7 @@ def test_set_up_steel_trade_lp_with_aggregated_constraints(monkeypatch):
     orig_init = ORIGINAL_DUMMY_TRADE_LP_MODEL_INIT
     constraints_set = {}
 
-    def init_with_constraint_tracking(self, lp_epsilon=1e-3, year=None, solver_options=None):
+    def init_with_constraint_tracking(self, lp_epsilon=1e-3, year=None, solver_options=None, random_seed=42):
         orig_init(self, lp_epsilon, year, solver_options)
         self.aggregated_commodity_constraints = {}
 
@@ -1382,7 +1383,7 @@ def test_set_up_steel_trade_lp_with_secondary_feedstock_constraints(monkeypatch)
     processes_added = []
     centers_added = []
 
-    def init_with_tracking(self, lp_epsilon=1e-3, year=None, solver_options=None):
+    def init_with_tracking(self, lp_epsilon=1e-3, year=None, solver_options=None, random_seed=42):
         orig_init(self, lp_epsilon, year, solver_options)
         original_add_processes = self.add_processes
         original_add_centers = self.add_process_centers
@@ -1692,7 +1693,7 @@ def test_set_up_steel_trade_lp_with_meta_furnace_groups(monkeypatch):
     # Patch DummyTradeLPModel to have required processes
     orig_init = ORIGINAL_DUMMY_TRADE_LP_MODEL_INIT
 
-    def init_with_processes(self, lp_epsilon=1e-3, year=None, solver_options=None):
+    def init_with_processes(self, lp_epsilon=1e-3, year=None, solver_options=None, random_seed=42):
         orig_init(self, lp_epsilon, year, solver_options)
         for proc_name in ["BF", "EAF", "demand", "scrap_supply"]:
             self._processes[proc_name] = DummyProcess(proc_name, DummyProcessType.PRODUCTION, [])

--- a/tests/unit/test_simulation_config.py
+++ b/tests/unit/test_simulation_config.py
@@ -73,18 +73,13 @@ def test_config_factory_from_data_directory(prepared_data_dir):
     """
     Tests that the from_data_directory factory correctly populates path fields.
     """
-    from steelo.simulation import GeoConfig
-
-    # Create a custom GeoConfig with different random_seed
-    custom_geo_config = GeoConfig(random_seed=123)
-
     config = SimulationConfig.from_data_directory(
         data_dir=prepared_data_dir,
         output_dir=Path("/tmp/sim_output"),
         start_year=Year(2025),
         end_year=Year(2030),
-        # Pass the custom geo_config
-        geo_config=custom_geo_config,
+        # Override the top-level random_seed; it is propagated into geo_config in __post_init__.
+        random_seed=123,
     )
 
     # Check that the factory correctly set the data directory


### PR DESCRIPTION
- Single SimulationConfig.random_seed (default 42) drives Python random, NumPy global RNG, geospatial RNG, and HiGHS LP solver
- Bootstrap seeds Python random and NumPy globals; geo_config.random_seed propagated in __post_init__
- TradeLPModel takes random_seed as required arg; threaded from config in set_up_steel_trade_lp
- Django form adds "Randomise seed" checkbox: when ticked, clean() draws a fresh seed via secrets.randbelow(2**31); otherwise user value (default 42) is used
- Removed hardcoded random.seed(42) from domain/models.py