### PR TITLE
Some UI additions

### DIFF
--- a/src/electron/build-django.js
+++ b/src/electron/build-django.js
@@ -993,18 +993,6 @@ print("[OK] All NetCDF4 and HDF5 packages are installed")
       
       console.log('[OK] Complete python-build-standalone copied');
 
-      // Remove GNU libiconv from python-build-standalone on macOS.
-      // It exports _libiconv (GNU names) but pyogrio/fiona's libgdal expects _iconv (POSIX names)
-      // from the system /usr/lib/libiconv.2.dylib. DYLD_LIBRARY_PATH causes the bundled GNU version
-      // to shadow the system one, breaking geopandas shapefile reading.
-      if (IS_MAC) {
-        const gnuLibiconv = path.join(pythonDir, 'lib', 'libiconv.2.dylib');
-        if (fs.existsSync(gnuLibiconv)) {
-          fs.unlinkSync(gnuLibiconv);
-          console.log('[OK] Removed GNU libiconv.2.dylib (system libiconv will be used instead)');
-        }
-      }
-
       // CRITICAL: Verify bundled libpython shared library exists
       const libDir = path.join(pythonDir, 'lib');
       let libpythonFound = false;
@@ -1271,6 +1259,24 @@ print("[OK] All NetCDF4 and HDF5 packages are installed")
     }
     
     console.log(`Total HDF5/NetCDF shared libraries copied: ${sharedLibsCopied}`);
+
+    // Remove GNU libiconv from the bundle on macOS.
+    // python-build-standalone and netCDF4 wheels ship a GNU libiconv that exports
+    // _libiconv (GNU names) instead of _iconv (POSIX names). DYLD_LIBRARY_PATH
+    // shadows the system /usr/lib/libiconv.2.dylib, breaking pyogrio/fiona's libgdal.
+    // Must run AFTER all shared-library copying to avoid re-introduction.
+    if (IS_MAC) {
+      const libiconvPaths = [
+        path.join(pythonDir, 'lib', 'libiconv.2.dylib'),
+        path.join(sitePackagesDir, 'netCDF4', '.dylibs', 'libiconv.2.dylib'),
+      ];
+      for (const libPath of libiconvPaths) {
+        if (fs.existsSync(libPath)) {
+          fs.unlinkSync(libPath);
+          console.log(`[OK] Removed GNU libiconv: ${libPath}`);
+        }
+      }
+    }
 
     // Test the portable Python installation
     console.log('Testing portable Python installation...');

--- a/src/steeloweb/views.py
+++ b/src/steeloweb/views.py
@@ -647,6 +647,7 @@ def create_modelrun(request):
             config = {
                 "start_year": form.cleaned_data["start_year"],
                 "end_year": form.cleaned_data["end_year"],
+                "random_seed": form.cleaned_data.get("random_seed", 42),
                 "plant_lifetime": form.cleaned_data.get("plant_lifetime", 20),
                 "global_risk_free_rate": float(form.cleaned_data.get("global_risk_free_rate") or 0.0209),
                 "steel_price_buffer": float(
@@ -670,6 +671,7 @@ def create_modelrun(request):
                     if form.cleaned_data.get("opening_balance_multiplier") is not None
                     else 1.0
                 ),
+                "consideration_time": form.cleaned_data.get("consideration_time", 3),
                 "construction_time": form.cleaned_data.get("construction_time", 4),
                 "probabilistic_agents": form.cleaned_data.get("probabilistic_agents", True),
                 "probability_of_announcement": float(form.cleaned_data.get("probability_of_announcement") or 0.7),


### PR DESCRIPTION
- `random_seed` and `consideration_time` were collected from the user in the form but never added to the config dict in `create_modelrun`, so `SimulationConfig` always used its defaults (42 and 3) regardless of user input
- Also includes a build fix for GNU libiconv removal ordering in `build-django.js`
