### PR TITLE
Fix AVG_BOM energy reconstruction and unit_cost semantics

### DIFF
--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -13,7 +13,6 @@ function_overrides:
   # Suppress noisy functions
   calculate_unit_production_cost: WARNING
   extract_price_from_costcurve: WARNING
-  generate_input_effectiveness_mapping_from_feedstocks: ERROR
 
 external:
   pyomo: ERROR

--- a/src/steelo/adapters/geospatial/geospatial_statistics.py
+++ b/src/steelo/adapters/geospatial/geospatial_statistics.py
@@ -18,6 +18,7 @@ def export_lcoe_lcoh_statistics_by_country(
     energy_prices: xr.Dataset,
     year: "Year",
     output_dir: Path,
+    hydrogen_ceiling_percentile: float = 100.0,
 ) -> None:
     """
     Calculate and export LCOE and LCOH statistics by country to separate files.
@@ -31,6 +32,7 @@ def export_lcoe_lcoh_statistics_by_country(
         energy_prices: xarray Dataset containing iso3, power_price (LCOE in USD/kWh), and capped_lcoh (LCOH in USD/kg)
         year: Current simulation year
         output_dir: Base output directory (will save to output_dir/data/)
+        hydrogen_ceiling_percentile: Hydrogen ceiling percentile from GeoConfig (0-100).
 
     Returns:
         None (saves two separate CSV files to disk: lcoe_stats_{year}.csv and lcoh_stats_{year}.csv)
@@ -74,6 +76,7 @@ def export_lcoe_lcoh_statistics_by_country(
         country_stats = {
             "country": country,
             "year": year,
+            "hydrogen_ceiling_pct": hydrogen_ceiling_percentile,
             # LCOE statistics (in USD/MWh)
             "lcoe_avg_usd_per_mwh": float(np.mean(lcoe_values_mwh)),
             "lcoe_min_usd_per_mwh": float(np.min(lcoe_values_mwh)),
@@ -121,6 +124,7 @@ def export_lcoe_lcoh_statistics_by_country(
     lcoh_columns = [
         "country",
         "year",
+        "hydrogen_ceiling_pct",
         "lcoh_avg_usd_per_kg",
         "lcoh_min_usd_per_kg",
         "lcoh_max_usd_per_kg",
@@ -279,3 +283,38 @@ def export_overbuild_factor_statistics_by_country(
     stats_df.to_csv(output_path, index=False, float_format="%.4f")
 
     logger.info(f"Exported {factor_name} statistics for {len(statistics)} countries to {output_path}")
+
+
+def aggregate_lcoe_lcoh_statistics(
+    output_dir: Path,
+    start_year: int,
+    end_year: int,
+) -> None:
+    """Concatenate per-year LCOE/LCOH stat CSVs into one stacked CSV per metric.
+
+    Reads all ``lcoe_stats_{year}.csv`` and ``lcoh_stats_{year}.csv`` files from
+    *output_dir*/data, concatenates them, and writes aggregated files named
+    ``lcoe_stats_{start_year}_{end_year}.csv`` / ``lcoh_stats_{start_year}_{end_year}.csv``.
+
+    Args:
+        output_dir: Base output directory (expects a ``data/`` subdirectory).
+        start_year: Simulation start year (used in output filename).
+        end_year: Simulation end year (used in output filename).
+    """
+    data_dir = output_dir / "data"
+    if not data_dir.exists():
+        logger.warning("Data directory %s does not exist — skipping LCOE/LCOH aggregation", data_dir)
+        return
+
+    for prefix in ("lcoe_stats", "lcoh_stats"):
+        per_year_files = sorted(data_dir.glob(f"{prefix}_*.csv"))
+        # Exclude any previously aggregated file (filename contains a year range like 2020_2050)
+        per_year_files = [f for f in per_year_files if f.stem.removeprefix(f"{prefix}_").isdigit()]
+        if not per_year_files:
+            continue
+
+        combined = pd.concat([pd.read_csv(f) for f in per_year_files], ignore_index=True)
+        combined = combined.sort_values(["year", "country"]).reset_index(drop=True)
+        agg_path = data_dir / f"{prefix}_{start_year}_{end_year}.csv"
+        combined.to_csv(agg_path, index=False, float_format="%.4f")
+        logger.info("Saved aggregated %s (%d years) to %s", prefix, len(per_year_files), agg_path)

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -8363,7 +8363,7 @@ class Environment:
                     technology_name: {
                         material_name: {
                             "unit_cost": float,        # Average cost per ton
-                            "demand_share_pct": float  # Material's % share of total demand
+                            "input_share_pct": float   # Fraction of total input demand (sums to 1.0)
                         }
                     }
                 }
@@ -8456,8 +8456,8 @@ class Environment:
                     else None
                 )
 
-                # demand share as a percentage
-                demand_share_pct_of_mc = (
+                # input share (fraction of total demand for this technology)
+                input_share_pct_of_mc = (
                     (demand_of_metallic_charge / total_demand_all_mc_for_tech)
                     if total_demand_all_mc_for_tech > 0
                     else None
@@ -8465,7 +8465,7 @@ class Environment:
 
                 stats[tech][mat_name] = {
                     "unit_cost": unit_cost_for_metallic_charge if unit_cost_for_metallic_charge is not None else 0.0,
-                    "demand_share_pct": demand_share_pct_of_mc if demand_share_pct_of_mc is not None else 0.0,
+                    "input_share_pct": input_share_pct_of_mc if input_share_pct_of_mc is not None else 0.0,
                 }
         self._diag_bof_sample_count = tech_contributor_counts.get("BOF", 0)
         if diag.diagnostics_enabled():
@@ -8532,13 +8532,13 @@ class Environment:
                         avg_cost = self.get_average_fallback_material_cost(technology=tech)
                         if avg_cost is not None:
                             bom[metallic_charge]["unit_cost"] = avg_cost
-                            bom[metallic_charge]["demand_share_pct"] = 1.0
+                            bom[metallic_charge]["input_share_pct"] = 1.0
                     else:
                         # Use region-specific cost (Note: get_available_fallback_technologies doesn't take iso3/tech params)
                         specific_cost = self.get_fallback_material_cost(iso3, tech)
                         if specific_cost is not None:
                             bom[metallic_charge]["unit_cost"] = specific_cost
-                            bom[metallic_charge]["demand_share_pct"] = 1.0
+                            bom[metallic_charge]["input_share_pct"] = 1.0
                 else:
                     logger.warning(f"Technology {tech} not found in default_metallic_charge_per_technology mapping")
                 self.avg_boms[tech] = bom
@@ -8818,19 +8818,19 @@ class Environment:
                     skipped_mcs.append(feedstock)
                     continue
 
-            # Extract demand_share_pct and unit_cost
-            demand_share_pct = share_data.get("demand_share_pct")
-            if demand_share_pct is None:
+            # Extract input_share_pct and unit_cost
+            input_share_pct = share_data.get("input_share_pct")
+            if input_share_pct is None:
                 if len(self.avg_boms[tech]) == 1 and "unit_cost" in share_data:
-                    demand_share_pct = 1.0
+                    input_share_pct = 1.0
                     logger.warning(
-                        "[BOM] avg_boms[%s][%s] missing demand_share_pct; defaulting to 1.0 for single-input BOM",
+                        "[BOM] avg_boms[%s][%s] missing input_share_pct; defaulting to 1.0 for single-input BOM",
                         tech,
                         feedstock,
                     )
                 else:
                     raise KeyError(
-                        f"avg_boms missing demand_share_pct for technology {tech!r}, feedstock {feedstock!r}. "
+                        f"avg_boms missing input_share_pct for technology {tech!r}, feedstock {feedstock!r}. "
                         f"share_data keys: {list(share_data.keys())}"
                     )
 
@@ -8845,17 +8845,17 @@ class Environment:
             surviving[normalized_feedstock] = {
                 "feedstock_key": feedstock,
                 "pf": matched_pf,
-                "demand_share_pct": float(demand_share_pct),
+                "input_share_pct": float(input_share_pct),
                 "eff": eff,
                 "unit_cost": float(unit_cost),
             }
             logger.debug(
-                "[AVG_BOM_DIAG] pf_match: tech=%s mc=%s pf=%s eff=%.4f demand_share=%.4f",
+                "[AVG_BOM_DIAG] pf_match: tech=%s mc=%s pf=%s eff=%.4f input_share=%.4f",
                 tech,
                 feedstock,
                 matched_pf,
                 eff,
-                demand_share_pct,
+                input_share_pct,
             )
 
         if skipped_mcs:
@@ -8877,7 +8877,7 @@ class Environment:
             raw_output: dict[str, float] = {}
             for norm_mc, data in surviving.items():
                 if data["eff"] and data["eff"] > 0:
-                    raw_output[norm_mc] = data["demand_share_pct"] / data["eff"]
+                    raw_output[norm_mc] = data["input_share_pct"] / data["eff"]
                 else:
                     raw_output[norm_mc] = 0.0
 
@@ -8898,13 +8898,13 @@ class Environment:
             for norm_mc, data in surviving.items():
                 feedstock = data["feedstock_key"]
                 eff = data["eff"]
-                demand_share_pct_val = data["demand_share_pct"]
+                input_share_pct_val = data["input_share_pct"]
                 unit_cost_val = data["unit_cost"]
                 matched_pf = data["pf"]
                 o_share = output_shares[norm_mc]
 
                 # Materials
-                material_demand = demand_share_pct_val * capacity * eff
+                material_demand = input_share_pct_val * capacity * eff
                 material_cost = unit_cost_val * material_demand
 
                 bom_dict["materials"][feedstock] = {
@@ -8914,6 +8914,7 @@ class Environment:
                     "unit_cost": unit_cost_val,
                     "unit_material_cost": unit_cost_val,
                     "product_volume": capacity,
+                    "demand_share_pct": input_share_pct_val * eff,
                 }
 
                 # Energy — accumulate from PrimaryFeedstock

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -8703,30 +8703,39 @@ class Environment:
             )
 
         if most_common_reductant is None and feedstocks_for_tech:
-            cheapest_reductant, _ = calculate_energy_costs_and_most_common_reductant(
-                feedstocks_for_tech,
-                energy_costs,
-            )
-            if cheapest_reductant:
-                most_common_reductant = cheapest_reductant
-                logger.warning(
-                    "[AVG_BOM_DIAG] reductant: tech=%s source=cheapest_reductant_fallback chosen=%s",
+            has_reductants = any(f.reductant and str(f.reductant).strip() for f in feedstocks_for_tech)
+            if not has_reductants:
+                # Reductant-free tech (e.g. EAF, BOF) — skip cheapest-reductant calculation
+                most_common_reductant = ""
+                logger.debug(
+                    "[AVG_BOM_DIAG] reductant: tech=%s no reductants in feedstocks, using empty string",
                     tech,
-                    most_common_reductant,
                 )
             else:
-                # Cheapest-reductant returned empty — fall back to first available
-                for feed in feedstocks_for_tech:
-                    if feed.reductant and str(feed.reductant).strip():
-                        most_common_reductant = str(feed.reductant)
-                        break
-                if most_common_reductant is None:
-                    most_common_reductant = ""
-                logger.warning(
-                    "[AVG_BOM_DIAG] reductant: tech=%s cheapest_reductant_failed, using first_available=%s",
-                    tech,
-                    most_common_reductant,
+                cheapest_reductant, _ = calculate_energy_costs_and_most_common_reductant(
+                    feedstocks_for_tech,
+                    energy_costs,
                 )
+                if cheapest_reductant:
+                    most_common_reductant = cheapest_reductant
+                    logger.warning(
+                        "[AVG_BOM_DIAG] reductant: tech=%s source=cheapest_reductant_fallback chosen=%s",
+                        tech,
+                        most_common_reductant,
+                    )
+                else:
+                    # Cheapest-reductant returned empty — fall back to first available
+                    for feed in feedstocks_for_tech:
+                        if feed.reductant and str(feed.reductant).strip():
+                            most_common_reductant = str(feed.reductant)
+                            break
+                    if most_common_reductant is None:
+                        most_common_reductant = ""
+                    logger.warning(
+                        "[AVG_BOM_DIAG] reductant: tech=%s cheapest_reductant_failed, using first_available=%s",
+                        tech,
+                        most_common_reductant,
+                    )
         elif most_common_reductant is not None:
             logger.debug(
                 "[AVG_BOM_DIAG] reductant: tech=%s source=fleet chosen=%s",
@@ -8892,6 +8901,12 @@ class Environment:
             else:
                 output_shares = {mc: raw / total_raw for mc, raw in raw_output.items()}
 
+            logger.debug(
+                "[AVG_BOM_DIAG] output_shares: tech=%s shares=%s",
+                tech,
+                {mc: f"{s:.4f}" for mc, s in output_shares.items()},
+            )
+
             # Pass 2 — build materials + accumulate energy
             energy_accum: dict[str, float] = {}
 
@@ -8916,6 +8931,18 @@ class Environment:
                     "product_volume": capacity,
                     "demand_share_pct": input_share_pct_val * eff,
                 }
+                logger.debug(
+                    "[AVG_BOM_DIAG] material: tech=%s mc=%s input_share=%.4f eff=%.4f "
+                    "demand=%.2f unit_cost_input=%.2f unit_cost_output=%.2f demand_share=%.4f",
+                    tech,
+                    feedstock,
+                    input_share_pct_val,
+                    eff,
+                    material_demand,
+                    unit_cost_val,
+                    material_cost / capacity,
+                    input_share_pct_val * eff,
+                )
 
                 # Energy — accumulate from PrimaryFeedstock
                 if matched_pf is not None:
@@ -8926,7 +8953,7 @@ class Environment:
                         contrib = o_share * float(intensity) * capacity
                         energy_accum[norm_carrier] = energy_accum.get(norm_carrier, 0.0) + contrib
                         logger.debug(
-                            "[AVG_BOM_DEBUG] energy_contrib: tech=%s mc=%s carrier=%s "
+                            "[AVG_BOM_DIAG] energy_contrib: tech=%s mc=%s carrier=%s "
                             "o_share=%.4f intensity=%.4f contrib=%.2f",
                             tech,
                             feedstock,
@@ -8943,7 +8970,7 @@ class Environment:
                         contrib = o_share * float(intensity) * capacity
                         energy_accum[norm_sec] = energy_accum.get(norm_sec, 0.0) + contrib
                         logger.debug(
-                            "[AVG_BOM_DEBUG] energy_contrib_sec: tech=%s mc=%s carrier=%s "
+                            "[AVG_BOM_DIAG] energy_contrib_sec: tech=%s mc=%s carrier=%s "
                             "o_share=%.4f intensity=%.4f contrib=%.2f",
                             tech,
                             feedstock,
@@ -8971,11 +8998,18 @@ class Environment:
                     "product_volume": capacity,
                 }
 
-            logger.warning(
-                "[AVG_BOM_DEBUG] summary: tech=%s materials=%d energy=%d energy_carriers=%s",
+            total_material_cost = sum(m["total_cost"] for m in bom_dict["materials"].values())
+            total_energy_cost = sum(e["total_cost"] for e in bom_dict["energy"].values())
+            logger.info(
+                "[AVG_BOM_DIAG] summary: tech=%s capacity=%.0f reductant=%s "
+                "materials=%d (cost=%.0f) energy=%d (cost=%.0f) carriers=%s",
                 tech,
+                capacity,
+                most_common_reductant,
                 len(bom_dict["materials"]),
+                total_material_cost,
                 len(bom_dict["energy"]),
+                total_energy_cost,
                 list(bom_dict["energy"].keys()),
             )
 

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -15,6 +15,7 @@ from steelo.domain import events, commands
 from steelo.domain.calculate_costs import (
     calculate_capex_with_subsidies,
     calculate_debt_with_subsidies,
+    calculate_energy_costs_and_most_common_reductant,
     calculate_opex_list_with_subsidies,
     calculate_unit_total_opex,
     calculate_variable_opex,
@@ -8722,28 +8723,52 @@ class Environment:
         feedstocks_for_tech = self.dynamic_feedstocks.get(tech, self.dynamic_feedstocks.get(tech.lower(), []))
         bom_dict: dict[str, dict[str, dict[str, float]]] = {"materials": {}, "energy": {}}
 
-        # Step 3: Build input effectiveness mapping for selected reductant
-        # When most_common_reductant is None, all feedstocks are accepted because avg_boms
-        # will determine the actual mix of metallic charges used
-        logger.debug("[BOM] Step 3: Building input effectiveness")
-        input_effectiveness = self.generate_input_effectiveness_mapping_from_feedstocks(
-            feedstocks_for_tech, most_common_reductant
-        )
+        # Step 3a: Resolve reductant
+        can_reconstruct_energy = bool(feedstocks_for_tech)
+        if not feedstocks_for_tech:
+            logger.warning(
+                "[AVG_BOM_DIAG] reductant: tech=%s no PrimaryFeedstock data, energy reconstruction impossible",
+                tech,
+            )
 
-        # If no reductant was specified but we got feedstocks, extract a reductant to return
-        # This ensures the function returns a non-None reductant for validation purposes
-        if most_common_reductant is None and input_effectiveness and feedstocks_for_tech:
-            for feed in feedstocks_for_tech:
-                if feed.reductant and str(feed.reductant).strip():
-                    most_common_reductant = str(feed.reductant)
-                    logger.debug(
-                        f"[BOM] No reductant specified, extracted first available for return: {most_common_reductant}"
-                    )
-                    break
-            # If still None after checking all feedstocks, use empty string
-            if most_common_reductant is None:
-                most_common_reductant = ""
-                logger.debug("[BOM] All feedstocks have empty reductants, using empty string")
+        if most_common_reductant is None and feedstocks_for_tech:
+            cheapest_reductant, _ = calculate_energy_costs_and_most_common_reductant(
+                feedstocks_for_tech,
+                energy_costs,
+            )
+            if cheapest_reductant:
+                most_common_reductant = cheapest_reductant
+                logger.warning(
+                    "[AVG_BOM_DIAG] reductant: tech=%s source=cheapest_reductant_fallback chosen=%s",
+                    tech,
+                    most_common_reductant,
+                )
+            else:
+                # Cheapest-reductant returned empty — fall back to first available
+                for feed in feedstocks_for_tech:
+                    if feed.reductant and str(feed.reductant).strip():
+                        most_common_reductant = str(feed.reductant)
+                        break
+                if most_common_reductant is None:
+                    most_common_reductant = ""
+                logger.warning(
+                    "[AVG_BOM_DIAG] reductant: tech=%s cheapest_reductant_failed, using first_available=%s",
+                    tech,
+                    most_common_reductant,
+                )
+        elif most_common_reductant is not None:
+            logger.debug(
+                "[AVG_BOM_DIAG] reductant: tech=%s source=fleet chosen=%s",
+                tech,
+                most_common_reductant,
+            )
+
+        # Step 3b: Build input effectiveness mapping for resolved reductant
+        logger.debug("[BOM] Step 3b: Building input effectiveness")
+        input_effectiveness = self.generate_input_effectiveness_mapping_from_feedstocks(
+            feedstocks_for_tech,
+            most_common_reductant,
+        )
 
         # Step 4: Fallback if no average BOM available
         logger.debug("[BOM] Step 4: Checking avg_boms")
@@ -8769,16 +8794,16 @@ class Environment:
 
         logger.debug(f"[BOM] Found avg_boms for {tech}: {self.avg_boms[tech]}")
 
-        # Step 5: Build BOM based on avg_boms and input effectiveness
-        logger.debug("[BOM] Step 5: Building final BOM")
+        # ── Step 5: Two-pass BOM construction ──────────────────────────────
+        # Pass 1 — pre-scan: validate each MC and collect surviving entries
+        surviving: dict[str, dict] = {}
+        skipped_mcs: list[str] = []
+
         for feedstock, share_data in self.avg_boms[tech].items():
             normalized_feedstock = normalize_name(feedstock)
-            logger.debug(f"[BOM] Processing feedstock: {feedstock} (normalized: {normalized_feedstock})")
-            logger.debug(f"[BOM] Share data: {share_data}")
 
-            # Skip carbon outputs - they are tracked separately and don't need input effectiveness
+            # Skip carbon outputs
             if hasattr(self, "carbon_output_keys") and normalized_feedstock in self.carbon_output_keys:
-                logger.debug(f"[BOM] Skipping carbon output: {feedstock}")
                 continue
 
             if not isinstance(share_data, dict):
@@ -8787,13 +8812,42 @@ class Environment:
                     f"expected dict, got {type(share_data).__name__}"
                 )
 
-            # Calculate material demand and cost
+            # (a) Check input_effectiveness
             if normalized_feedstock not in input_effectiveness:
-                raise KeyError(
-                    f"Input effectiveness for feedstock '{feedstock}' not found for technology {tech}. "
-                    f"Available inputs: {list(input_effectiveness.keys())}. "
-                    f"This indicates a mismatch between avg_boms and dynamic_feedstocks data."
+                logger.warning(
+                    "[AVG_BOM_DIAG] pf_match: tech=%s mc=%s skipped, not in input_effectiveness (available: %s)",
+                    tech,
+                    feedstock,
+                    list(input_effectiveness.keys()),
                 )
+                skipped_mcs.append(feedstock)
+                continue
+
+            # (b) Find matching PrimaryFeedstock for (mc, reductant)
+            matched_pf: PrimaryFeedstock | None = None
+            if can_reconstruct_energy:
+                for feed in feedstocks_for_tech:
+                    if normalize_name(feed.metallic_charge) == normalized_feedstock and (
+                        feed.reductant == most_common_reductant
+                        or (
+                            isinstance(feed.reductant, str)
+                            and feed.reductant.lower() == (most_common_reductant or "").lower()
+                        )
+                        or (not most_common_reductant and not feed.reductant)
+                    ):
+                        matched_pf = feed
+                        break
+                if matched_pf is None:
+                    logger.warning(
+                        "[AVG_BOM_DIAG] pf_match: tech=%s mc=%s reductant=%s no PrimaryFeedstock match, skipping MC",
+                        tech,
+                        feedstock,
+                        most_common_reductant,
+                    )
+                    skipped_mcs.append(feedstock)
+                    continue
+
+            # Extract demand_share_pct and unit_cost
             demand_share_pct = share_data.get("demand_share_pct")
             if demand_share_pct is None:
                 if len(self.avg_boms[tech]) == 1 and "unit_cost" in share_data:
@@ -8816,53 +8870,142 @@ class Environment:
                     f"share_data keys: {list(share_data.keys())}"
                 )
 
-            material_demand = float(demand_share_pct) * capacity * input_effectiveness[normalized_feedstock]
-            material_cost = float(unit_cost) * material_demand
+            eff = input_effectiveness[normalized_feedstock]
+            surviving[normalized_feedstock] = {
+                "feedstock_key": feedstock,
+                "pf": matched_pf,
+                "demand_share_pct": float(demand_share_pct),
+                "eff": eff,
+                "unit_cost": float(unit_cost),
+            }
             logger.debug(
-                "[BOM] Material calculation: demand=%s, cost=%s, unit cost=%s",
-                material_demand,
-                material_cost,
-                unit_cost,
+                "[AVG_BOM_DIAG] pf_match: tech=%s mc=%s pf=%s eff=%.4f demand_share=%.4f",
+                tech,
+                feedstock,
+                matched_pf,
+                eff,
+                demand_share_pct,
             )
 
-            bom_dict["materials"][feedstock] = {
-                "demand": material_demand,
-                "total_cost": material_cost,
-                "total_material_cost": material_cost,  # Required by calculate_variable_opex
-                "unit_cost": float(unit_cost),
-                "unit_material_cost": float(unit_cost),  # Same as unit_cost for avg_boms
-                "product_volume": capacity,  # Output volume for this furnace
-            }
+        if skipped_mcs:
+            logger.warning(
+                "[AVG_BOM_DIAG] pf_match: tech=%s skipped_mcs=%s (%d of %d)",
+                tech,
+                skipped_mcs,
+                len(skipped_mcs),
+                len(skipped_mcs) + len(surviving),
+            )
 
-            # Calculate energy demand and cost using energy_vopex (only for genuine energy carriers)
-            if normalized_feedstock in ENERGY_FEEDSTOCK_KEYS:
-                energy_cost_per_unit = energy_costs.get(
-                    normalized_feedstock,
-                    energy_costs.get(normalize_name(feedstock), 0.0),
+        if not surviving:
+            logger.warning(
+                "[AVG_BOM_DIAG] pf_match: tech=%s all metallic charges skipped, BOM will be empty",
+                tech,
+            )
+        else:
+            # Compute output shares from input shares and effectiveness
+            raw_output: dict[str, float] = {}
+            for norm_mc, data in surviving.items():
+                if data["eff"] and data["eff"] > 0:
+                    raw_output[norm_mc] = data["demand_share_pct"] / data["eff"]
+                else:
+                    raw_output[norm_mc] = 0.0
+
+            total_raw = sum(raw_output.values())
+            if total_raw == 0:
+                logger.warning(
+                    "[AVG_BOM_DIAG] output_shares: tech=%s total_raw=0, using equal shares",
+                    tech,
                 )
-                energy_demand = float(demand_share_pct) * capacity
-                total_energy_cost = energy_cost_per_unit * energy_demand
-                if total_energy_cost < 0:
-                    logger.warning(
-                        "[BOM] Negative energy cost for '%s': unit=$%.6f x demand=%.1f = $%.4f",
-                        feedstock,
-                        energy_cost_per_unit,
-                        energy_demand,
-                        total_energy_cost,
-                    )
-                logger.debug(f"[BOM] Energy calculation: demand={energy_demand}, total_cost={total_energy_cost}")
+                equal_share = 1.0 / len(surviving)
+                output_shares = {mc: equal_share for mc in surviving}
+            else:
+                output_shares = {mc: raw / total_raw for mc, raw in raw_output.items()}
 
-                if energy_demand <= 0:
-                    logger.debug(
-                        f"[BOM] WARNING: Zero energy demand for {feedstock}. Material demand: {material_demand}"
-                    )
+            # Pass 2 — build materials + accumulate energy
+            energy_accum: dict[str, float] = {}
 
-                bom_dict["energy"][feedstock] = {
-                    "demand": energy_demand,
-                    "total_cost": total_energy_cost,
-                    "unit_cost": total_energy_cost / energy_demand if energy_demand > 0 else float("inf"),
-                    "product_volume": capacity,  # Required by calculate_variable_opex
+            for norm_mc, data in surviving.items():
+                feedstock = data["feedstock_key"]
+                eff = data["eff"]
+                demand_share_pct_val = data["demand_share_pct"]
+                unit_cost_val = data["unit_cost"]
+                matched_pf = data["pf"]
+                o_share = output_shares[norm_mc]
+
+                # Materials
+                material_demand = demand_share_pct_val * capacity * eff
+                material_cost = unit_cost_val * material_demand
+
+                bom_dict["materials"][feedstock] = {
+                    "demand": material_demand,
+                    "total_cost": material_cost,
+                    "total_material_cost": material_cost,
+                    "unit_cost": unit_cost_val,
+                    "unit_material_cost": unit_cost_val,
+                    "product_volume": capacity,
                 }
+
+                # Energy — accumulate from PrimaryFeedstock
+                if matched_pf is not None:
+                    for carrier, intensity in (matched_pf.energy_requirements or {}).items():
+                        norm_carrier = normalize_name(carrier)
+                        if norm_carrier not in ENERGY_FEEDSTOCK_KEYS:
+                            continue
+                        contrib = o_share * float(intensity) * capacity
+                        energy_accum[norm_carrier] = energy_accum.get(norm_carrier, 0.0) + contrib
+                        logger.debug(
+                            "[AVG_BOM_DEBUG] energy_contrib: tech=%s mc=%s carrier=%s "
+                            "o_share=%.4f intensity=%.4f contrib=%.2f",
+                            tech,
+                            feedstock,
+                            norm_carrier,
+                            o_share,
+                            intensity,
+                            contrib,
+                        )
+
+                    for sec_name, intensity in (matched_pf.secondary_feedstock or {}).items():
+                        norm_sec = normalize_name(sec_name)
+                        if norm_sec not in ENERGY_FEEDSTOCK_KEYS:
+                            continue
+                        contrib = o_share * float(intensity) * capacity
+                        energy_accum[norm_sec] = energy_accum.get(norm_sec, 0.0) + contrib
+                        logger.debug(
+                            "[AVG_BOM_DEBUG] energy_contrib_sec: tech=%s mc=%s carrier=%s "
+                            "o_share=%.4f intensity=%.4f contrib=%.2f",
+                            tech,
+                            feedstock,
+                            norm_sec,
+                            o_share,
+                            intensity,
+                            contrib,
+                        )
+
+            # Build bom_dict["energy"] from accumulated demands
+            for carrier, demand in energy_accum.items():
+                price = energy_costs.get(carrier, 0.0)
+                total_cost = price * demand
+                if demand > 0 and price == 0:
+                    logger.warning(
+                        "[AVG_BOM_DIAG] energy: tech=%s carrier=%s has demand=%.2f but zero price in energy_costs",
+                        tech,
+                        carrier,
+                        demand,
+                    )
+                bom_dict["energy"][carrier] = {
+                    "demand": demand,
+                    "total_cost": total_cost,
+                    "unit_cost": price,
+                    "product_volume": capacity,
+                }
+
+            logger.warning(
+                "[AVG_BOM_DEBUG] summary: tech=%s materials=%d energy=%d energy_carriers=%s",
+                tech,
+                len(bom_dict["materials"]),
+                len(bom_dict["energy"]),
+                list(bom_dict["energy"].keys()),
+            )
 
         utilization = (
             self.avg_utilization.get(tech, {}).get("utilization_rate", 0.6)

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -8911,8 +8911,8 @@ class Environment:
                     "demand": material_demand,
                     "total_cost": material_cost,
                     "total_material_cost": material_cost,
-                    "unit_cost": unit_cost_val,
-                    "unit_material_cost": unit_cost_val,
+                    "unit_cost": material_cost / capacity,
+                    "unit_material_cost": material_cost / capacity,
                     "product_volume": capacity,
                     "demand_share_pct": input_share_pct_val * eff,
                 }

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -8619,35 +8619,6 @@ class Environment:
                 logger.debug(
                     f"[BOM] Added to input_effectiveness: {feed.metallic_charge.lower()} = {feed.required_quantity_per_ton_of_product}"
                 )
-            # Include secondary feedstocks and other non-metallic inputs so avg_boms stay aligned with dynamic feedstocks
-            secondary_requirements = feed.secondary_feedstock or {}
-            if not secondary_requirements:
-                continue
-            reductant_matches = (
-                most_common_reductant is None  # Accept any reductant when None
-                or feed.reductant == most_common_reductant
-                or str(feed.reductant).lower() == most_common_reductant
-                or (not most_common_reductant and not feed.reductant)
-            )
-            if not reductant_matches:
-                continue
-            for sec_name, volume in secondary_requirements.items():
-                normalized_secondary = normalize_name(sec_name)
-                if (
-                    normalized_secondary in input_effectiveness
-                ):  # Should not happen, as each secondary feedstock should only appear once per feedstock and reductant combo
-                    logger.warning(
-                        "[BOM] Secondary feedstock %s overwriting %.4f with %.4f",
-                        normalized_secondary,
-                        input_effectiveness[normalized_secondary],
-                        volume,
-                    )
-                input_effectiveness[normalized_secondary] = volume
-            if hasattr(feed, "energy_requirements") and feed.energy_requirements:
-                for en_in in feed.energy_requirements or []:
-                    normalized_energy = normalize_name(en_in)
-                    if normalized_energy not in input_effectiveness:
-                        input_effectiveness[normalized_energy] = feed.energy_requirements[en_in]
         # If no inputs matched the most common reductant
         if not input_effectiveness:
             logger.error(

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -172,6 +172,7 @@ class GeospatialModel:
                     energy_prices=custom_energy_costs,
                     year=bus.env.year,
                     output_dir=bus.env.config.output_dir,
+                    hydrogen_ceiling_percentile=geo_config.hydrogen_ceiling_percentile,
                 )
             except Exception as e:
                 logger.warning(f"Failed to export LCOE/LCOH statistics for year {bus.env.year}: {e}")

--- a/src/steelo/service_layer/handlers.py
+++ b/src/steelo/service_layer/handlers.py
@@ -191,6 +191,14 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
     """
     with uow:
         plant = uow.plants.get(cmd.plant_id)
+        # TODO(3h): BOM uses plant.energy_costs (last FG's subsidised costs), not the new
+        # tech's. Impact zero during construction (0% utilisation); refreshed when operational.
+        avg_bom_result = env.get_bom_from_avg_boms(
+            plant.energy_costs or {},
+            cmd.technology_name,
+            cmd.capacity,
+            env.most_common_reductant_by_tech.get(cmd.technology_name, None),
+        )
         new_furnace = plant.generate_new_furnace(
             technology_name=cmd.technology_name,
             product=cmd.product,
@@ -209,20 +217,8 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
                 env.dynamic_feedstocks.get(cmd.technology_name.lower(), []),
             ),
             equity_needed=cmd.equity_needed,
-            # TODO(3h): BOM uses plant.energy_costs (last FG's subsidised costs), not the new
-            # tech's. Impact zero during construction (0% utilisation); refreshed when operational.
-            bill_of_materials=env.get_bom_from_avg_boms(
-                plant.energy_costs or {},
-                cmd.technology_name,
-                cmd.capacity,
-                env.most_common_reductant_by_tech.get(cmd.technology_name, None),
-            )[0],
-            chosen_reductant=env.get_bom_from_avg_boms(
-                plant.energy_costs or {},
-                cmd.technology_name,
-                cmd.capacity,
-                env.most_common_reductant_by_tech.get(cmd.technology_name, None),
-            )[2],
+            bill_of_materials=avg_bom_result[0],
+            chosen_reductant=avg_bom_result[2],
             disposal_cost_outputs=env.config.disposal_cost_outputs,
         )
         # Set the subsidies on the new furnace group

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -32,6 +32,7 @@ from steelo.utilities.plotting import (
     plot_bar_chart_of_new_plants_by_status,
     plot_map_of_new_plants_operating,
 )
+from .adapters.geospatial.geospatial_statistics import aggregate_lcoe_lcoh_statistics
 from .logging_config import LoggingConfig
 from steelo.domain.constants import T_TO_KT, MT_TO_T
 from steelo.domain.calculate_costs import filter_subsidies_for_year, get_subsidised_energy_costs
@@ -1437,6 +1438,9 @@ class SimulationRunner:
             plt.savefig(price_plot_path, dpi=300, bbox_inches="tight")
             plt.close()
             logger.info(f"Saved market prices plot to {price_plot_path}")
+
+        # Aggregate per-year LCOE/LCOH statistics into stacked CSVs
+        aggregate_lcoe_lcoh_statistics(self.config.output_dir, start_year, end_year)
 
         # Clean up temporary directory
         self._cleanup_temp_dir()

--- a/tests/integration/test_simulation_service.py
+++ b/tests/integration/test_simulation_service.py
@@ -345,7 +345,7 @@ def test_simulation_service_with_plant_agent_events(
             bus.env.avg_boms[tech] = {}
             for material, share in bus.env.default_metallic_charge_per_technology[tech].items():
                 bus.env.avg_boms[tech][material] = {
-                    "demand_share_pct": share * 100,  # Convert to percentage
+                    "input_share_pct": share,
                     "unit_cost": bus.env.average_material_cost.get(material.lower(), {}).get("average_cost", 100.0),
                 }
 

--- a/tests/unit/test_bom_energy_reconstruction.py
+++ b/tests/unit/test_bom_energy_reconstruction.py
@@ -1,0 +1,250 @@
+"""Tests for energy reconstruction in get_bom_from_avg_boms (Stage 1).
+
+Validates the two-pass approach: MC validation, output-share computation,
+and PrimaryFeedstock-based energy accumulation.
+"""
+
+import pytest
+
+from steelo.domain.models import Environment
+
+
+class DummyFeed:
+    """Minimal PrimaryFeedstock stand-in for unit tests."""
+
+    def __init__(
+        self,
+        metallic_charge: str,
+        reductant: str,
+        required_qty: float,
+        secondary_feedstock: dict[str, float] | None = None,
+        energy_requirements: dict[str, float] | None = None,
+    ):
+        self.metallic_charge = metallic_charge
+        self.reductant = reductant
+        self.required_quantity_per_ton_of_product = required_qty
+        self.secondary_feedstock = secondary_feedstock or {}
+        self.energy_requirements = energy_requirements or {}
+
+
+def _make_env(**overrides) -> Environment:
+    """Create a minimal Environment stub for get_bom_from_avg_boms tests."""
+    env = Environment.__new__(Environment)
+    for k, v in overrides.items():
+        setattr(env, k, v)
+    return env
+
+
+def test_two_pass_mc_skip_with_warning():
+    """MC missing from input_effectiveness is skipped; survivor gets output_share=1.0."""
+    env = _make_env(
+        dynamic_feedstocks={
+            "EAF": [
+                DummyFeed("scrap", "coke", 1.1, energy_requirements={"electricity": 400.0}),
+            ],
+        },
+        avg_boms={
+            "EAF": {
+                "scrap": {"demand_share_pct": 0.8, "unit_cost": 300.0},
+                # ghost_metal has no matching PrimaryFeedstock → should be skipped
+                "ghost_metal": {"demand_share_pct": 0.2, "unit_cost": 500.0},
+            },
+        },
+        avg_utilization={"EAF": {"utilization_rate": 0.8}},
+    )
+
+    bom, utilization, reductant = env.get_bom_from_avg_boms(
+        energy_costs={"electricity": 50.0},
+        tech="EAF",
+        capacity=100.0,
+        most_common_reductant="coke",
+    )
+
+    # ghost_metal skipped — only scrap survives
+    assert "scrap" in bom["materials"]
+    assert "ghost_metal" not in bom["materials"]
+
+    # With single survivor, output_share = 1.0
+    # electricity demand = 1.0 * 400.0 * 100.0 = 40,000
+    assert bom["energy"]["electricity"]["demand"] == pytest.approx(40_000.0)
+    assert bom["energy"]["electricity"]["unit_cost"] == pytest.approx(50.0)
+
+
+def test_energy_reconstruction_single_mc():
+    """Single MC with known PF data → verify carrier demands exactly."""
+    env = _make_env(
+        dynamic_feedstocks={
+            "BF": [
+                DummyFeed(
+                    "io_high",
+                    "coke",
+                    1.4,
+                    secondary_feedstock={"burnt_lime": 0.05, "coking_coal": 0.3},
+                    energy_requirements={"electricity": 50.0, "natural_gas": 2.0},
+                ),
+            ],
+        },
+        avg_boms={"BF": {"io_high": {"demand_share_pct": 1.0, "unit_cost": 150.0}}},
+        avg_utilization={},
+    )
+
+    bom, _, _ = env.get_bom_from_avg_boms(
+        energy_costs={"electricity": 60.0, "natural_gas": 8.0, "burnt_lime": 100.0, "coking_coal": 200.0},
+        tech="BF",
+        capacity=1000.0,
+        most_common_reductant="coke",
+    )
+
+    # output_share = 1.0 for single MC
+    # electricity: 1.0 * 50.0 * 1000 = 50,000
+    assert bom["energy"]["electricity"]["demand"] == pytest.approx(50_000.0)
+    assert bom["energy"]["electricity"]["total_cost"] == pytest.approx(3_000_000.0)
+    # natural_gas: 1.0 * 2.0 * 1000 = 2,000
+    assert bom["energy"]["natural_gas"]["demand"] == pytest.approx(2_000.0)
+    # burnt_lime from secondary_feedstock (in ENERGY_FEEDSTOCK_KEYS): 1.0 * 0.05 * 1000 = 50
+    assert bom["energy"]["burnt_lime"]["demand"] == pytest.approx(50.0)
+    # coking_coal from secondary_feedstock: 1.0 * 0.3 * 1000 = 300
+    assert bom["energy"]["coking_coal"]["demand"] == pytest.approx(300.0)
+
+
+def test_energy_reconstruction_multi_mc_output_shares():
+    """Two MCs with different effectivenesses → verify output-share-weighted energy.
+
+    EAF with 80% scrap (eff=1.09) / 20% pig_iron (eff=1.1351) input shares.
+    Matches the worked example in the spec (§3.3).
+    """
+    env = _make_env(
+        dynamic_feedstocks={
+            "EAF": [
+                DummyFeed("scrap", "coke", 1.09, energy_requirements={"electricity": 413.3}),
+                DummyFeed("pig_iron", "coke", 1.1351, energy_requirements={"electricity": 100.0}),
+            ],
+        },
+        avg_boms={
+            "EAF": {
+                "scrap": {"demand_share_pct": 0.8, "unit_cost": 300.0},
+                "pig_iron": {"demand_share_pct": 0.2, "unit_cost": 400.0},
+            },
+        },
+        avg_utilization={},
+    )
+
+    bom, _, _ = env.get_bom_from_avg_boms(
+        energy_costs={"electricity": 50.0},
+        tech="EAF",
+        capacity=100.0,
+        most_common_reductant="coke",
+    )
+
+    # Output shares:
+    # raw_scrap = 0.8/1.09 = 0.7339, raw_pig = 0.2/1.1351 = 0.1762
+    # total_raw = 0.9101
+    # o_scrap = 0.7339/0.9101 ≈ 0.8064, o_pig = 0.1762/0.9101 ≈ 0.1936
+    # Weighted electricity = 0.8064*413.3 + 0.1936*100.0 ≈ 352.65 kWh/t
+    # Total demand = 352.65 * 100 = 35,265
+    assert bom["energy"]["electricity"]["demand"] == pytest.approx(35_265.0, rel=1e-3)
+
+    # Materials use input shares (not output shares)
+    # scrap demand = 0.8 * 100 * 1.09 = 87.2
+    assert bom["materials"]["scrap"]["demand"] == pytest.approx(87.2)
+    # pig_iron demand = 0.2 * 100 * 1.1351 = 22.702
+    assert bom["materials"]["pig_iron"]["demand"] == pytest.approx(22.702)
+
+
+def test_cheapest_reductant_fallback():
+    """When most_common_reductant is None, cheapest-reductant fallback picks the right one."""
+    env = _make_env(
+        dynamic_feedstocks={
+            "DRI": [
+                # natural_gas reductant — cheaper energy
+                DummyFeed(
+                    "io_low",
+                    "natural_gas",
+                    1.5,
+                    energy_requirements={"electricity": 100.0, "natural_gas": 3.0},
+                ),
+                # hydrogen reductant — expensive energy
+                DummyFeed(
+                    "io_low",
+                    "hydrogen",
+                    1.5,
+                    energy_requirements={"electricity": 200.0, "hydrogen": 5.0},
+                ),
+            ],
+        },
+        avg_boms={"DRI": {"io_low": {"demand_share_pct": 1.0, "unit_cost": 200.0}}},
+        avg_utilization={},
+    )
+
+    bom, _, reductant = env.get_bom_from_avg_boms(
+        energy_costs={"electricity": 50.0, "natural_gas": 10.0, "hydrogen": 500.0},
+        tech="DRI",
+        capacity=1000.0,
+        most_common_reductant=None,  # trigger fallback
+    )
+
+    # natural_gas reductant: 100*50 + 3*10 = 5,030
+    # hydrogen reductant: 200*50 + 5*500 = 12,500
+    # Should pick natural_gas
+    assert reductant == "natural_gas"
+
+    # Energy from the natural_gas PF variant
+    assert "electricity" in bom["energy"]
+    assert bom["energy"]["electricity"]["demand"] == pytest.approx(100_000.0)
+    assert "natural_gas" in bom["energy"]
+    assert bom["energy"]["natural_gas"]["demand"] == pytest.approx(3_000.0)
+    # hydrogen should NOT be present (wrong reductant)
+    assert "hydrogen" not in bom["energy"]
+
+
+def test_zero_cost_carrier_warning():
+    """PF has positive intensity but energy_costs has no entry → included with 0 cost."""
+    env = _make_env(
+        dynamic_feedstocks={
+            "DRI+CCU": [
+                DummyFeed(
+                    "io_low",
+                    "hydrogen",
+                    1.5,
+                    energy_requirements={"electricity": 100.0, "hydrogen": 5.0},
+                ),
+            ],
+        },
+        avg_boms={"DRI+CCU": {"io_low": {"demand_share_pct": 1.0, "unit_cost": 200.0}}},
+        avg_utilization={},
+    )
+
+    bom, _, _ = env.get_bom_from_avg_boms(
+        energy_costs={"electricity": 50.0},  # no hydrogen price
+        tech="DRI+CCU",
+        capacity=1000.0,
+        most_common_reductant="hydrogen",
+    )
+
+    # hydrogen included with zero cost (demand is real, price is missing)
+    assert "hydrogen" in bom["energy"]
+    assert bom["energy"]["hydrogen"]["demand"] == pytest.approx(5_000.0)
+    assert bom["energy"]["hydrogen"]["total_cost"] == pytest.approx(0.0)
+    assert bom["energy"]["hydrogen"]["unit_cost"] == pytest.approx(0.0)
+
+
+def test_deployed_tech_reorder_noop():
+    """When most_common_reductant is already set, reductant resolution is a no-op."""
+    feed = DummyFeed("scrap", "coke", 1.1, energy_requirements={"electricity": 400.0})
+    env = _make_env(
+        dynamic_feedstocks={"EAF": [feed]},
+        avg_boms={"EAF": {"scrap": {"demand_share_pct": 1.0, "unit_cost": 300.0}}},
+        avg_utilization={"EAF": {"utilization_rate": 0.9}},
+    )
+
+    bom, utilization, reductant = env.get_bom_from_avg_boms(
+        energy_costs={"electricity": 50.0},
+        tech="EAF",
+        capacity=100.0,
+        most_common_reductant="coke",
+    )
+
+    assert reductant == "coke"
+    assert utilization == pytest.approx(0.9)
+    assert bom["materials"]["scrap"]["demand"] == pytest.approx(110.0)
+    assert bom["energy"]["electricity"]["demand"] == pytest.approx(40_000.0)

--- a/tests/unit/test_bom_energy_reconstruction.py
+++ b/tests/unit/test_bom_energy_reconstruction.py
@@ -45,9 +45,9 @@ def test_two_pass_mc_skip_with_warning():
         },
         avg_boms={
             "EAF": {
-                "scrap": {"demand_share_pct": 0.8, "unit_cost": 300.0},
+                "scrap": {"input_share_pct": 0.8, "unit_cost": 300.0},
                 # ghost_metal has no matching PrimaryFeedstock → should be skipped
-                "ghost_metal": {"demand_share_pct": 0.2, "unit_cost": 500.0},
+                "ghost_metal": {"input_share_pct": 0.2, "unit_cost": 500.0},
             },
         },
         avg_utilization={"EAF": {"utilization_rate": 0.8}},
@@ -84,7 +84,7 @@ def test_energy_reconstruction_single_mc():
                 ),
             ],
         },
-        avg_boms={"BF": {"io_high": {"demand_share_pct": 1.0, "unit_cost": 150.0}}},
+        avg_boms={"BF": {"io_high": {"input_share_pct": 1.0, "unit_cost": 150.0}}},
         avg_utilization={},
     )
 
@@ -122,8 +122,8 @@ def test_energy_reconstruction_multi_mc_output_shares():
         },
         avg_boms={
             "EAF": {
-                "scrap": {"demand_share_pct": 0.8, "unit_cost": 300.0},
-                "pig_iron": {"demand_share_pct": 0.2, "unit_cost": 400.0},
+                "scrap": {"input_share_pct": 0.8, "unit_cost": 300.0},
+                "pig_iron": {"input_share_pct": 0.2, "unit_cost": 400.0},
             },
         },
         avg_utilization={},
@@ -172,7 +172,7 @@ def test_cheapest_reductant_fallback():
                 ),
             ],
         },
-        avg_boms={"DRI": {"io_low": {"demand_share_pct": 1.0, "unit_cost": 200.0}}},
+        avg_boms={"DRI": {"io_low": {"input_share_pct": 1.0, "unit_cost": 200.0}}},
         avg_utilization={},
     )
 
@@ -210,7 +210,7 @@ def test_zero_cost_carrier_warning():
                 ),
             ],
         },
-        avg_boms={"DRI+CCU": {"io_low": {"demand_share_pct": 1.0, "unit_cost": 200.0}}},
+        avg_boms={"DRI+CCU": {"io_low": {"input_share_pct": 1.0, "unit_cost": 200.0}}},
         avg_utilization={},
     )
 
@@ -233,7 +233,7 @@ def test_deployed_tech_reorder_noop():
     feed = DummyFeed("scrap", "coke", 1.1, energy_requirements={"electricity": 400.0})
     env = _make_env(
         dynamic_feedstocks={"EAF": [feed]},
-        avg_boms={"EAF": {"scrap": {"demand_share_pct": 1.0, "unit_cost": 300.0}}},
+        avg_boms={"EAF": {"scrap": {"input_share_pct": 1.0, "unit_cost": 300.0}}},
         avg_utilization={"EAF": {"utilization_rate": 0.9}},
     )
 
@@ -248,3 +248,40 @@ def test_deployed_tech_reorder_noop():
     assert utilization == pytest.approx(0.9)
     assert bom["materials"]["scrap"]["demand"] == pytest.approx(110.0)
     assert bom["energy"]["electricity"]["demand"] == pytest.approx(40_000.0)
+
+
+def test_demand_share_pct_in_materials_output():
+    """Output BOM materials include demand_share_pct in TM convention (input_share * eff).
+
+    Two MCs with different effectivenesses — demand_share_pct should NOT sum to 1.0.
+    """
+    env = _make_env(
+        dynamic_feedstocks={
+            "EAF": [
+                DummyFeed("scrap", "coke", 1.09, energy_requirements={"electricity": 400.0}),
+                DummyFeed("pig_iron", "coke", 1.14, energy_requirements={"electricity": 100.0}),
+            ],
+        },
+        avg_boms={
+            "EAF": {
+                "scrap": {"input_share_pct": 0.8, "unit_cost": 300.0},
+                "pig_iron": {"input_share_pct": 0.2, "unit_cost": 400.0},
+            },
+        },
+        avg_utilization={},
+    )
+
+    bom, _, _ = env.get_bom_from_avg_boms(
+        energy_costs={"electricity": 50.0},
+        tech="EAF",
+        capacity=100.0,
+        most_common_reductant="coke",
+    )
+
+    # demand_share_pct = input_share * eff (TM convention)
+    assert bom["materials"]["scrap"]["demand_share_pct"] == pytest.approx(0.8 * 1.09)
+    assert bom["materials"]["pig_iron"]["demand_share_pct"] == pytest.approx(0.2 * 1.14)
+
+    # Verify it does NOT sum to 1.0 (unlike input_share_pct)
+    total = sum(m["demand_share_pct"] for m in bom["materials"].values())
+    assert total != pytest.approx(1.0)

--- a/tests/unit/test_bom_energy_reconstruction.py
+++ b/tests/unit/test_bom_energy_reconstruction.py
@@ -285,3 +285,11 @@ def test_demand_share_pct_in_materials_output():
     # Verify it does NOT sum to 1.0 (unlike input_share_pct)
     total = sum(m["demand_share_pct"] for m in bom["materials"].values())
     assert total != pytest.approx(1.0)
+
+    # unit_cost = total_cost / product_volume (per-output, TM convention)
+    # scrap: 300 * 0.8 * 100 * 1.09 / 100 = 300 * 0.8 * 1.09 = 261.6
+    assert bom["materials"]["scrap"]["unit_cost"] == pytest.approx(300.0 * 0.8 * 1.09)
+    # pig_iron: 400 * 0.2 * 100 * 1.14 / 100 = 400 * 0.2 * 1.14 = 91.2
+    assert bom["materials"]["pig_iron"]["unit_cost"] == pytest.approx(400.0 * 0.2 * 1.14)
+    # total_cost unchanged (authoritative value)
+    assert bom["materials"]["scrap"]["total_cost"] == pytest.approx(300.0 * 0.8 * 100.0 * 1.09)

--- a/tests/unit/test_bom_secondary_feedstock.py
+++ b/tests/unit/test_bom_secondary_feedstock.py
@@ -32,15 +32,18 @@ def test_bom_handles_secondary_feedstock_inputs():
             )
         ]
     }
-    env.avg_boms = {"BF_CHARCOAL": {"bio_pci": {"demand_share_pct": 1.0, "unit_cost": 100.0}}}
+    env.avg_boms = {"BF_CHARCOAL": {"io_high": {"demand_share_pct": 1.0, "unit_cost": 100.0}}}
     bom_dict, utilization, reductant = env.get_bom_from_avg_boms(
         energy_costs={"bio_pci": 0.0, "electricity": 0.0},
         tech="BF_CHARCOAL",
         capacity=1.0,
     )
 
-    assert "bio_pci" in bom_dict["materials"]
-    assert bom_dict["materials"]["bio_pci"]["demand"] > 0
+    assert "io_high" in bom_dict["materials"]
+    assert bom_dict["materials"]["io_high"]["demand"] == pytest.approx(1.0)
+    # bio_pci from secondary_feedstock should appear in energy (it's in ENERGY_FEEDSTOCK_KEYS)
+    assert "bio_pci" in bom_dict["energy"]
+    assert bom_dict["energy"]["bio_pci"]["demand"] == pytest.approx(0.5)
 
 
 def test_bom_from_feedstocks_for_dri_esf_ccs_not_empty():
@@ -71,6 +74,11 @@ def test_bom_from_feedstocks_for_dri_esf_ccs_not_empty():
     assert "io_low" in bom_dict["materials"]
     assert bom_dict["materials"]["io_low"]["demand"] > 0
     assert utilization == 0.6
+    # Energy reconstructed from PrimaryFeedstock
+    assert "electricity" in bom_dict["energy"]
+    assert bom_dict["energy"]["electricity"]["demand"] == pytest.approx(100_000.0)
+    assert "coking_coal" in bom_dict["energy"]
+    assert bom_dict["energy"]["coking_coal"]["demand"] == pytest.approx(50.0)
 
 
 def test_bom_from_avg_boms_missing_tech_raises():

--- a/tests/unit/test_bom_secondary_feedstock.py
+++ b/tests/unit/test_bom_secondary_feedstock.py
@@ -32,7 +32,7 @@ def test_bom_handles_secondary_feedstock_inputs():
             )
         ]
     }
-    env.avg_boms = {"BF_CHARCOAL": {"io_high": {"demand_share_pct": 1.0, "unit_cost": 100.0}}}
+    env.avg_boms = {"BF_CHARCOAL": {"io_high": {"input_share_pct": 1.0, "unit_cost": 100.0}}}
     bom_dict, utilization, reductant = env.get_bom_from_avg_boms(
         energy_costs={"bio_pci": 0.0, "electricity": 0.0},
         tech="BF_CHARCOAL",
@@ -61,7 +61,7 @@ def test_bom_from_feedstocks_for_dri_esf_ccs_not_empty():
 
     feed = DummyFeed()
     env.dynamic_feedstocks = {"DRI+ESF+CCS": [feed], "dri+esf+ccs": [feed]}
-    env.avg_boms = {"DRI+ESF+CCS": {"io_low": {"demand_share_pct": 1.0, "unit_cost": 200.0}}}
+    env.avg_boms = {"DRI+ESF+CCS": {"io_low": {"input_share_pct": 1.0, "unit_cost": 200.0}}}
     env.avg_utilization = {"DRI+ESF+CCS": {"utilization_rate": 0.6}}
 
     bom_dict, utilization, reductant = env.get_bom_from_avg_boms(

--- a/tests/unit/test_carbon_cost_calculations.py
+++ b/tests/unit/test_carbon_cost_calculations.py
@@ -679,7 +679,7 @@ def test_get_bom_from_avg_boms_excludes_metallic_energy_entries():
     pf.outputs = {"steel": Volumes(1.0)}
 
     env.dynamic_feedstocks = {"EAF": [pf], "eaf": [pf]}
-    env.avg_boms = {"EAF": {"dri_mid": {"demand_share_pct": 1.0, "unit_cost": 7000.0}}}
+    env.avg_boms = {"EAF": {"dri_mid": {"input_share_pct": 1.0, "unit_cost": 7000.0}}}
     env.avg_utilization = {"EAF": {"utilization_rate": 0.6}}
     env.energy_costs = {"electricity": 50.0}
     env.primary_products = ["steel"]

--- a/tests/unit/test_carbon_cost_calculations.py
+++ b/tests/unit/test_carbon_cost_calculations.py
@@ -693,6 +693,10 @@ def test_get_bom_from_avg_boms_excludes_metallic_energy_entries():
     assert bom is not None
     assert "dri_mid" not in bom["energy"], "Metallic feedstocks must not appear in BOM energy entries"
     assert bom["materials"]["dri_mid"]["unit_cost"] == pytest.approx(7000.0)
+    # Energy reconstructed from PrimaryFeedstock (electricity intensity=2.0, output_share=1.0, capacity=1000)
+    assert "electricity" in bom["energy"]
+    assert bom["energy"]["electricity"]["demand"] == pytest.approx(2000.0)
+    assert bom["energy"]["electricity"]["unit_cost"] == pytest.approx(50.0)
 
     def test_carbon_cost_magnitude_validation(self):
         """Ensure carbon costs are in realistic ranges for different scenarios."""

--- a/tests/unit/test_generate_average_boms_hardcoded_schema.py
+++ b/tests/unit/test_generate_average_boms_hardcoded_schema.py
@@ -35,7 +35,7 @@ def _make_env(tmp_path: Path) -> Environment:
     return Environment(config=config, tech_switches_csv=tech_switches_csv)
 
 
-def test_hardcoded_avg_bom_includes_demand_share_pct(tmp_path: Path) -> None:
+def test_hardcoded_avg_bom_includes_input_share_pct(tmp_path: Path) -> None:
     env = _make_env(tmp_path)
     env.fallback_material_costs = [
         FallbackMaterialCost(
@@ -88,7 +88,7 @@ def test_hardcoded_avg_bom_includes_demand_share_pct(tmp_path: Path) -> None:
 
     env.generate_average_boms([plant], iso3=None)
 
-    assert env.avg_boms["BF_CHARCOAL"]["io_high"]["demand_share_pct"] == pytest.approx(1.0)
+    assert env.avg_boms["BF_CHARCOAL"]["io_high"]["input_share_pct"] == pytest.approx(1.0)
     assert env.avg_boms["BF_CHARCOAL"]["io_high"]["unit_cost"] == pytest.approx(123.0)
 
     bom, _, _ = env.get_bom_from_avg_boms(
@@ -103,7 +103,7 @@ def test_hardcoded_avg_bom_includes_demand_share_pct(tmp_path: Path) -> None:
     assert bom["energy"]["electricity"]["demand"] == pytest.approx(100.0)
 
 
-def test_get_bom_from_avg_boms_defaults_missing_demand_share_pct_for_single_entry(tmp_path: Path) -> None:
+def test_get_bom_from_avg_boms_defaults_missing_input_share_pct_for_single_entry(tmp_path: Path) -> None:
     env = _make_env(tmp_path)
 
     charcoal_feedstock = PrimaryFeedstock(metallic_charge="io_high", reductant="charcoal", technology="BF_CHARCOAL")

--- a/tests/unit/test_generate_average_boms_hardcoded_schema.py
+++ b/tests/unit/test_generate_average_boms_hardcoded_schema.py
@@ -98,6 +98,9 @@ def test_hardcoded_avg_bom_includes_demand_share_pct(tmp_path: Path) -> None:
     )
     assert bom is not None
     assert bom["materials"]["io_high"]["demand"] == pytest.approx(100.0)
+    # Energy reconstructed from PrimaryFeedstock (intensity=1.0, output_share=1.0, capacity=100)
+    assert "electricity" in bom["energy"]
+    assert bom["energy"]["electricity"]["demand"] == pytest.approx(100.0)
 
 
 def test_get_bom_from_avg_boms_defaults_missing_demand_share_pct_for_single_entry(tmp_path: Path) -> None:
@@ -117,3 +120,4 @@ def test_get_bom_from_avg_boms_defaults_missing_demand_share_pct_for_single_entr
     )
     assert bom is not None
     assert bom["materials"]["io_high"]["demand"] == pytest.approx(100.0)
+    assert bom["energy"]["electricity"]["demand"] == pytest.approx(100.0)


### PR DESCRIPTION
### Problem

Investment decisions in the model — building new plants, expanding capacity, switching technology — ignored energy costs. Electricity, hydrogen, natural gas, and all other energy carriers were treated as free when evaluating whether to invest. The most visible consequence: carbon capture technologies (CCU) appeared artificially cheap because their large hydrogen consumption was invisible to the investment calculation, biasing the model toward building hydrogen-heavy plants even in regions where hydrogen is expensive. Operating plants were not affected — the trade model already populated energy data correctly. The bug only affected the forward-looking investment pathway.

### Changes

- **Reconstruct `bom["energy"]` from PrimaryFeedstock data** — energy demands are now derived from `energy_requirements` and `secondary_feedstock` on matched PrimaryFeedstock rows, weighted by output share. Previously energy was incorrectly tied to `demand_share_pct` of metallic charges.
- **Fix `unit_cost` to per-output semantics** — `unit_cost` and `unit_material_cost` in the output BOM now represent cost per tonne of *product* (material_cost / capacity), not per tonne of input.
- **Rename `demand_share_pct` → `input_share_pct` in avg_boms** — clarifies that the stored field is the fraction of total input demand. A separate TM-convention `demand_share_pct` (= input_share × effectiveness) is added to the output BOM for downstream consumers.
- **Simplify `input_effectiveness` to metallic charges only** — removes secondary feedstocks and energy carriers that were incorrectly included in the effectiveness mapping.
- **Add reductant-free technology guard** — technologies without reductants (e.g. EAF, BOF) no longer trigger the cheapest-reductant calculation; when reductant is unknown, falls back to cheapest available reductant via `calculate_energy_costs_and_most_common_reductant`.
- **Two-pass BOM construction** — pass 1 validates each metallic charge and matches it to a PrimaryFeedstock; pass 2 builds materials and accumulates energy. Unmatched MCs are gracefully skipped with warnings instead of raising `KeyError`.
- **Deduplicate `get_bom_from_avg_boms` call** in `add_furnace_group_to_plant` handler (was called twice with identical args).
- **Aggregate LCOE/LCOH stats** into stacked CSVs at end of simulation; add `hydrogen_ceiling_pct` column to LCOH output.