### PR TITLE
LP slack costs adjustment

### DIFF
--- a/src/steelo/domain/trade_modelling/trade_lp_modelling.py
+++ b/src/steelo/domain/trade_modelling/trade_lp_modelling.py
@@ -366,8 +366,8 @@ class TradeLPModel:
         self.solution_status = None
         self.optimal_solution = None
         self.allocations: Allocations | None = None
-        self.demand_slack_cost = 10000
-        self.soft_minimum_capacity_slack_cost = 10000
+        self.demand_slack_cost = 10_000_000
+        self.soft_minimum_capacity_slack_cost = 100_000
         self.real_life_costs_normalization_factor = 1
         self.tariff_quotas_by_iso3: dict[Tuple[str, str, str], float] = {}
         self.tariff_taxes_by_iso3: dict[Tuple[str, str, str], float] = {}

--- a/src/steelo/domain/trade_modelling/trade_lp_modelling.py
+++ b/src/steelo/domain/trade_modelling/trade_lp_modelling.py
@@ -971,6 +971,7 @@ class TradeLPModel:
                 + from_pc.production_cost  # Production cost (carbon cost) at the source process center
                 - willingness_to_pay_value  # Reduce cost for high-WTP destinations
             )
+        # With current slack costs (1e12) this check will never trigger
         # add a check to ensure allocation costs aren't insane:
         for key in self.lp_model.allocation_costs:
             if self.lp_model.allocation_costs[key] >= (


### PR DESCRIPTION
- demand_slack_cost: 10,000 → 10,000,000
- soft_minimum_capacity_slack_cost: 10,000 → 100,000
- Ratio of 100:1
- Both were equal, so LP was indifferent between meeting demand and spreading production across plants
- Now following what the docstring says
- Identified block that would not trigger with these slack costs