### PR TITLE
Fix capacity limit double-counting from deferred tech switches

### DIFF
--- a/src/steelo/domain/events.py
+++ b/src/steelo/domain/events.py
@@ -23,7 +23,7 @@ class FurnaceGroupTechChanged(Event):
 
     furnace_group_id: str
     technology_name: str
-    capacity: int
+    capacity: float
     is_new_plant: bool = False  # True if this is a new plant, False if it's a switch
 
 
@@ -41,7 +41,7 @@ class FurnaceGroupAdded(Event):
     plant_id: str
     furnace_group_id: str
     technology_name: str
-    capacity: int
+    capacity: float
     is_new_plant: bool = False  # True if this is a new plant, False if it's an expansion
 
 

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -3636,7 +3636,7 @@ class Plant:
             events.FurnaceGroupTechChanged(
                 furnace_group_id=furnace_group_id,
                 technology_name=technology_name,
-                capacity=int(furnace_group.capacity),
+                capacity=furnace_group.capacity,
             )
         )
 
@@ -4168,7 +4168,7 @@ class Plant:
         capex_no_subsidy: float,
         cost_of_debt: float,
         cost_of_debt_no_subsidy: float,
-        capacity: int,
+        capacity: float,
         lag: int,
         status: str,
         util_rate: float,
@@ -4307,7 +4307,7 @@ class Plant:
         return furnace_group
 
     def furnace_group_added(
-        self, furnace_group_id: str, plant_id: str, technology_name: str, capacity: int, is_new_plant: bool = False
+        self, furnace_group_id: str, plant_id: str, technology_name: str, capacity: float, is_new_plant: bool = False
     ) -> None:
         """
         Record a FurnaceGroupAdded event to the plant's event list.

--- a/src/steelo/service_layer/handlers.py
+++ b/src/steelo/service_layer/handlers.py
@@ -194,7 +194,7 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
         new_furnace = plant.generate_new_furnace(
             technology_name=cmd.technology_name,
             product=cmd.product,
-            capacity=int(cmd.capacity),
+            capacity=cmd.capacity,
             capex=cmd.capex,
             capex_no_subsidy=cmd.capex_no_subsidy,
             cost_of_debt=cmd.cost_of_debt,
@@ -234,7 +234,7 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
             new_furnace.furnace_group_id,
             cmd.plant_id,
             technology_name=cmd.technology_name,
-            capacity=int(cmd.capacity),
+            capacity=cmd.capacity,
             is_new_plant=False,  # This is an expansion to an existing plant
         )
         uow.commit()
@@ -626,7 +626,7 @@ def update_status_of_furnace_group(cmd: commands.UpdateFurnaceGroupStatus, uow: 
                         furnace_group_id=fg.furnace_group_id,
                         plant_id=plant.plant_id,
                         technology_name=fg.technology.name,
-                        capacity=int(fg.capacity),
+                        capacity=fg.capacity,
                         is_new_plant=True,  # This is a new plant being constructed
                     )
 
@@ -695,10 +695,10 @@ def load_checkpoint_handler(
 
 EVENT_HANDLERS: dict[type[events.Event], list[Callable]] = {
     events.FurnaceGroupClosed: [update_cost_curve],
-    events.FurnaceGroupTechChanged: [update_cost_curve, update_capacity_buildout],
+    events.FurnaceGroupTechChanged: [update_cost_curve],
     events.FurnaceGroupRenovated: [update_cost_curve],
     events.FurnaceGroupAdded: [update_future_cost_curve, update_capacity_buildout],
-    events.SinteringCapacityAdded: [update_future_cost_curve, update_capacity_buildout],
+    events.SinteringCapacityAdded: [update_future_cost_curve],
     events.SteelAllocationsCalculated: [update_furnace_utilization_rates, update_cost_curve, update_future_cost_curve],
     events.IterationOver: [finalise_iteration, update_cost_curve],
     events.SaveCheckpoint: [save_checkpoint_handler],

--- a/tests/unit/test_capacity_buildout.py
+++ b/tests/unit/test_capacity_buildout.py
@@ -1,0 +1,162 @@
+"""Tests for capacity buildout event handler mappings and behaviour.
+
+Verifies that:
+- FurnaceGroupTechChanged does NOT trigger update_capacity_buildout (the double-counting fix).
+- SinteringCapacityAdded does NOT trigger update_capacity_buildout (latent bug cleanup).
+- FurnaceGroupAdded still correctly triggers update_capacity_buildout.
+- The handler correctly updates env.added_capacity and env.new_plant_capacity.
+- Deferred tech switches do not pollute added_capacity after counter reset.
+"""
+
+from unittest.mock import MagicMock
+
+from steelo.domain import events
+from steelo.service_layer import handlers
+
+
+# ---------------------------------------------------------------------------
+# 1. Event handler mapping tests
+# ---------------------------------------------------------------------------
+
+
+def test_furnace_group_tech_changed_does_not_trigger_capacity_buildout():
+    """FurnaceGroupTechChanged must not include update_capacity_buildout.
+
+    Completed deferred tech switches emit this event after the annual counter
+    reset, so routing it to update_capacity_buildout would inflate
+    added_capacity for the following year (the double-counting bug).
+    """
+    handler_list = handlers.EVENT_HANDLERS[events.FurnaceGroupTechChanged]
+    assert handlers.update_capacity_buildout not in handler_list, (
+        "update_capacity_buildout must not handle FurnaceGroupTechChanged"
+    )
+
+
+def test_sintering_capacity_added_does_not_trigger_capacity_buildout():
+    """SinteringCapacityAdded must not include update_capacity_buildout.
+
+    This event lacks the technology_name and is_new_plant attributes that
+    update_capacity_buildout relies on, so routing it there would crash.
+    """
+    handler_list = handlers.EVENT_HANDLERS[events.SinteringCapacityAdded]
+    assert handlers.update_capacity_buildout not in handler_list, (
+        "update_capacity_buildout must not handle SinteringCapacityAdded"
+    )
+
+
+def test_furnace_group_added_still_triggers_capacity_buildout():
+    """FurnaceGroupAdded must still route to update_capacity_buildout.
+
+    Real capacity additions (PAM expansions and GEO new plants) emit this
+    event and need their capacity tracked.
+    """
+    handler_list = handlers.EVENT_HANDLERS[events.FurnaceGroupAdded]
+    assert handlers.update_capacity_buildout in handler_list, "update_capacity_buildout must handle FurnaceGroupAdded"
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeUnitOfWork:
+    """Minimal UoW fake that supports context-manager protocol and commit."""
+
+    def __init__(self):
+        self.committed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def commit(self):
+        self.committed = True
+
+
+# ---------------------------------------------------------------------------
+# 2. Handler behaviour tests
+# ---------------------------------------------------------------------------
+
+
+def test_capacity_buildout_adds_to_env_added_capacity():
+    """update_capacity_buildout should increment env.added_capacity for the
+    technology specified in the FurnaceGroupAdded event.
+    """
+    env = MagicMock()
+    uow = _FakeUnitOfWork()
+
+    event = events.FurnaceGroupAdded(
+        plant_id="plant-1",
+        furnace_group_id="fg-1",
+        technology_name="EAF",
+        capacity=5000.0,
+        is_new_plant=False,
+    )
+
+    handlers.update_capacity_buildout(event, uow=uow, env=env)
+
+    env.add_capacity.assert_called_once()
+    env.add_new_plant_capacity.assert_not_called()
+    assert uow.committed is True
+
+
+def test_capacity_buildout_tracks_new_plant_capacity_when_flagged():
+    """When is_new_plant=True, update_capacity_buildout should also call
+    env.add_new_plant_capacity so GEO new plants are tracked separately.
+    """
+    env = MagicMock()
+    uow = _FakeUnitOfWork()
+
+    event = events.FurnaceGroupAdded(
+        plant_id="plant-1",
+        furnace_group_id="fg-1",
+        technology_name="DRI",
+        capacity=8000.0,
+        is_new_plant=True,
+    )
+
+    handlers.update_capacity_buildout(event, uow=uow, env=env)
+
+    env.add_capacity.assert_called_once()
+    env.add_new_plant_capacity.assert_called_once()
+    assert uow.committed is True
+
+
+def test_deferred_switch_does_not_pollute_added_capacity():
+    """Simulates the deferred switch lifecycle: switch capacity is tracked at
+    initiation, counters are reset at year-end, then FurnaceGroupTechChanged
+    fires. After the fix, added_capacity must remain empty because the event
+    no longer triggers update_capacity_buildout.
+    """
+    env = MagicMock()
+    env.added_capacity = {}
+    env.switched_capacity = {}
+    env.new_plant_capacity = {}
+
+    # Step 1: At switch initiation, switched_capacity would be incremented.
+    # (Handled by ChangeFurnaceGroupStatusToSwitchingTechnology — not under test here.)
+
+    # Step 2: Year-end reset (as finalise_iteration does).
+    env.added_capacity = {}
+    env.switched_capacity = {}
+    env.new_plant_capacity = {}
+
+    # Step 3: FurnaceGroupTechChanged fires after reset.
+    events.FurnaceGroupTechChanged(
+        furnace_group_id="fg-1",
+        technology_name="SR",
+        capacity=11100.0,
+    )
+
+    # The event handler list for FurnaceGroupTechChanged should NOT contain
+    # update_capacity_buildout, so processing it through the registered
+    # handlers must leave added_capacity untouched.
+    for handler in handlers.EVENT_HANDLERS[events.FurnaceGroupTechChanged]:
+        # Skip handlers that need real infrastructure (cost curve etc.)
+        if handler is handlers.update_capacity_buildout:
+            raise AssertionError("update_capacity_buildout should not be in FurnaceGroupTechChanged handlers")
+
+    # added_capacity must still be empty — no phantom capacity.
+    assert env.added_capacity == {}, f"added_capacity should be empty after deferred switch, got {env.added_capacity}"


### PR DESCRIPTION
- Remove update_capacity_buildout from FurnaceGroupTechChanged handlers (completed deferred switches were bleeding into added_capacity after the annual counter reset, inflating the limit check and blocking all PAM expansions after ~2034)
- Remove update_capacity_buildout from SinteringCapacityAdded handlers (latent AttributeError — event lacks technology_name/is_new_plant)
- Change capacity type from int to float on FurnaceGroupTechChanged and FurnaceGroupAdded events, remove needless int() casts at construction sites to match float used everywhere else