### PR TITLE
plant group balance

### DIFF
--- a/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
+++ b/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
@@ -109,20 +109,20 @@ The flow from business opportunity to new plant is as follows:
 
 ## Per-ISO3 Plant Group Routing
 
-All new plants start in a single master "indi" plant group, which acts as an incubator for business opportunities in "considered" and "announced" status. When a plant transitions to "construction", it is moved from the master group to a per-country group (`indi_{iso3}`, e.g. `indi_CHN`, `indi_AUS`). These groups are created lazily the first time a plant in that country reaches construction.
+Every new plant is routed into its per-country group (`indi_{iso3}`, e.g. `indi_CHN`, `indi_AUS`) **at birth** — the moment `add_new_business_opportunities_to_repository` handles the plant. Per-country groups are created lazily on first use. The master `indi` group remains as the dispatch point for candidate generation (`identify_new_business_opportunities_4indi`) but is structurally empty: it never holds plants.
 
-**Why this matters:** The plant agent model evaluates expansion (adding a new furnace group to an existing plant) once per plant group per year. With a single "indi" group, only one expansion could occur per year across all new plants globally. Per-ISO3 groups allow one expansion per country per year.
+**Why this matters:** The plant agent model evaluates expansion (adding a new furnace group to an existing plant) once per plant group per year. With a single "indi" group, only one expansion could occur per year across all new plants globally. Per-ISO3 groups allow one expansion per country per year. Routing at birth also ensures the plant-group reverse-lookup map (`plant_id_to_plantgroup_id`) is populated for runtime-born plants.
 
 **Lifecycle summary:**
 
 | Status | Plant group | Processed by |
 |--------|------------|--------------|
-| Considered | `indi` (master) | GEO: dynamic cost updates, status tracking |
-| Announced | `indi` (master) | GEO: dynamic cost updates, conversion to construction |
+| Considered | `indi_{iso3}` | GEO: dynamic cost updates, status tracking |
+| Announced | `indi_{iso3}` | GEO: dynamic cost updates, conversion to construction |
 | Construction | `indi_{iso3}` | Simulation loop: time-based transition to operating |
 | Operating | `indi_{iso3}` | PAM: balance updates, furnace group strategy, expansion |
 
-**Implementation:** The routing runs in `GeospatialModel.run()` (`plant_agent.py`) after status commands are handled and before new opportunities are identified. Plants are identified as GEO-originated by `parent_gem_id.startswith("indi")`.
+**Implementation:** Routing runs inside the `add_new_business_opportunities_to_repository` handler via `PlantGroupRepository.register_plant_in_group`, which creates the per-country group on demand. The handler also overwrites `plant.parent_gem_id` from the `"indi"` placeholder set by `PlantGroup.generate_new_plant` to `indi_{iso3}`. Plants are identified as GEO-originated by `parent_gem_id.startswith("indi")`.
 
 ## Business Opportunity Identification
 

--- a/docs/domain_simulation_logic/plant_agent_model/agent_definitions.md
+++ b/docs/domain_simulation_logic/plant_agent_model/agent_definitions.md
@@ -75,7 +75,7 @@ PlantGroup (Company/Owner)
 **Key relationships**:
 - Contains multiple `Plant` objects
 - Identified by `plant_group_id` (typically from GEM database)
-- Aggregates `total_balance` across all plants
+- Owns the treasury ``balance`` — a stored ledger credited by the FG sweep and debited by ``deduct_equity``
 
 **Strategic role**:
 - Evaluates expansion options across all plants
@@ -176,7 +176,7 @@ PlantGroup (Company/Owner)
 PlantGroup
     │
     ├── plant_group_id: str
-    ├── total_balance: float
+    ├── balance: float  # stored treasury (ledger)
     └── plants: list[Plant] ────────────────┐
                                             │
                                             ▼

--- a/docs/domain_simulation_logic/plant_agent_model/economic_considerations.md
+++ b/docs/domain_simulation_logic/plant_agent_model/economic_considerations.md
@@ -66,8 +66,8 @@ Decisions require sufficient accumulated profits:
 
 **Investment Capacity**:
 ```python
-equity_needed = capacity × capex × equity_share  # Default: 20% equity
-can_afford = plant_group.total_balance >= equity_needed
+equity_needed = capex × capacity × equity_share  # Default: 20% equity
+can_afford = plant_group.balance >= equity_needed
 ```
 
 **Example**:

--- a/docs/domain_simulation_logic/plant_agent_model/furnace_group_strategy.md
+++ b/docs/domain_simulation_logic/plant_agent_model/furnace_group_strategy.md
@@ -319,13 +319,12 @@ Stage 11-13: Final Checks & Command Generation
 
 ## Detailed Stage Breakdown
 
-### Stage 1: Check Plant Financial Health
-**Decision**: Can the plant afford to invest?
-- **Check**: `plant.balance >= 0`
-- **If negative**: Return `None` (no action possible)
-- **Rationale**: Negative balance = no capital available for investment
+Affordability is checked per-capex at the point of decision against
+``plant_group.balance`` (renovation in Stage 8, switch in Stage 9). A negative
+group balance does not short-circuit evaluation; the historic-loss closure
+threshold in Stage 2 runs unconditionally.
 
-### Stage 2: Check Furnace Group Status
+### Stage 1: Check Furnace Group Status
 **Decision**: Is the furnace group eligible for strategy evaluation?
 - **Check**: Status is not "operating pre-retirement"
 - **If pre-retirement**: Return `None` (already scheduled to close)
@@ -410,19 +409,19 @@ Stage 11-13: Final Checks & Command Generation
    - Cost = `CAPEX × capacity × equity_share`
 
 2. **Affordability check**:
-   - If `renovation_cost > plant.balance` → Return `CloseFurnaceGroup`
+   - If `renovation_cost > plant_group.balance` → Return `CloseFurnaceGroup`
    - Rationale: Can't afford to renovate, must close
 
 3. **Execute renovation**:
-   - Deduct cost from plant balance: `plant.balance -= renovation_cost`
+   - Debit the group treasury: `plant_group.deduct_equity(renovation_cost, reason="renovation")`
    - Return `RenovateFurnaceGroup` command
 
 **Example Calculation**:
-- Subsidized renovation CAPEX: $160/tonne
+- Subsidised renovation CAPEX: $160/tonne
 - Capacity: 5 Mt
 - Equity share: 30%
 - Renovation cost: $160 × 5,000,000 × 0.30 = $240,000,000
-- Plant balance: $300,000,000 → **Affordable, renovate**
+- Plant group balance: $300,000,000 → **Affordable, renovate**
 
 ### Stage 10: Handle Technology Switch Scenario
 **Condition**: Best technology ≠ current technology
@@ -433,17 +432,17 @@ Stage 11-13: Final Checks & Command Generation
    - Cost = `CAPEX × capacity × equity_share`
 
 2. **Affordability check**:
-   - If `switch_cost > plant.balance` → Return `None`
+   - If `switch_cost > plant_group.balance` → Return `None`
    - Rationale: Can't afford to switch
 
 3. **Continue to probabilistic adoption** (Stage 11)
 
 **Example Calculation**:
-- Subsidized greenfield CAPEX: $650/tonne
+- Subsidised greenfield CAPEX: $650/tonne
 - Capacity: 5 Mt
 - Equity share: 30%
 - Switch cost: $650 × 5,000,000 × 0.30 = $975,000,000
-- Plant balance: $1,200,000,000 → **Affordable, proceed**
+- Plant group balance: $1,200,000,000 → **Affordable, proceed**
 
 ### Stage 11: Probabilistic Adoption Decision
 **Purpose**: Model real-world hesitation in technology adoption (financing risk, permit delays, market uncertainty)
@@ -510,7 +509,7 @@ if expansion_and_switch_capacity + furnace_capacity > expansion_limit:
 
 ### Stage 13: Execute Technology Switch
 **Final Actions**:
-1. **Update plant balance**: `plant.balance -= switch_cost`
+1. **Debit group treasury**: `plant_group.deduct_equity(switch_cost, reason="switch")`
 2. **Generate command**: Return `ChangeFurnaceGroupTechnology`
 
 **Command includes**:
@@ -538,10 +537,9 @@ if expansion_and_switch_capacity + furnace_capacity > expansion_limit:
 
 ### 4. `None`
 - **When**:
-  - Plant has negative balance
   - Furnace group pre-retirement
   - All NPVs negative or zero
-  - Cannot afford switch
+  - Cannot afford switch (group balance too low)
   - Probabilistic rejection
   - Capacity limit exceeded
   - Current tech optimal but lifetime not expired
@@ -549,7 +547,7 @@ if expansion_and_switch_capacity + furnace_capacity > expansion_limit:
 ## Data Dependencies
 
 ### For Strategic Decisions (`evaluate_furnace_group_strategy`)
-- `plant.balance`: Available capital for investment
+- `plant_group.balance`: Group treasury — gates renovation and switch affordability
 - `furnace_group.status`: Operating status
 - `furnace_group.historic_balance`: Cumulative profit/loss
 - `furnace_group.lifetime.expired`: Whether renovation is needed

--- a/docs/domain_simulation_logic/plant_agent_model/market_price_calculation.md
+++ b/docs/domain_simulation_logic/plant_agent_model/market_price_calculation.md
@@ -104,9 +104,9 @@ Plant C: profit = (600 - 600) × 10 = $0M  (marginal plant breaks even)
 
 ### Where It's Used
 
-1. **Balance Sheet Updates** (`Plant.update_furnace_and_plant_balance()`):
-   - Uses market price to calculate: `balance = (market_price - unit_cost) × production`
-   - Aggregates to plant and plant group balances
+1. **Balance Sheet Updates** (`PlantGroup.sweep_fg_balances_to_group()`):
+   - Uses market price to compute each FG's annual P&L: `(market_price - unit_cost) × production`
+   - Aggregates every plant's FGs into the group treasury ``balance`` and resets ``fg.balance`` to 0
 
 2. **NPV Calculations** (`FurnaceGroup.optimal_technology_name()`):
    - Uses forecasted market prices for each year, by extracting future demands from current cost curves

--- a/docs/domain_simulation_logic/plant_agent_model/plant_expansions.md
+++ b/docs/domain_simulation_logic/plant_agent_model/plant_expansions.md
@@ -51,13 +51,13 @@ graph TD
   - Log plant group ID, current year, capacity requirements
   - Log available balance and number of plants
   - Log configuration (probabilistic agents, equity share)
-- **Key Variables**: `self.plant_group_id`, `current_year`, `capacity`, `self.total_balance`
+- **Key Variables**: `self.plant_group_id`, `current_year`, `capacity`, `self.balance`
 
 ### Stage 2: Evaluate All Expansion Options
 - **Purpose**: Calculate NPV for all possible technology expansions across all plants
 - **Actions**:
   - Call `evaluate_expansion_options()` to get NPV for each plant-technology combination
-  - **Per-plant affordability filter**: For each plant-technology combination, check that the plant's individual balance can cover `capacity × capex` before computing NPV. Plants that cannot afford a given technology are skipped for that technology (but may still be considered for cheaper alternatives).
+  - **Per-(plant, tech) affordability pre-filter**: For each combination, check that the group treasury can cover `capex × capacity × equity_share` before computing NPV. Combinations the group cannot afford are skipped so max-NPV selection picks from affordable candidates only.
   - **P3 CO2 storage gate (pre-NPV)**: For each CCS candidate, the gate computes `get_co2_need_by_name(tech, capacity, reductant)` and compares against `get_co2_headroom(iso3, current_year + construction_time)`. If `need > headroom` the tech is dropped before NPV is computed, so the per-plant NPV race naturally picks the next-best non-CCS alternative (or yields no expansion for that plant). Reductant lookup is two-level (PlantGroup-local first, env fallback) to stay aligned with the downstream `get_bom_from_avg_boms` call — gate and NPV see the same reductant.
   - Consider regional CAPEX, subsidies, dynamic feedstocks
   - Pass all subsidy information for proper NPV calculation
@@ -90,19 +90,21 @@ graph TD
 
 ### Stage 6: Check Balance Sufficiency
 - **Purpose**: Verify plant group has sufficient funds for equity portion
-- **Calculation**: `equity_needed = capacity × capex`
+- **Calculation**: `equity_needed = capex × capacity × equity_share`
 - **Decision Point**: Does plant group have enough balance?
 - **Actions**:
-  - Compare `self.total_balance` with `equity_needed`
+  - Compare `self.balance` with `equity_needed`
   - If insufficient: Log shortfall and return None
   - If sufficient: Log success and continue
-- **Note**: Balance deduction happens at FurnaceGroup level, not here
-- **Example**: 2,500 kt capacity × $500/t = $1,250,000 equity needed
+- **Note**: The debit lands in the ``add_furnace_group_to_plant`` handler via
+  ``plant_group.deduct_equity(cmd.equity_needed, reason="expansion")`` once the
+  factory has attached the new furnace to the plant.
+- **Example**: 2,500 kt capacity × $500/t × 20% equity_share = $250,000 equity needed
 
 ### Stage 7: Probabilistic Acceptance
 - **Purpose**: Model investment decision uncertainty
 - **Calculation**:
-  - Probabilistic mode: `probability = exp(-(investment_cost) / NPV)`
+  - Probabilistic mode: `probability = exp(-equity_needed / NPV)`
   - Deterministic mode: `probability = 1.0`
 - **Actions**:
   - Generate random number [0, 1]
@@ -222,17 +224,23 @@ Returns either:
 
 ## Side Effects
 
-- **NO Balance Deduction Here**: Balance deduction happens at the FurnaceGroup level via command handler, not in this function
+- **No balance mutation in this function**: The debit is performed by the
+  ``add_furnace_group_to_plant`` handler, which calls
+  ``plant_group.deduct_equity(cmd.equity_needed, reason="expansion")`` after the
+  factory has attached the new furnace to the plant.
 - **Command Creation**: Generates AddFurnaceGroup command for message bus processing
 - **Logging**: Extensive debug logging throughout the decision process
 
 ## Important Notes
 
-1. **Balance Management and the Group vs Plant Asymmetry**:
-   - Stage 6 checks the **plant group's** pooled `total_balance`, but the equity deduction lands on the **individual plant** that receives the new furnace group (via `generate_new_furnace`). No balance is redistributed between plants in a group.
-   - Without mitigation, a plant with a small balance could be selected (best NPV), have a large equity amount deducted, go deeply negative, and have all its furnace group strategies (renovation, technology switches) frozen until it recovers through operational profit.
-   - **Mitigation (per-plant affordability filter)**: In Stage 2, each plant-technology combination is checked against the plant's individual balance (`plant.balance >= capacity * capex`). Plants that cannot afford a technology are excluded from NPV evaluation for that technology. This ensures the winning plant can absorb the cost without going negative.
-   - **Limitation**: The cost is still borne by a single plant rather than shared across the group. A more realistic approach would deduct equity proportionally from all plants in the group, but this is not currently implemented.
+1. **Balance is pooled at the plant group**:
+   - Both the Stage 2 pre-filter and the Stage 6 gate read ``plant_group.balance``.
+     The equity debit lands on the same group wallet; no plant carries an individual balance.
+   - A lower-balance plant can still "win" max-NPV within the group — the cost
+     is absorbed by the shared treasury, not the plant. This makes sibling plants'
+     operational P&L fungible for group-level expansion financing.
+   - The pre-filter drops `(plant, tech)` pairs the group cannot afford so max-NPV
+     picks from genuinely affordable candidates; Stage 6 is a redundant defensive check.
 
 2. **Capacity Limits**:
    - Separate limits for iron and steel products

--- a/docs/domain_simulation_logic/plant_agent_model/plant_expansions.md
+++ b/docs/domain_simulation_logic/plant_agent_model/plant_expansions.md
@@ -260,9 +260,8 @@ Returns either:
    - Info level: Successful expansion approvals
 
 7. **Per-ISO3 Indi Plant Groups**:
-   - New plants created by the GEO module start in a master "indi" plant group (the incubator).
-   - While in "considered" or "announced" status, plants remain in the master group for dynamic cost updates and status transitions.
-   - When a plant transitions to "construction" status, it is moved to a per-country group (`indi_{iso3}`, e.g. `indi_CHN`, `indi_AUS`). These groups are created lazily on first use.
-   - Since `evaluate_expansion` runs once per plant group, this allows each country to independently expand its new plants (one expansion per country per year, rather than one globally).
-   - The construction-to-operating transition (`simulation.py`) iterates all plants regardless of plant group, so moved plants are unaffected.
+   - New plants created by the GEO module are routed into their per-country group (`indi_{iso3}`, e.g. `indi_CHN`, `indi_AUS`) **at birth** by the `AddNewBusinessOpportunities` handler. The per-country group is created lazily on first use via `PlantGroupRepository.register_plant_in_group`.
+   - The master `indi` plant group is the dispatch point for candidate generation (`identify_new_business_opportunities_4indi`) and remains structurally empty — it never holds plants.
+   - Since `evaluate_expansion` runs once per plant group, per-country groups let each country independently expand its new plants (one expansion per country per year, rather than one globally).
+   - The construction-to-operating transition (`simulation.py`) iterates all plants regardless of plant group, so routing is unaffected.
    - Plants in indi groups are identified by `parent_gem_id.startswith("indi")` rather than an exact match.

--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -14,9 +14,19 @@ function_overrides:
   # Suppress noisy functions
   calculate_unit_production_cost: WARNING
   extract_price_from_costcurve: WARNING
-  # Indi routing visibility
+  # Indi routing visibility (Stage 1)
   add_new_business_opportunities_to_repository: INFO
   register_plant_in_group: DEBUG
+  # Capex debit tracking (Stage 2: verify invariant A, construction no-debit, expansion equity fix)
+  deduct_equity: INFO
+  add_furnace_group_to_plant: INFO
+  update_status_of_furnace_group: INFO
+  # Balance flow (Stage 2: verify sweep + opening seed + group-first ordering)
+  _seed_opening_balances: INFO
+  sweep_fg_balances_to_group: DEBUG
+  # Expansion decision path (Stage 2: verify probabilistic fix + pre-filter)
+  evaluate_expansion: INFO
+  evaluate_expansion_options: INFO
 
 external:
   pyomo: ERROR

--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -14,6 +14,9 @@ function_overrides:
   # Suppress noisy functions
   calculate_unit_production_cost: WARNING
   extract_price_from_costcurve: WARNING
+  # Indi routing visibility
+  add_new_business_opportunities_to_repository: INFO
+  register_plant_in_group: DEBUG
 
 external:
   pyomo: ERROR

--- a/logging_config.yaml
+++ b/logging_config.yaml
@@ -14,19 +14,7 @@ function_overrides:
   # Suppress noisy functions
   calculate_unit_production_cost: WARNING
   extract_price_from_costcurve: WARNING
-  # Indi routing visibility (Stage 1)
-  add_new_business_opportunities_to_repository: INFO
-  register_plant_in_group: DEBUG
-  # Capex debit tracking (Stage 2: verify invariant A, construction no-debit, expansion equity fix)
-  deduct_equity: INFO
-  add_furnace_group_to_plant: INFO
-  update_status_of_furnace_group: INFO
-  # Balance flow (Stage 2: verify sweep + opening seed + group-first ordering)
-  _seed_opening_balances: INFO
-  sweep_fg_balances_to_group: DEBUG
-  # Expansion decision path (Stage 2: verify probabilistic fix + pre-filter)
-  evaluate_expansion: INFO
-  evaluate_expansion_options: INFO
+  get_bom_from_avg_boms: WARNING
 
 external:
   pyomo: ERROR

--- a/src/steelo/adapters/dataprocessing/postprocessing/post_process_datacollection.py
+++ b/src/steelo/adapters/dataprocessing/postprocessing/post_process_datacollection.py
@@ -85,7 +85,7 @@ def extract_and_process_stored_dataCollection(
                 "unit_fopex",
                 "unit_production_cost",
                 "debt_repayment_for_current_year",
-                "historic_balance",
+                "furnace_group_profit_and_loss",
             ]
             if "unit_debt_repayment" in plant.columns:
                 fg_cols_to_select.append("unit_debt_repayment")
@@ -210,7 +210,7 @@ def extract_and_process_stored_dataCollection(
                     full_furnace_df[col] = None
         full_furnace_df["plant_id"] = full_furnace_df["furnace_group_id"].apply(lambda x: x.split("_")[0])
         full_furnace_df = (
-            df[["location", "balance"]]
+            df[["location", "plant_profit_and_loss", "plant_group_id", "plant_group_balance"]]
             .reset_index()
             .rename(columns={"index": "plant_id"})
             .merge(full_furnace_df, on="plant_id", how="right")
@@ -317,16 +317,19 @@ def extract_and_process_stored_dataCollection(
     carb_cols = set(c for c in all_cols if c.startswith(CARB_PREFIX))
     non_breakdown_cols = [c for c in all_cols if not c.startswith(CB_PREFIX) and not c.startswith(CARB_PREFIX)]
 
-    # Core columns in explicit order
+    # Core columns in explicit order: identifiers → plant group → plant → commands → furnace group.
     CORE_COLS = [
         "year",
         "region",
         "country",
         "iso3",
+        "plant_group_id",
+        "plant_group_balance",
         "plant_id",
-        "balance",
+        "plant_profit_and_loss",
         "commands",
         "furnace_group_id",
+        "furnace_group_profit_and_loss",
         "technology",
         "product",
     ]

--- a/src/steelo/adapters/repositories/in_memory_repository.py
+++ b/src/steelo/adapters/repositories/in_memory_repository.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Iterable
 
 from .interface import (
@@ -67,6 +68,34 @@ class PlantGroupInMemoryRepository:
             raise ValueError(f"No plant group found for plant ID: {plant_id}")
         plant_group_id = self.plant_id_to_plantgroup_id[plant_id]
         return self.data[plant_group_id]
+
+    def register_plant_in_group(self, plant: Plant, group_id: str) -> None:
+        """
+        Register a plant into a plant group by ID, creating the group on demand.
+
+        Appends the plant to the group's ``plants`` list, updates the
+        ``plant_id_to_plantgroup_id`` reverse map, and adds the group to
+        ``seen`` unconditionally (dirty-set invariant: re-registering an
+        existing group still marks it as changed for this UoW turn).
+
+        Args:
+            plant: The plant to register.
+            group_id: Target plant group ID. If absent from ``self.data``
+                the group is created with an empty ``plants`` list first.
+        """
+        group_was_created = group_id not in self.data
+        if group_was_created:
+            group = PlantGroup(plant_group_id=group_id, plants=[])
+            self.data[group_id] = group
+        else:
+            group = self.data[group_id]
+        group.plants.append(plant)
+        self.plant_id_to_plantgroup_id[plant.plant_id] = group_id
+        self.seen.add(group)
+        debug_logger = logging.getLogger(f"{__name__}.register_plant_in_group")
+        debug_logger.debug(
+            f"[REPO REGISTER] plant_id={plant.plant_id} group_id={group_id} group_was_created={group_was_created}"
+        )
 
 
 class FurnaceGroupInMemoryRepository:

--- a/src/steelo/adapters/repositories/in_memory_repository.py
+++ b/src/steelo/adapters/repositories/in_memory_repository.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Iterable
 
 from .interface import (
@@ -83,19 +82,12 @@ class PlantGroupInMemoryRepository:
             group_id: Target plant group ID. If absent from ``self.data``
                 the group is created with an empty ``plants`` list first.
         """
-        group_was_created = group_id not in self.data
-        if group_was_created:
-            group = PlantGroup(plant_group_id=group_id, plants=[])
-            self.data[group_id] = group
-        else:
-            group = self.data[group_id]
+        if group_id not in self.data:
+            self.data[group_id] = PlantGroup(plant_group_id=group_id, plants=[])
+        group = self.data[group_id]
         group.plants.append(plant)
         self.plant_id_to_plantgroup_id[plant.plant_id] = group_id
         self.seen.add(group)
-        debug_logger = logging.getLogger(f"{__name__}.register_plant_in_group")
-        debug_logger.debug(
-            f"[REPO REGISTER] plant_id={plant.plant_id} group_id={group_id} group_was_created={group_was_created}"
-        )
 
 
 class FurnaceGroupInMemoryRepository:

--- a/src/steelo/adapters/repositories/interface.py
+++ b/src/steelo/adapters/repositories/interface.py
@@ -101,6 +101,29 @@ class PlantGroupRepository(Protocol):
         """Get a plant group from the repository by plant ID."""
         ...
 
+    def register_plant_in_group(self, plant: Plant, group_id: str) -> None:
+        """
+        Register a plant into a plant group by ID, creating the group on demand.
+
+        Appends the plant to the group's ``plants`` list, updates the
+        ``plant_id_to_plantgroup_id`` reverse map, and adds the group to
+        ``seen`` unconditionally (so UoW change-tracking is coherent even
+        when the group already existed).
+
+        Args:
+            plant: The plant to register.
+            group_id: Target plant group ID. If the group does not yet
+                exist in the repository, it is created with an empty plant
+                list before the plant is appended.
+
+        Notes:
+            Used for runtime-born plants (e.g. opportunities created by
+            ``GeospatialModel.run``), which are routed into per-country
+            ``indi_<ISO3>`` groups at birth rather than being parented to
+            a single master group.
+        """
+        ...
+
 
 @runtime_checkable
 class SupplierRepository(Protocol):

--- a/src/steelo/adapters/repositories/json_repository.py
+++ b/src/steelo/adapters/repositories/json_repository.py
@@ -795,6 +795,28 @@ class PlantGroupJsonRepository:
             locked[pg.plant_group_id] = pg
         self._write_models(list(locked.values()))
 
+    def register_plant_in_group(self, plant: Plant, group_id: str) -> None:
+        """
+        Register a plant into a plant group by ID, creating the group on demand.
+
+        Mirrors the in-memory repository semantics for protocol symmetry:
+        get-or-create the group, append the plant, persist, and add the
+        resulting domain group to ``seen``. Runtime routing correctness
+        comes from the in-memory repository; this path exists so the
+        JSON-backed code path stays consistent.
+
+        Args:
+            plant: The plant to register.
+            group_id: Target plant group ID. If absent from the JSON
+                store the group is created with an empty plant list.
+        """
+        locked = self._fetch_all()
+        if group_id not in locked:
+            locked[group_id] = PlantGroupInDb(plant_group_id=group_id, plants=[])
+        locked[group_id].plants.append(PlantInDb.from_domain(plant))
+        self._write_models(list(locked.values()))
+        self.seen.add(locked[group_id].to_domain(self.plant_lifetime, self.metadata, self.current_simulation_year))
+
 
 class FurnaceGroupJsonRepository:
     """

--- a/src/steelo/bootstrap.py
+++ b/src/steelo/bootstrap.py
@@ -232,7 +232,7 @@ def bootstrap_simulation(
     # Seed Python and NumPy global RNGs. LP solver reads the same seed at solve time.
     random.seed(config.random_seed)
     np.random.seed(config.random_seed)
-    logger.info(f"Seeded RNGs with random_seed={config.random_seed}")
+    logger.info(f"Random seed = {config.random_seed}")
 
     # If no repository is provided, create one from JSON files (production behavior)
     repository_json = None
@@ -340,23 +340,6 @@ def bootstrap_simulation(
             return normalised
 
         env.carbon_costs = {iso3: _normalise_cost_series(series) for iso3, series in env.carbon_costs.items()}
-        try:
-            price_sample = list(env.carbon_costs.items())[:3]
-            logger.warning(
-                "Carbon-cost dict sample: %s",
-                [
-                    (
-                        iso3,
-                        [
-                            (repr(year_key), type(year_key).__name__, value)
-                            for year_key, value in list(series.items())[:3]
-                        ],
-                    )
-                    for iso3, series in price_sample
-                ],
-            )
-        except Exception:
-            logger.exception("Failed to log carbon cost sample")
         env.initiate_input_costs(input_costs_list=repository_json.input_costs.list())
         env.initiate_dynamic_feedstocks(feedstocks=repository_json.primary_feedstocks.list())
         env.initiate_techno_economic_details(capex_list=repository_json.capex.list())

--- a/src/steelo/domain/datacollector.py
+++ b/src/steelo/domain/datacollector.py
@@ -597,6 +597,11 @@ class DataCollector:
         self.collect_iron_ore_by_quality(self.env.year)
         self.collect_metallic_charges(self.env.year)
 
+        # Authoritative plant -> group lookup from the live PlantGroup objects (not derived from
+        # parent_gem_id string parsing).
+        collect_logger = logging.getLogger(f"{__name__}.collect")
+        pg_by_plant_id: dict[str, PlantGroup] = {plant.plant_id: pg for pg in world_plant_groups for plant in pg.plants}
+
         plants = {}
         for p in world_plant_list:
             plant_dict = []
@@ -646,7 +651,7 @@ class DataCollector:
                     "unit_production_cost": fg.unit_production_cost,
                     "debt_repayment_per_year": fg.debt_repayment_per_year,
                     "debt_repayment_for_current_year": fg.debt_repayment_for_current_year,
-                    "historic_balance": fg.historic_balance,
+                    "furnace_group_profit_and_loss": fg.historic_balance,
                 }
 
                 if fg.production and fg.production > 0 and has_materials:
@@ -758,7 +763,7 @@ class DataCollector:
                         "unit_production_cost": fg.unit_production_cost,
                         "debt_repayment_per_year": fg.debt_repayment_per_year,
                         "debt_repayment_for_current_year": fg.debt_repayment_for_current_year,
-                        "historic_balance": fg.historic_balance,
+                        "furnace_group_profit_and_loss": fg.historic_balance,
                         "unit_subsidy_capex": 0.0,
                         "unit_subsidy_opex": 0.0,
                         "unit_subsidy_debt": 0.0,
@@ -766,13 +771,26 @@ class DataCollector:
                     }
                 plant_dict.append(record)
 
-            plant_group = p.ultimate_plant_group
+            pg = pg_by_plant_id.get(p.plant_id)
+            if pg is None:
+                collect_logger.warning(
+                    "[ORPHAN PLANT] plant_id=%s parent_gem_id=%s ultimate_plant_group=%s",
+                    p.plant_id,
+                    p.parent_gem_id,
+                    p.ultimate_plant_group,
+                )
+                plant_group_id: str | None = p.ultimate_plant_group
+                plant_group_balance: float | None = None
+            else:
+                plant_group_id = pg.plant_group_id
+                plant_group_balance = pg.balance
 
             plants[p.plant_id] = {
                 "furnace_groups": plant_dict,
-                "plant_group": plant_group,
+                "plant_group_id": plant_group_id,
                 "location": p.location.iso3,
-                "balance": p.balance,
+                "plant_profit_and_loss": sum(fg.historic_balance for fg in p.furnace_groups),
+                "plant_group_balance": plant_group_balance,
             }
 
         # Ensure the TM directory exists

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -3258,7 +3258,6 @@ class Plant:
         self.added_capacity = Volumes(0)
         self.removed_capacity = Volumes(0)
         self.removed_capacity_by_product: dict[str, float] = {}
-        self.balance = 0.0
 
         # cost and capacity
         self.technology_unit_fopex = technology_unit_fopex
@@ -3268,6 +3267,11 @@ class Plant:
 
     def add_furnace_group(self, new_furnace_group: FurnaceGroup) -> None:
         self.furnace_groups.append(new_furnace_group)
+
+    @property
+    def historic_balance(self) -> float:
+        """Lifetime operational P&L summed across all FGs (including closed). Pure derivation."""
+        return sum(fg.historic_balance for fg in self.furnace_groups)
 
     @property
     def ultimate_plant_group(self) -> str:
@@ -3729,6 +3733,7 @@ class Plant:
     def evaluate_furnace_group_strategy(
         self,
         furnace_group_id: str,
+        plant_group: PlantGroup,
         market_price_series: dict,
         region_capex: dict[str, float],
         capex_renovation_share: dict[str, float],
@@ -3764,22 +3769,23 @@ class Plant:
         Evaluate the economic strategy for a furnace group using NPV-based decision making.
 
         Steps:
-        1. Check plant financial health (skip if negative balance)
-        2. Check furnace group status (skip if pre-retirement)
-        3. Check for forced closure (historic losses exceed threshold = CAPEX × capacity)
-        4. Filter allowed technology transitions based on current year
-        5. Calculate NPV for all technology options (adjusted for COSA when switching)
-        6. Check if any technology option is profitable (NPV > 0)
-        7. Identify optimal technology (maximum NPV)
-        8. Select technology (weighted random if probabilistic_agents=True, otherwise optimal)
-        9. If current tech is optimal and lifetime expired: evaluate renovation
-        10. If different tech is optimal: evaluate technology switch
-        11. Check capacity limits for expansions/switches
-        12. Apply probabilistic adoption decision (if enabled)
-        13. Return appropriate command (ChangeFurnaceGroupTechnology, RenovateFurnaceGroup, CloseFurnaceGroup, or None)
+        1. Check furnace group status (skip if pre-retirement)
+        2. Check for forced closure (historic losses exceed threshold = CAPEX × capacity)
+        3. Filter allowed technology transitions based on current year
+        4. Calculate NPV for all technology options (adjusted for COSA when switching)
+        5. Check if any technology option is profitable (NPV > 0)
+        6. Identify optimal technology (maximum NPV)
+        7. Select technology (weighted random if probabilistic_agents=True, otherwise optimal)
+        8. If current tech is optimal and lifetime expired: evaluate renovation (gated on plant_group.balance)
+        9. If different tech is optimal: evaluate technology switch (gated on plant_group.balance)
+        10. Check capacity limits for expansions/switches
+        11. Apply probabilistic adoption decision (if enabled)
+        12. Return appropriate command (ChangeFurnaceGroupTechnology, RenovateFurnaceGroup, CloseFurnaceGroup, or None)
 
         Args:
             furnace_group_id: Unique identifier for the furnace group
+            plant_group: PlantGroup that owns this plant. Its ``balance`` is the treasury
+                used to gate and debit renovation / switch equity.
             market_price_series: Time series of market prices for relevant commodities
             region_capex: Capital costs by technology for the region ($/tonne capacity), without subsidies
             capex_renovation_share: Fraction of greenfield CAPEX needed for renovation by technology (0-1)
@@ -3814,9 +3820,12 @@ class Plant:
             CloseFurnaceGroup for closures) or None if no action is profitable/feasible
 
         Side Effects:
-            Updates self.balance when renovation or technology switch is approved
+            Debits ``plant_group.balance`` via ``plant_group.deduct_equity`` when a
+            renovation or technology switch is approved. No mutation of plant-level
+            state.
         """
         logger = logging.getLogger(f"{__name__}.evaluate_furnace_group_strategy")
+        unmask_logger = logging.getLogger(f"{__name__}.evaluate_furnace_group_strategy.unmask")
         furnace_group = self.get_furnace_group(furnace_group_id)
 
         active_energy_subs = {
@@ -3840,22 +3849,26 @@ class Plant:
         logger.debug(f"[FG STRATEGY]   - Status: {furnace_group.status}")
         logger.debug(f"[FG STRATEGY]   - FG balance: ${furnace_group.balance:,.2f}")
         logger.debug(f"[FG STRATEGY]   - Historic balance: ${furnace_group.historic_balance:,.2f}")
-        logger.debug(f"[FG STRATEGY]   - Plant balance: ${self.balance:,.2f}")
+        logger.debug(f"[FG STRATEGY]   - Plant group balance: ${plant_group.balance:,.2f}")
         logger.debug(f"[FG STRATEGY]   - Location: {self.location.iso3}")
 
-        # ===== STAGE 1: Check plant financial health =====
-        # Negative balance means no investment capacity available
-        if self.balance < 0:
-            logger.debug(f"[FG STRATEGY] DECISION - No action (negative plant balance: ${self.balance:,.2f})")
-            return None
+        # Log when the Stage 1 plant-balance gate would have fired pre-refactor; Stage 3
+        # closure now runs unconditionally on underwater groups.
+        if plant_group.balance < 0:
+            unmask_logger.debug(
+                "[STAGE 1 UNMASK] plant_id=%s plant_group_id=%s plant_group.balance=%.2f",
+                self.plant_id,
+                plant_group.plant_group_id,
+                plant_group.balance,
+            )
 
-        # ===== STAGE 2: Check furnace group status =====
+        # ===== STAGE 1: Check furnace group status =====
         # Skip if already scheduled for retirement
         if furnace_group.status.lower() == "operating pre-retirement":
             logger.debug(f"[FG STRATEGY] DECISION - No action (FG status: {furnace_group.status})")
             return None
 
-        # ===== STAGE 3: Check for forced closure =====
+        # ===== STAGE 2: Check for forced closure =====
         # Close if historic losses exceed the CAPEX value (write-off point)
         current_capex_per_tonne = region_capex.get(furnace_group.technology.name)
         if current_capex_per_tonne is None:
@@ -3875,7 +3888,7 @@ class Plant:
             )
             return commands.CloseFurnaceGroup(plant_id=self.plant_id, furnace_group_id=furnace_group.furnace_group_id)
 
-        # ===== STAGE 4: Filter allowed technology transitions =====
+        # ===== STAGE 3: Filter allowed technology transitions =====
         # Intersect allowed techs for current year with valid furnace transitions
         allowed_techs_in_year = allowed_techs.get(current_year, None)
         if not allowed_techs_in_year:
@@ -3917,7 +3930,7 @@ class Plant:
             f"{filtered_allowed_furnace_transitions.get(furnace_group.technology.name)}"
         )
 
-        # ===== STAGE 5: Calculate NPV for all technology options =====
+        # ===== STAGE 4: Calculate NPV for all technology options =====
         logger.debug("[FG STRATEGY] === Calculating NPV for all technology options ===")
         logger.debug(f"[FG STRATEGY] Fixed opex for technologies: {self.technology_unit_fopex}")
         tech_npv_dict, npv_capex_dict, cosa, bom_dict = furnace_group.optimal_technology_name(
@@ -3953,7 +3966,7 @@ class Plant:
         logger.debug(f"[FG STRATEGY] CAPEX by tech ($/t): {npv_capex_dict}")
         logger.debug(f"[FG STRATEGY] COSA: {cosa_msg}")
 
-        # ===== STAGE 6: Check if any technology option is profitable =====
+        # ===== STAGE 5: Check if any technology option is profitable =====
         best_npv = max(tech_npv_dict.values(), default=0)
         logger.debug(f"[FG STRATEGY] Best NPV across all options: ${best_npv:,.2f}")
 
@@ -3961,7 +3974,7 @@ class Plant:
             logger.debug("[FG STRATEGY] DECISION - No action (all NPVs negative or zero)")
             return None
 
-        # ===== STAGE 7: Identify optimal technology =====
+        # ===== STAGE 6: Identify optimal technology =====
         current_tech = furnace_group.technology.name
         optimal_tech = max(tech_npv_dict, key=lambda k: tech_npv_dict[k])
         is_current_best = current_tech == optimal_tech
@@ -3971,7 +3984,7 @@ class Plant:
             f"Current is best: {is_current_best}"
         )
 
-        # ===== STAGE 8: Technology selection =====
+        # ===== STAGE 7: Technology selection =====
         # Use weighted random selection if current tech is not optimal
         if not is_current_best:
             logger.debug("[FG STRATEGY] Current technology is not optimal, selecting alternative")
@@ -4052,7 +4065,7 @@ class Plant:
         if original_capex_per_tonne is None:
             raise ValueError(f"CAPEX without subsidies for technology {best_tech} not found in region CAPEX dict")
 
-        # ===== STAGE 9: Handle renovation scenario (best tech = current tech) =====
+        # ===== STAGE 8: Handle renovation scenario (best tech = current tech) =====
         if best_tech == current_tech:
             logger.debug("[FG STRATEGY] Best technology is current technology")
 
@@ -4080,25 +4093,29 @@ class Plant:
                 logger.debug(f"[FG STRATEGY]   - Equity share: {furnace_group.equity_share:.1%}")
                 logger.debug(f"[FG STRATEGY]   - Total cost: ${renovate_cost:,.2f}")
                 logger.info(
-                    f"[FG STRATEGY]   - Plant balance: ${self.balance:,.2f}, "
-                    f"headroom: ${self.balance - renovate_cost:,.2f}"
+                    f"[FG STRATEGY] plant_id={self.plant_id} plant_group_id={plant_group.plant_group_id} "
+                    f"renovate_cost=${renovate_cost:,.2f} balance=${plant_group.balance:,.2f} "
+                    f"headroom=${plant_group.balance - renovate_cost:,.2f}"
                 )
 
-                # Check affordability
-                if renovate_cost > self.balance:
+                # Check affordability against group treasury
+                if renovate_cost > plant_group.balance:
                     logger.info(
-                        f"[FG STRATEGY] DECISION - CLOSE FG "
-                        f"(cannot afford renovation: ${renovate_cost:,.2f} > balance ${self.balance:,.2f})"
+                        f"[FG STRATEGY] DECISION - CLOSE FG plant_id={self.plant_id} "
+                        f"plant_group_id={plant_group.plant_group_id} gate_pass=False "
+                        f"(cannot afford renovation: ${renovate_cost:,.2f} > "
+                        f"group balance ${plant_group.balance:,.2f})"
                     )
                     return commands.CloseFurnaceGroup(
                         plant_id=self.plant_id, furnace_group_id=furnace_group.furnace_group_id
                     )
 
-                # Proceed with renovation (update plant balance)
-                self.balance -= renovate_cost
+                # Debit the group treasury via the single-site capex mutation
+                plant_group.deduct_equity(renovate_cost, reason="renovation")
                 logger.info(
-                    f"[FG STRATEGY] DECISION - RENOVATE {best_tech} "
-                    f"(cost: ${renovate_cost:,.2f}, new balance: ${self.balance:,.2f})"
+                    f"[FG STRATEGY] DECISION - RENOVATE {best_tech} plant_id={self.plant_id} "
+                    f"plant_group_id={plant_group.plant_group_id} gate_pass=True "
+                    f"(cost: ${renovate_cost:,.2f}, new group balance: ${plant_group.balance:,.2f})"
                 )
 
                 return commands.RenovateFurnaceGroup(
@@ -4118,7 +4135,7 @@ class Plant:
                 )
                 return None
 
-        # ===== STAGE 10: Handle technology switch scenario =====
+        # ===== STAGE 9: Handle technology switch scenario =====
         logger.debug(f"[FG STRATEGY] Evaluating technology switch from {current_tech} to {best_tech}")
 
         # Get subsidized greenfield CAPEX per tonne
@@ -4136,18 +4153,21 @@ class Plant:
         logger.debug(f"[FG STRATEGY]   - Equity share: {furnace_group.equity_share:.1%}")
         logger.debug(f"[FG STRATEGY]   - Total cost: ${switch_cost:,.2f}")
         logger.info(
-            f"[FG STRATEGY]   - Plant balance: ${self.balance:,.2f}, headroom: ${self.balance - switch_cost:,.2f}"
+            f"[FG STRATEGY] plant_id={self.plant_id} plant_group_id={plant_group.plant_group_id} "
+            f"switch_cost=${switch_cost:,.2f} balance=${plant_group.balance:,.2f} "
+            f"headroom=${plant_group.balance - switch_cost:,.2f}"
         )
 
-        # Check affordability
-        if switch_cost > self.balance:
+        # Check affordability against group treasury
+        if switch_cost > plant_group.balance:
             logger.debug(
-                f"[FG STRATEGY] DECISION - No action "
-                f"(cannot afford switch: ${switch_cost:,.2f} > balance ${self.balance:,.2f})"
+                f"[FG STRATEGY] DECISION - No action plant_id={self.plant_id} "
+                f"plant_group_id={plant_group.plant_group_id} gate_pass=False "
+                f"(cannot afford switch: ${switch_cost:,.2f} > group balance ${plant_group.balance:,.2f})"
             )
             return None
 
-        # ===== STAGE 11: Probabilistic adoption decision =====
+        # ===== STAGE 10: Probabilistic adoption decision =====
         # Simulates real-world hesitation/uncertainty in technology adoption
         # Acceptance probability = exp(-switch_cost / NPV)
         # Higher cost relative to benefit → lower probability
@@ -4165,7 +4185,7 @@ class Plant:
         fg_is_ccs_or_ccu = furnace_group.is_ccs_or_ccu
 
         if not fg_is_ccs_or_ccu and random_draw < accept_prob:
-            # ===== STAGE 12: Check capacity limits =====
+            # ===== STAGE 11: Check capacity limits =====
             # Ensure switch doesn't exceed annual capacity expansion limits
             if (
                 capacity_limit_steel is not None
@@ -4208,14 +4228,14 @@ class Plant:
                     )
                     return None
 
-            # ===== STAGE 13: Execute technology switch =====
-            # Update plant balance and return command
-            self.balance -= switch_cost
+            # ===== STAGE 12: Execute technology switch =====
+            # Debit group treasury and return command
+            plant_group.deduct_equity(switch_cost, reason="switch")
             logger.info(
-                f"[FG STRATEGY] DECISION - SWITCH TECHNOLOGY "
-                f"{current_tech} → {best_tech} "
+                f"[FG STRATEGY] DECISION - SWITCH TECHNOLOGY {current_tech} → {best_tech} "
+                f"plant_id={self.plant_id} plant_group_id={plant_group.plant_group_id} gate_pass=True "
                 f"(NPV: ${tech_npv_dict.get(best_tech, 0):,.2f}, cost: ${switch_cost:,.2f}, "
-                f"new balance: ${self.balance:,.2f})"
+                f"new group balance: ${plant_group.balance:,.2f})"
             )
 
             npv_value = tech_npv_dict.get(best_tech)
@@ -4288,7 +4308,6 @@ class Plant:
         lag: int,
         status: str,
         util_rate: float,
-        equity_needed: float,
         plant_lifetime: int,
         chosen_reductant: str,
         dynamic_business_case: list[PrimaryFeedstock] | None = None,
@@ -4307,8 +4326,11 @@ class Plant:
         3. Initialize a FurnaceGroup with the technology, capacity, status, and financial parameters.
         4. Set energy costs (either inherited from plant or explicitly provided for new plants).
         5. Generate energy VOPEX by reductant and set fixed OPEX based on technology.
-        6. Adjust plant balance for equity investment if status is not "considered".
-        7. Mark the furnace group as created by PAM (Plant Asset Model).
+        6. Mark the furnace group as created by PAM (Plant Asset Model).
+
+        Pure factory; does not mutate any balance. Equity debit for expansion is
+        handled in ``add_furnace_group_to_plant`` via ``plant_group.deduct_equity``.
+        New-plant construction does not debit any treasury.
 
         Args:
             technology_name (str): The name of the technology for the new furnace group.
@@ -4324,7 +4346,6 @@ class Plant:
                 expansion, "considered" if coming from new plant opening.
             util_rate (float): The utilization rate for the new furnace group; set to 0.0 if coming from capacity
                 expansion, since it will be ramped up over time by the trade module.
-            equity_needed (float): The amount of equity investment required for the new furnace group.
             plant_lifetime (int): The expected lifetime of the plant in years.
             chosen_reductant (str): The reductant type chosen for the furnace group (e.g., "hydrogen").
             dynamic_business_case (list[PrimaryFeedstock] | None): Optional list of primary feedstocks for dynamic
@@ -4343,8 +4364,7 @@ class Plant:
             FurnaceGroup: A new FurnaceGroup object with the specified technology and parameters.
 
         Side Effects:
-            - Decreases plant balance by equity_needed if status is not "considered".
-            - Increments the plant's furnace ID counter.
+            Increments the plant's furnace ID counter.
         """
 
         technology = Technology(
@@ -4412,10 +4432,6 @@ class Plant:
             furnace_group.tech_unit_fopex = float(fopex_value)
         else:
             raise ValueError(f"Fixed OPEX for technology {technology_name} not found")
-
-        # Adjust plant balance for equity investment (applies to expansion/switches, not "considered" new plants)
-        if status != "considered":
-            self.balance -= equity_needed
 
         # Mark as model-generated (not from historical data)
         furnace_group.created_by_PAM = True
@@ -4639,48 +4655,6 @@ class Plant:
 
         return agg_util_rate
 
-    def update_furnace_and_plant_balance(self, market_price: dict[str, float], active_statuses: list[str]) -> None:
-        """
-        Update the balance sheet for the plant and all its furnace groups.
-
-        Iterates through all furnace groups, updating each one's balance based on market prices,
-        then aggregates those balances to the plant level. Skips furnace groups that are inactive,
-        have zero capacity, are classified as "other" technology, or produce products not in the market.
-
-        Args:
-            market_price (dict[str, float]): Dictionary mapping product names (lowercase) to their market prices.
-            active_statuses (list[str]): List of status strings considered active for balance updates.
-
-        Side Effects:
-            - Updates each furnace group's balance via update_balance_sheet().
-            - Adds each furnace group's balance to the plant's balance.
-            - Resets each furnace group's balance to zero after aggregation.
-        """
-        logger = logging.getLogger(f"{__name__}.update_furnace_and_plant_balance")
-
-        for fg in self.furnace_groups:
-            # Skip furnace groups that should not be included in balance updates
-            if (
-                fg.capacity == 0
-                or fg.status.lower() not in [s.lower() for s in active_statuses]
-                or fg.technology.name.lower() == "other"
-                or fg.technology.product.lower() not in market_price
-            ):
-                continue
-            logger.debug(f"[BALANCE UPDATE]: FG ID: {fg.furnace_group_id}")
-            logger.debug(f"[BALANCE UPDATE]: FG balance before update: ${fg.balance:,.2f}")
-
-            # Update furnace group balance based on market price for its product
-            fg.update_balance_sheet(market_price[fg.technology.product.lower()])
-            logger.debug(f"[BALANCE UPDATE]: FG balance after update: ${fg.balance:,.2f}")
-
-            # Aggregate furnace group balance to plant level
-            self.balance += fg.balance
-            logger.debug(f"[BALANCE UPDATE]: Plant balance after FG update: ${self.balance:,.2f}")
-
-            # Reset furnace group balance after aggregation
-            fg.balance = 0.0
-
     def update_furnace_technology_emission_factors(
         self, technology_emission_factors: list[TechnologyEmissionFactors]
     ) -> None:
@@ -4809,19 +4783,96 @@ def get_new_plant_id(existent_plant_ids: list[str] = []) -> str:
 
 class PlantGroup:
     def __init__(self, *, plant_group_id: str, plants: list[Plant]) -> None:
+        """
+        A plant group is the treasury owner for its constituent plants.
+
+        Attributes:
+            plant_group_id: authoritative group identifier (e.g. a corporate GEM id
+                or ``indi_<iso3>`` for per-country indi groups).
+            plants: plants currently owned by the group.
+            balance: stored ledger (not derived). Credited by ``sweep_fg_balances_to_group``
+                from operational P&L; debited by ``deduct_equity`` for renovation,
+                switch, and expansion. Greenfield construction does not debit.
+        """
         self.plant_group_id = plant_group_id
         self.plants = plants
-        self.total_balance = 0.0
+        self.balance = 0.0
         self.events: list[events.Event] = []
 
-    def collect_total_plant_balance(self) -> float:
+    def deduct_equity(self, amount: float, reason: str) -> None:
         """
-        Collect the total balance from all plants in the plant group
+        Debit equity against the group treasury.
+
+        Sole mutation site for capex debits. Called by renovation and switch from
+        ``evaluate_furnace_group_strategy`` and by expansion from the
+        ``add_furnace_group_to_plant`` handler. Does not check affordability — gates
+        live at the call sites.
+
+        Args:
+            amount: equity amount in USD (``capex_per_tonne × capacity × equity_share``).
+            reason: one of ``"renovation"``, ``"switch"``, ``"expansion"``. Used only
+                for the structured log line today; forward-compatible for per-reason
+                tracing or aggregation.
+
+        Notes:
+            New-plant construction does not debit any treasury — the 20% equity is
+            external investor money outside the simulated ledger.
         """
-        # print(sum([plant.get_total_balance_sheet() for plant in self.plants]))
-        balances: list[float] = [plant.balance for plant in self.plants]
-        self.total_balance = float(sum(balances))
-        return self.total_balance
+        deduct_logger = logging.getLogger(f"{__name__}.deduct_equity")
+        balance_before = self.balance
+        self.balance -= amount
+        deduct_logger.info(
+            "[DEDUCT EQUITY] reason=%s amount=%.2f plant_group_id=%s balance_before=%.2f balance_after=%.2f",
+            reason,
+            amount,
+            self.plant_group_id,
+            balance_before,
+            self.balance,
+        )
+
+    def sweep_fg_balances_to_group(self, market_price: dict[str, float], active_statuses: list[str]) -> None:
+        """
+        Sweep annual operational P&L from all furnace groups into the group treasury.
+
+        For each plant in the group, iterates the plant's furnace groups. Skips FGs
+        that are inactive, have zero capacity, are classified as "other" technology,
+        or produce a product not in the market. For each eligible FG, runs
+        ``fg.update_balance_sheet`` to set its annual P&L, adds the result to the
+        group's ``balance``, then zeroes ``fg.balance`` so the sweep is idempotent.
+
+        Args:
+            market_price: Dictionary mapping product names (lowercase) to market prices.
+            active_statuses: Status strings considered active for balance updates.
+
+        Side Effects:
+            - Sets ``fg.balance`` to the annual P&L (via ``update_balance_sheet``).
+            - Increments ``self.balance`` by each FG's annual P&L.
+            - Resets ``fg.balance`` to 0.0 after aggregation.
+        """
+        sweep_logger = logging.getLogger(f"{__name__}.sweep_fg_balances_to_group")
+        active_lc = [s.lower() for s in active_statuses]
+
+        for plant in self.plants:
+            for fg in plant.furnace_groups:
+                if (
+                    fg.capacity == 0
+                    or fg.status.lower() not in active_lc
+                    or fg.technology.name.lower() == "other"
+                    or fg.technology.product.lower() not in market_price
+                ):
+                    continue
+
+                fg.update_balance_sheet(market_price[fg.technology.product.lower()])
+                annual_pnl = fg.balance
+                self.balance += annual_pnl
+                sweep_logger.debug(
+                    "[SWEEP] fg_id=%s annual_pnl=%.2f plant_group_id=%s balance=%.2f",
+                    fg.furnace_group_id,
+                    annual_pnl,
+                    self.plant_group_id,
+                    self.balance,
+                )
+                fg.balance = 0.0
 
     @property
     def most_common_reductant(self) -> dict[str, str]:
@@ -4919,10 +4970,8 @@ class PlantGroup:
             technology_unit_fopex={technology_name.lower(): cost_data[product][site_id][technology_name]["fopex"]},  # type: ignore[dict-item]
         )
 
-        # Create new furnace group in plant
-        # cost_data has been validated by prepare_cost_data to ensure capex is numeric
-        capex_value = cost_data[product][site_id][technology_name]["capex"]  # type: ignore[index]
-        equity_needed = equity_share * float(capex_value)  # type: ignore[arg-type]
+        # Create new furnace group in plant. New-plant construction does NOT debit any
+        # treasury (20% equity is external investor money, 80% debt amortises via P&L).
         new_furnace = new_plant.generate_new_furnace(
             technology_name=technology_name,
             product=product,
@@ -4940,7 +4989,6 @@ class PlantGroup:
                 cost_data[product][site_id][technology_name]["utilization_rate"]  # type: ignore[arg-type]
             ),  # average utilization rate for the technology
             chosen_reductant=cost_data[product][site_id][technology_name]["reductant"],  # type: ignore[arg-type]
-            equity_needed=equity_needed,
             lag=int(1e6),  # Set lag to a very high number so that the plant needs to be made operational explicitly
             plant_lifetime=plant_lifetime,
             dynamic_business_case=dynamic_feedstocks,
@@ -5050,6 +5098,11 @@ class PlantGroup:
             raise ValueError(f"No allowed technologies found for year {current_year}")
         logger.info(f"[PG EXPANSION] Allowed technologies in {current_year}: {allowed_techs_in_year}")
 
+        # Pre-filter counters for site #13 log
+        num_pairs_evaluated = 0
+        num_pairs_passed_prefilter = 0
+        num_pairs_dropped_prefilter = 0
+
         # Dictionary to store best NPV and technology choice for each plant
         NPV_p = {}
 
@@ -5089,14 +5142,17 @@ class PlantGroup:
                         f"No greenfield capex data for {tech} in region {iso3_to_region_map[plant.location.iso3]}"
                     )
 
-                # Skip if plant cannot individually afford this technology
-                equity_needed_for_tech = capacity * capex
-                if plant.balance < equity_needed_for_tech:
+                # Skip if the group treasury cannot cover equity for this (plant, tech)
+                num_pairs_evaluated += 1
+                equity_needed_for_tech = capex * capacity * equity_share
+                if self.balance < equity_needed_for_tech:
+                    num_pairs_dropped_prefilter += 1
                     logger.debug(
                         f"[PG EXPANSION] Skipping {tech} for plant {plant.plant_id}: "
-                        f"balance ${plant.balance:,.2f} < equity needed ${equity_needed_for_tech:,.2f}"
+                        f"group balance ${self.balance:,.2f} < equity needed ${equity_needed_for_tech:,.2f}"
                     )
                     continue
+                num_pairs_passed_prefilter += 1
 
                 # Skip BOF technology if plant lacks hot metal furnace (prerequisite)
                 if tech == "BOF" and not plant.has_hot_metal_furnace:
@@ -5257,6 +5313,15 @@ class PlantGroup:
 
                 NPV_p[plant.plant_id] = NPV.get(best_tech), best_tech, best_capex
 
+        logger.info(
+            "[PG EXPANSION OPTIONS] plant_group_id=%s num_pairs_evaluated=%d "
+            "num_pairs_passed_prefilter=%d num_pairs_dropped_prefilter=%d",
+            self.plant_group_id,
+            num_pairs_evaluated,
+            num_pairs_passed_prefilter,
+            num_pairs_dropped_prefilter,
+        )
+
         return NPV_p
 
     def evaluate_expansion(
@@ -5348,10 +5413,11 @@ class PlantGroup:
             - Logs detailed decision-making process at debug level
 
         Note:
-        - Balance deduction does NOT happen here - it occurs at the FurnaceGroup level via command handler.
-          The handler deducts equity from the FurnaceGroup, then FurnaceGroup updates Plant balance,
-          and PlantGroup.total_balance is updated from Plant balances.
-        - Probabilistic acceptance uses formula: exp(-investment_cost / NPV)
+        - Balance deduction does NOT happen here - the ``add_furnace_group_to_plant``
+          handler debits ``plant_group.balance`` via ``plant_group.deduct_equity`` after
+          the factory has attached the new furnace to the plant.
+        - Probabilistic acceptance uses formula: ``exp(-equity_needed / NPV)`` — the
+          equity-basis equity outlay is dimensionally consistent with the equity-basis NPV.
         - Capacity limits distinguish between new plants and expansions/switches
         - All subsidies are filtered to only include those active in the current year
         """
@@ -5360,7 +5426,7 @@ class PlantGroup:
         # ========== STAGE 1: INITIALIZATION ==========
         logger.debug(
             f"[PG EXPANSION] {self.plant_group_id}: "
-            f"balance=${self.total_balance:,.2f}, plants={len(self.plants)}, year={current_year}"
+            f"balance=${self.balance:,.2f}, plants={len(self.plants)}, year={current_year}"
         )
 
         # ========== STAGE 2: EVALUATE ALL EXPANSION OPTIONS ==========
@@ -5419,26 +5485,42 @@ class PlantGroup:
             return None
 
         # ========== STAGE 6: CHECK BALANCE SUFFICIENCY ==========
-        equity_needed = capacity * capex  # Equity to finance up-front cost
+        # Equity = capex × capacity × equity_share
+        investment = capacity * capex
+        equity_needed = investment * equity_share
 
-        if self.total_balance < equity_needed:
+        if self.balance < equity_needed:
             logger.debug(
                 f"[PG EXPANSION] DECISION - No expansion (insufficient funds: "
-                f"${self.total_balance:,.2f} < ${equity_needed:,.2f})"
+                f"${self.balance:,.2f} < ${equity_needed:,.2f})"
             )
             return None
 
         # ========== STAGE 7: PROBABILISTIC ACCEPTANCE ==========
+        # Acceptance: exp(-equity_needed / NPV). Dimensionally consistent with NPV, which is equity-basis
         if probabilistic_agents:
-            # Probabilistic acceptance: exp(-investment/NPV) → higher cost/benefit ratio = lower probability
-            investment_cost = capacity * capex
-            acceptance_probability = math.exp(-investment_cost / npv)
+            acceptance_probability = math.exp(-equity_needed / npv)
         else:
             acceptance_probability = 1
 
         random_draw = random.random()
+        accepted = random_draw < acceptance_probability
 
-        if random_draw >= acceptance_probability:
+        logger.info(
+            "[PG EXPANSION] plant_group_id=%s plant_id=%s tech=%s investment=%.2f "
+            "equity_needed=%.2f npv=%.2f acceptance_probability=%.4f random_draw=%.4f accepted=%s",
+            self.plant_group_id,
+            plant_id,
+            tech,
+            investment,
+            equity_needed,
+            npv,
+            acceptance_probability,
+            random_draw,
+            accepted,
+        )
+
+        if not accepted:
             logger.debug(
                 f"[PG EXPANSION] DECISION - No expansion (probabilistic rejection: "
                 f"draw={random_draw:.4f} >= prob={acceptance_probability:.2%})"
@@ -5489,9 +5571,9 @@ class PlantGroup:
             # )
 
         # ========== STAGE 9: VALIDATE PLANT AND LOCATION ==========
-        # NOTE: Balance deduction does NOT happen here - it occurs at the FurnaceGroup level via command handler.
-        # The handler deducts equity from the FurnaceGroup, then FurnaceGroup updates Plant balance,
-        # and PlantGroup.total_balance is updated from Plant balances.
+        # NOTE: Balance deduction does NOT happen here - the add_furnace_group_to_plant handler
+        # calls plant_group.deduct_equity(cmd.equity_needed, reason="expansion") after the factory
+        # has attached the new furnace to the plant.
 
         # Find the plant and validate location
         plant = next((p for p in self.plants if p.plant_id == plant_id), None)
@@ -5584,7 +5666,7 @@ class PlantGroup:
         logger.info("[PG EXPANSION] ✓ SUCCESS - Expansion approved")
         logger.info(f"[PG EXPANSION]   - Plant: {plant_id}, Technology: {tech}, Product: {product}")
         logger.info(f"[PG EXPANSION]   - Capacity: {capacity * T_TO_KT:,.0f} kt, NPV: ${npv:,.0f}")
-        logger.info(f"[PG EXPANSION]   - Investment: ${capacity * capex:,.0f} (equity: ${equity_needed:,.0f})")
+        logger.info(f"[PG EXPANSION]   - Investment: ${investment:,.0f} (equity to debit: ${equity_needed:,.0f})")
         logger.info(f"[PG EXPANSION]   - CAPEX: ${base_capex:.2f}/t → ${capex:.2f}/t (with subsidies)")
         logger.info(
             f"[PG EXPANSION]   - Cost of debt: {cost_of_debt_original:.2%} → {cost_of_debt:.2%} (with subsidies)"
@@ -8910,7 +8992,7 @@ class Environment:
                 )
                 if cheapest_reductant:
                     most_common_reductant = cheapest_reductant
-                    logger.warning(
+                    logger.info(
                         "[AVG_BOM_DIAG] reductant: tech=%s source=cheapest_reductant_fallback chosen=%s",
                         tech,
                         most_common_reductant,

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -4954,7 +4954,6 @@ class PlantGroup:
         # cost_data has been validated by validate_and_clean_cost_data to ensure these are floats/dicts
         new_furnace.railway_cost = cost_data[product][site_id][technology_name]["railway_cost"]  # type: ignore[assignment]
         new_plant.add_furnace_group(new_furnace)
-        self.plants.append(new_plant)
         return new_plant
 
     def evaluate_expansion_options(

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -13,7 +13,6 @@ from steelo.adapters.geospatial.geospatial_statistics import (
 )
 from steelo.adapters.repositories.in_memory_repository import InMemoryRepository
 from steelo.domain import Year
-from steelo.domain.models import PlantGroup
 from steelo.domain.commands import (
     AddFurnaceGroup,
     ChangeFurnaceGroupStatusToSwitchingTechnology,
@@ -119,7 +118,8 @@ class GeospatialModel:
             raise ValueError("config must be set in Environment for geospatial analysis")
         ## Prepare input costs
         geo_config = bus.env.config.geo_config
-        indi_pg = bus.uow.plant_groups.get("indi")
+        indi_master_pg = bus.uow.plant_groups.get("indi")
+        per_country_indi_groups = [pg for pg in bus.uow.plant_groups.list() if pg.plant_group_id.startswith("indi_")]
         input_costs_converted: dict[
             str, dict[Year, dict[str, float]]
         ] = {}  # country_code -> {year: {cost_type: cost_value}}
@@ -190,21 +190,24 @@ class GeospatialModel:
 
         # Update dynamic costs for all existing business opportunities yearly
         step_start = time.time()
-        dynamic_cost_commands = indi_pg.update_dynamic_costs_for_business_opportunities(
-            current_year=bus.env.year,
-            consideration_time=bus.env.config.consideration_time,
-            custom_energy_costs=custom_energy_costs,  # type: ignore[arg-type]  # needed to avoid importing xarray into the domain
-            capex_dict_all_locs=bus.env.name_to_capex["greenfield"],
-            cost_debt_all_locs=bus.env.industrial_cost_of_debt,
-            iso3_to_region_map=bus.env.country_mappings.iso3_to_region(),
-            global_risk_free_rate=bus.env.config.global_risk_free_rate,
-            capex_subsidies=bus.env.capex_subsidies,
-            debt_subsidies=bus.env.debt_subsidies,
-            energy_subsidies=bus.env.energy_subsidies,
-        )
-        if dynamic_cost_commands:
-            for command in dynamic_cost_commands:
-                bus.handle(command)
+        dynamic_cost_commands: list = []
+        for pg in per_country_indi_groups:
+            dynamic_cost_commands.extend(
+                pg.update_dynamic_costs_for_business_opportunities(
+                    current_year=bus.env.year,
+                    consideration_time=bus.env.config.consideration_time,
+                    custom_energy_costs=custom_energy_costs,  # type: ignore[arg-type]  # needed to avoid importing xarray into the domain
+                    capex_dict_all_locs=bus.env.name_to_capex["greenfield"],
+                    cost_debt_all_locs=bus.env.industrial_cost_of_debt,
+                    iso3_to_region_map=bus.env.country_mappings.iso3_to_region(),
+                    global_risk_free_rate=bus.env.config.global_risk_free_rate,
+                    capex_subsidies=bus.env.capex_subsidies,
+                    debt_subsidies=bus.env.debt_subsidies,
+                    energy_subsidies=bus.env.energy_subsidies,
+                )
+            )
+        for command in dynamic_cost_commands:
+            bus.handle(command)
         step_time = time.time() - step_start
         logger.info(
             f"operation=geo_update_costs year={bus.env.year} duration_s={step_time:.3f} fg_count={len(dynamic_cost_commands)}"
@@ -213,31 +216,35 @@ class GeospatialModel:
 
         # Update the status of all existing business opportunities (to move from opportunity to new plant)
         step_start = time.time()
-        status_commands = indi_pg.update_status_of_business_opportunities(
-            current_year=bus.env.year,
-            consideration_time=bus.env.config.consideration_time,
-            market_price=future_price_series,
-            cost_of_equity_all_locs=bus.env.industrial_cost_of_equity,
-            probability_of_announcement=bus.env.config.probability_of_announcement,
-            probability_of_construction=bus.env.config.probability_of_construction,
-            plant_lifetime=bus.env.config.plant_lifetime,
-            construction_time=bus.env.config.construction_time,
-            allowed_techs=bus.env.allowed_techs,
-            new_plant_capacity_in_year=bus.env.new_plant_capacity_in_year,
-            expanded_capacity=bus.env.config.expanded_capacity,
-            capacity_limit_iron=bus.env.config.capacity_limit_iron,
-            capacity_limit_steel=bus.env.config.capacity_limit_steel,
-            new_capacity_share_from_new_plants=bus.env.config.new_capacity_share_from_new_plants,
-            opex_subsidies=bus.env.opex_subsidies,
-            technology_emission_factors=bus.env.technology_emission_factors,
-            chosen_emissions_boundary_for_carbon_costs=bus.env.config.chosen_emissions_boundary_for_carbon_costs,
-            carbon_costs=bus.env.carbon_costs,
-            dynamic_business_cases=bus.env.dynamic_feedstocks,
-            get_co2_headroom=bus.env.get_co2_headroom,
-            get_co2_need=bus.env.get_co2_need,
-            co2_storage_diagnostics=bus.env.co2_storage_diagnostics,
-            reserved_discount_factor=bus.env.config.co2_storage_reserved_discount_factor,
-        )
+        status_commands: list = []
+        for pg in per_country_indi_groups:
+            status_commands.extend(
+                pg.update_status_of_business_opportunities(
+                    current_year=bus.env.year,
+                    consideration_time=bus.env.config.consideration_time,
+                    market_price=future_price_series,
+                    cost_of_equity_all_locs=bus.env.industrial_cost_of_equity,
+                    probability_of_announcement=bus.env.config.probability_of_announcement,
+                    probability_of_construction=bus.env.config.probability_of_construction,
+                    plant_lifetime=bus.env.config.plant_lifetime,
+                    construction_time=bus.env.config.construction_time,
+                    allowed_techs=bus.env.allowed_techs,
+                    new_plant_capacity_in_year=bus.env.new_plant_capacity_in_year,
+                    expanded_capacity=bus.env.config.expanded_capacity,
+                    capacity_limit_iron=bus.env.config.capacity_limit_iron,
+                    capacity_limit_steel=bus.env.config.capacity_limit_steel,
+                    new_capacity_share_from_new_plants=bus.env.config.new_capacity_share_from_new_plants,
+                    opex_subsidies=bus.env.opex_subsidies,
+                    technology_emission_factors=bus.env.technology_emission_factors,
+                    chosen_emissions_boundary_for_carbon_costs=bus.env.config.chosen_emissions_boundary_for_carbon_costs,
+                    carbon_costs=bus.env.carbon_costs,
+                    dynamic_business_cases=bus.env.dynamic_feedstocks,
+                    get_co2_headroom=bus.env.get_co2_headroom,
+                    get_co2_need=bus.env.get_co2_need,
+                    co2_storage_diagnostics=bus.env.co2_storage_diagnostics,
+                    reserved_discount_factor=bus.env.config.co2_storage_reserved_discount_factor,
+                )
+            )
         if status_commands:
             for command in status_commands:
                 bus.handle(command)
@@ -247,43 +254,10 @@ class GeospatialModel:
             )
             logger.debug(f"[GEO] Updated status for {len(status_commands)} furnace groups")
 
-        # Move construction-status plants from master indi to per-ISO3 groups
-        indi_logger = logging.getLogger(f"{__name__}.indi_routing")
-        indi_logger.debug(f"[GEO] Indi master group has {len(indi_pg.plants)} plants before routing")
-        moved_count = 0
-        for plant in list(indi_pg.plants):
-            statuses = [fg.status.lower() for fg in plant.furnace_groups]
-            indi_logger.debug(f"[GEO] Plant {plant.plant_id} ({plant.location.iso3}): FG statuses={statuses}")
-            if all(s == "construction" for s in statuses):
-                iso3 = plant.location.iso3
-                group_id = f"indi_{iso3}"
-                try:
-                    target = bus.uow.plant_groups.get(group_id)
-                except KeyError:
-                    target = PlantGroup(plant_group_id=group_id, plants=[])
-                    bus.uow.plant_groups.add(target)
-                    indi_logger.info(f"[GEO] Created per-country indi group: {group_id}")
-                target.plants.append(plant)
-                plant.parent_gem_id = group_id
-                indi_pg.plants.remove(plant)
-                moved_count += 1
-                indi_logger.debug(
-                    f"[GEO] Moved plant {plant.plant_id} ({iso3}) to {group_id} "
-                    f"(group now has {len(target.plants)} plants)"
-                )
-        if moved_count:
-            indi_logger.info(f"[GEO] Moved {moved_count} construction plants to per-ISO3 indi groups")
-        indi_groups = [pg for pg in bus.uow.plant_groups.list() if pg.plant_group_id.startswith("indi_")]
-        if indi_groups:
-            indi_logger.debug(
-                "[GEO] Per-ISO3 indi groups: "
-                + ", ".join(f"{pg.plant_group_id} ({len(pg.plants)} plants)" for pg in indi_groups)
-            )
-
         # Identify new business opportunities and prioritize them by NPV
         step_start = time.time()
         bus.handle(
-            indi_pg.identify_new_business_opportunities_4indi(
+            indi_master_pg.identify_new_business_opportunities_4indi(
                 current_year=bus.env.year,
                 consideration_time=bus.env.config.consideration_time,
                 construction_time=bus.env.config.construction_time,

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -733,150 +733,164 @@ class PlantAgentsModel:
 
         counter = 0  # Track number of commands executed across all plants
 
-        # Step 4: Process each plant for furnace group decisions
-        # Plants are evaluated in random order to avoid systematic biases in decision-making
+        # Step 4: Process each plant group for furnace group decisions.
+        # Group-first ordering: sweep every FG's annual P&L into the group treasury BEFORE any plant
+        # in the group runs its strategy. This gives all plants in the group equal information about
+        # the year's available wallet. Plant-iteration order within a group remains random.
         plant_eval_start = time.time()
-        logger.info("[PAM] Step 4 - Evaluating furnace group strategies")
-        for plant in random.sample(plants, len(plants)):
+        logger.info("[PAM] Step 4 - Evaluating furnace group strategies (group-first)")
+        step4_plant_groups = bus.uow.plant_groups.list()
+        for pg in random.sample(step4_plant_groups, len(step4_plant_groups)):
+            balance_before_sweep = pg.balance
+            pg.sweep_fg_balances_to_group(
+                market_price=freeze_market_price,
+                active_statuses=bus.env.config.active_statuses,
+            )
             logger.info(
-                f"\n\n[PAM] === Processing plant {plant.plant_id} in {plant.location.iso3} (year {bus.env.year}) === \n"
+                "[PAM STEP 4] plant_group_id=%s num_plants=%d balance_before_sweep=%.2f balance_after_sweep=%.2f",
+                pg.plant_group_id,
+                len(pg.plants),
+                balance_before_sweep,
+                pg.balance,
             )
 
-            # Update financial balances: aggregate furnace group balances into plant balance
-            # This resets furnace group balances to zero after aggregation
-            plant.update_furnace_and_plant_balance(
-                market_price=freeze_market_price, active_statuses=bus.env.config.active_statuses
-            )
-
-            # Retrieve location-specific subsidies for this plant
-            # Empty dicts are returned if no subsidies exist - this is expected behavior
-            tech_capex_subsidies = bus.env.capex_subsidies.get(plant.location.iso3, {})
-            tech_opex_subsidies = bus.env.opex_subsidies.get(plant.location.iso3, {})
-            tech_debt_subsidies = bus.env.debt_subsidies.get(plant.location.iso3, {})
-
-            logger.debug(f"[PAM] Plant group: {plant.parent_gem_id}")
-            logger.debug(f"[PAM] Plant balance before update: ${plant.balance:,.2f}")
-            logger.debug(f"[PAM] Plant balance after FG aggregation: ${plant.balance:,.2f}")
-            logger.debug(f"[PAM] Subsidies for {plant.location.iso3}:")
-            logger.debug(f"[PAM]  - CAPEX: {list(tech_capex_subsidies.keys())}")
-            logger.debug(f"[PAM]  - OPEX:  {list(tech_opex_subsidies.keys())}")
-            logger.debug(f"[PAM]  - DEBT:  {list(tech_debt_subsidies.keys())}")
-
-            # Evaluate each furnace group within the plant in random order
-            for fg in random.sample(plant.furnace_groups, len(plant.furnace_groups)):
-                # Skip furnace groups that should not be evaluated:
-                # - Zero capacity furnace groups
-                # - Inactive statuses (e.g., closed, mothballed)
-                # - Groups currently switching technology
-                # - "Other" technology category (not modeled)
-                # - Products not in the market price dictionary
-                if (
-                    fg.capacity == 0
-                    or fg.status.lower() not in bus.env.config.active_statuses
-                    or fg.status.lower() == "operating switching technology"
-                    or fg.technology.name.lower() == "other"
-                    or fg.technology.product.lower() not in freeze_market_price
-                ):
-                    logger.info(
-                        f"[PAM] == Skipping FG {fg.furnace_group_id} - Tech: {fg.technology.name}, Capacity: {fg.capacity * T_TO_KT:,.0f} kt, Status: {fg.status}, Product: {fg.technology.product} ==\n"
-                    )
-                    continue
-
+            for plant in random.sample(pg.plants, len(pg.plants)):
                 logger.info(
-                    f"\n\n[PAM] == Evaluating FG {fg.furnace_group_id} - Tech: {fg.technology.name}, Capacity: {fg.capacity * T_TO_KT:,.0f} kt, Status: {fg.status}, Product: {fg.technology.product} ==\n"
+                    f"\n\n[PAM] === Processing plant {plant.plant_id} in {plant.location.iso3} "
+                    f"(year {bus.env.year}) === \n"
                 )
-                logger.debug(f"[PAM] FG balance: ${fg.balance:,.2f}, Historic balance: ${fg.historic_balance:,.2f}")
 
-                # Retrieve region-specific CAPEX data for technology switching/renovation
-                if "greenfield" in bus.env.name_to_capex:
-                    # Map the plant's ISO3 code to its region
-                    if bus.env.country_mappings is None:
-                        raise ValueError("Country mapping required for furnace switching (not found in Environment)")
-                    iso3_to_region_mapping = bus.env.country_mappings.iso3_to_region()
-                    if plant.location.iso3 not in iso3_to_region_mapping:
-                        raise ValueError(f"Region mapping not found for ISO3 code {plant.location.iso3}")
-                    region = iso3_to_region_mapping[plant.location.iso3]
-                    region_capex = bus.env.name_to_capex["greenfield"][region]
-                    capex_renovation_share = bus.env.capex_renovation_share
+                # Retrieve location-specific subsidies for this plant
+                # Empty dicts are returned if no subsidies exist - this is expected behavior
+                tech_capex_subsidies = bus.env.capex_subsidies.get(plant.location.iso3, {})
+                tech_opex_subsidies = bus.env.opex_subsidies.get(plant.location.iso3, {})
+                tech_debt_subsidies = bus.env.debt_subsidies.get(plant.location.iso3, {})
 
-                    logger.debug(f"[PAM] Region {region} CAPEX loaded for {plant.location.iso3}")
-                    logger.debug(f"[PAM] Region CAPEX for technologies: {region_capex}")
-                    logger.debug(f"[PAM] Renovation share: {capex_renovation_share}")
-                else:
-                    raise KeyError("Region capex not found in bus.env.name_to_capex.")
+                logger.debug(f"[PAM] Plant group: {plant.parent_gem_id}")
+                logger.debug(f"[PAM] Plant group balance: ${pg.balance:,.2f}")
+                logger.debug(f"[PAM] Subsidies for {plant.location.iso3}:")
+                logger.debug(f"[PAM]  - CAPEX: {list(tech_capex_subsidies.keys())}")
+                logger.debug(f"[PAM]  - OPEX:  {list(tech_opex_subsidies.keys())}")
+                logger.debug(f"[PAM]  - DEBT:  {list(tech_debt_subsidies.keys())}")
 
-                # Get cost of debt for the plant location (before subsidies)
-                cost_of_debt = bus.env.industrial_cost_of_debt.get(plant.location.iso3)
-                if cost_of_debt is None:
-                    raise ValueError(f"Cost of debt not found for ISO3 code {plant.location.iso3}.")
-
-                # Get cost of equity for the plant location
-                cost_of_equity = bus.env.industrial_cost_of_equity.get(plant.location.iso3)
-                if cost_of_equity is None:
-                    raise ValueError(f"Cost of equity not found for ISO3 code {plant.location.iso3}")
-
-                logger.debug(f"[PAM] Cost of debt for {plant.location.iso3}: {cost_of_debt:.2%}")
-                logger.debug(f"[PAM] Cost of equity for {plant.location.iso3}: {cost_of_equity:.2%}")
-
-                # Evaluate potential technology switch or renovation for this furnace group
-                # This considers: switching technology, renovating existing technology, or closing the furnace
-                if (
-                    cmd := plant.evaluate_furnace_group_strategy(
-                        fg.furnace_group_id,
-                        market_price_series=future_price_series,
-                        region_capex=region_capex,
-                        cost_of_debt=cost_of_debt,
-                        cost_of_equity=cost_of_equity,
-                        capex_renovation_share=capex_renovation_share,
-                        get_bom_from_avg_boms=bus.env.get_bom_from_avg_boms,
-                        allowed_furnace_transitions=bus.env.allowed_furnace_transitions,
-                        dynamic_business_cases=bus.env.dynamic_feedstocks,
-                        probabilistic_agents=bus.env.config.probabilistic_agents,
-                        tech_capex_subsidies=tech_capex_subsidies,
-                        tech_opex_subsidies=tech_opex_subsidies,
-                        tech_debt_subsidies=tech_debt_subsidies,
-                        current_year=bus.env.year,
-                        allowed_techs=bus.env.allowed_techs,
-                        chosen_emissions_boundary_for_carbon_costs=bus.env.config.chosen_emissions_boundary_for_carbon_costs,
-                        technology_emission_factors=bus.env.technology_emission_factors,
-                        tech_to_product=bus.env.technology_to_product,
-                        plant_lifetime=bus.env.config.plant_lifetime,
-                        construction_time=bus.env.config.construction_time,
-                        risk_free_rate=bus.env.config.global_risk_free_rate,
-                        capacity_limit_steel=capacity_limit_pam_steel,
-                        capacity_limit_iron=capacity_limit_pam_iron,
-                        installed_capacity_in_year=bus.env.installed_capacity_in_year,
-                        new_plant_capacity_in_year=bus.env.new_plant_capacity_in_year,
-                        most_common_reductant_by_tech=bus.env.most_common_reductant_by_tech,
-                        get_co2_headroom=bus.env.get_co2_headroom,
-                        get_co2_need_by_name=bus.env.get_co2_need_by_name,
-                        co2_storage_diagnostics=bus.env.co2_storage_diagnostics,
-                    )
-                ) is not None:
-                    logger.info(f"[PAM] FG {fg.furnace_group_id} strategy returned command: {type(cmd).__name__}")
-                    if isinstance(cmd, ChangeFurnaceGroupTechnology):
-                        # Technology switch: operate with old technology during construction period
-                        # After construction_time years, switch to new technology
-                        command_to_execute = ChangeFurnaceGroupStatusToSwitchingTechnology(
-                            plant_id=cmd.plant_id,
-                            furnace_group_id=cmd.furnace_group_id,
-                            year_of_switch=bus.env.year + bus.env.config.construction_time,
-                            cmd=cmd,
-                        )
-                        product_opt = bus.env.technology_to_product.get(cmd.technology_name)
-                        if product_opt is None:
-                            raise ValueError(f"Technology {cmd.technology_name} not found in technology_to_product")
-                        tech_product: str = product_opt
+                # Evaluate each furnace group within the plant in random order
+                for fg in random.sample(plant.furnace_groups, len(plant.furnace_groups)):
+                    # Skip furnace groups that should not be evaluated:
+                    # - Zero capacity furnace groups
+                    # - Inactive statuses (e.g., closed, mothballed)
+                    # - Groups currently switching technology
+                    # - "Other" technology category (not modeled)
+                    # - Products not in the market price dictionary
+                    if (
+                        fg.capacity == 0
+                        or fg.status.lower() not in bus.env.config.active_statuses
+                        or fg.status.lower() == "operating switching technology"
+                        or fg.technology.name.lower() == "other"
+                        or fg.technology.product.lower() not in freeze_market_price
+                    ):
                         logger.info(
-                            f"[PAM] EXECUTING {type(command_to_execute).__name__} - Future command: {cmd}, Tech: {cmd.technology_name}, Product: {tech_product}, Capacity: {cmd.capacity * T_TO_KT:,.0f} kt"
+                            f"[PAM] == Skipping FG {fg.furnace_group_id} - Tech: {fg.technology.name}, Capacity: {fg.capacity * T_TO_KT:,.0f} kt, Status: {fg.status}, Product: {fg.technology.product} ==\n"
                         )
-                        counter += 1
-                        bus.handle(command_to_execute)
+                        continue
+
+                    logger.info(
+                        f"\n\n[PAM] == Evaluating FG {fg.furnace_group_id} - Tech: {fg.technology.name}, Capacity: {fg.capacity * T_TO_KT:,.0f} kt, Status: {fg.status}, Product: {fg.technology.product} ==\n"
+                    )
+                    logger.debug(f"[PAM] FG balance: ${fg.balance:,.2f}, Historic balance: ${fg.historic_balance:,.2f}")
+
+                    # Retrieve region-specific CAPEX data for technology switching/renovation
+                    if "greenfield" in bus.env.name_to_capex:
+                        # Map the plant's ISO3 code to its region
+                        if bus.env.country_mappings is None:
+                            raise ValueError(
+                                "Country mapping required for furnace switching (not found in Environment)"
+                            )
+                        iso3_to_region_mapping = bus.env.country_mappings.iso3_to_region()
+                        if plant.location.iso3 not in iso3_to_region_mapping:
+                            raise ValueError(f"Region mapping not found for ISO3 code {plant.location.iso3}")
+                        region = iso3_to_region_mapping[plant.location.iso3]
+                        region_capex = bus.env.name_to_capex["greenfield"][region]
+                        capex_renovation_share = bus.env.capex_renovation_share
+
+                        logger.debug(f"[PAM] Region {region} CAPEX loaded for {plant.location.iso3}")
+                        logger.debug(f"[PAM] Region CAPEX for technologies: {region_capex}")
+                        logger.debug(f"[PAM] Renovation share: {capex_renovation_share}")
                     else:
-                        # Execute other commands (e.g., CloseFurnaceGroup, RenovateFurnaceGroup)
-                        logger.info(f"[PAM] EXECUTING {type(cmd).__name__}")
-                        counter += 1
-                        bus.handle(cmd)
+                        raise KeyError("Region capex not found in bus.env.name_to_capex.")
+
+                    # Get cost of debt for the plant location (before subsidies)
+                    cost_of_debt = bus.env.industrial_cost_of_debt.get(plant.location.iso3)
+                    if cost_of_debt is None:
+                        raise ValueError(f"Cost of debt not found for ISO3 code {plant.location.iso3}.")
+
+                    # Get cost of equity for the plant location
+                    cost_of_equity = bus.env.industrial_cost_of_equity.get(plant.location.iso3)
+                    if cost_of_equity is None:
+                        raise ValueError(f"Cost of equity not found for ISO3 code {plant.location.iso3}")
+
+                    logger.debug(f"[PAM] Cost of debt for {plant.location.iso3}: {cost_of_debt:.2%}")
+                    logger.debug(f"[PAM] Cost of equity for {plant.location.iso3}: {cost_of_equity:.2%}")
+
+                    # Evaluate potential technology switch or renovation for this furnace group
+                    # This considers: switching technology, renovating existing technology, or closing the furnace
+                    if (
+                        cmd := plant.evaluate_furnace_group_strategy(
+                            fg.furnace_group_id,
+                            plant_group=pg,
+                            market_price_series=future_price_series,
+                            region_capex=region_capex,
+                            cost_of_debt=cost_of_debt,
+                            cost_of_equity=cost_of_equity,
+                            capex_renovation_share=capex_renovation_share,
+                            get_bom_from_avg_boms=bus.env.get_bom_from_avg_boms,
+                            allowed_furnace_transitions=bus.env.allowed_furnace_transitions,
+                            dynamic_business_cases=bus.env.dynamic_feedstocks,
+                            probabilistic_agents=bus.env.config.probabilistic_agents,
+                            tech_capex_subsidies=tech_capex_subsidies,
+                            tech_opex_subsidies=tech_opex_subsidies,
+                            tech_debt_subsidies=tech_debt_subsidies,
+                            current_year=bus.env.year,
+                            allowed_techs=bus.env.allowed_techs,
+                            chosen_emissions_boundary_for_carbon_costs=bus.env.config.chosen_emissions_boundary_for_carbon_costs,
+                            technology_emission_factors=bus.env.technology_emission_factors,
+                            tech_to_product=bus.env.technology_to_product,
+                            plant_lifetime=bus.env.config.plant_lifetime,
+                            construction_time=bus.env.config.construction_time,
+                            risk_free_rate=bus.env.config.global_risk_free_rate,
+                            capacity_limit_steel=capacity_limit_pam_steel,
+                            capacity_limit_iron=capacity_limit_pam_iron,
+                            installed_capacity_in_year=bus.env.installed_capacity_in_year,
+                            new_plant_capacity_in_year=bus.env.new_plant_capacity_in_year,
+                            most_common_reductant_by_tech=bus.env.most_common_reductant_by_tech,
+                            get_co2_headroom=bus.env.get_co2_headroom,
+                            get_co2_need_by_name=bus.env.get_co2_need_by_name,
+                            co2_storage_diagnostics=bus.env.co2_storage_diagnostics,
+                        )
+                    ) is not None:
+                        logger.info(f"[PAM] FG {fg.furnace_group_id} strategy returned command: {type(cmd).__name__}")
+                        if isinstance(cmd, ChangeFurnaceGroupTechnology):
+                            # Technology switch: operate with old technology during construction period
+                            # After construction_time years, switch to new technology
+                            command_to_execute = ChangeFurnaceGroupStatusToSwitchingTechnology(
+                                plant_id=cmd.plant_id,
+                                furnace_group_id=cmd.furnace_group_id,
+                                year_of_switch=bus.env.year + bus.env.config.construction_time,
+                                cmd=cmd,
+                            )
+                            product_opt = bus.env.technology_to_product.get(cmd.technology_name)
+                            if product_opt is None:
+                                raise ValueError(f"Technology {cmd.technology_name} not found in technology_to_product")
+                            tech_product: str = product_opt
+                            logger.info(
+                                f"[PAM] EXECUTING {type(command_to_execute).__name__} - Future command: {cmd}, Tech: {cmd.technology_name}, Product: {tech_product}, Capacity: {cmd.capacity * T_TO_KT:,.0f} kt"
+                            )
+                            counter += 1
+                            bus.handle(command_to_execute)
+                        else:
+                            # Execute other commands (e.g., CloseFurnaceGroup, RenovateFurnaceGroup)
+                            logger.info(f"[PAM] EXECUTING {type(cmd).__name__}")
+                            counter += 1
+                            bus.handle(cmd)
 
         plant_eval_elapsed = time.time() - plant_eval_start
         logger.info(
@@ -898,8 +912,7 @@ class PlantAgentsModel:
 
             # Aggregate financial balance across all plants in the group
             # This is used to determine if the plant group can afford expansion
-            pg.collect_total_plant_balance()
-            logger.debug(f"[PAM] Plant group total balance: ${pg.total_balance:,.2f}")
+            logger.debug(f"[PAM] Plant group balance: ${pg.balance:,.2f}")
             # Evaluate expansion by comparing NPV of adding a new furnace group to status quo
             if (
                 cmd := pg.evaluate_expansion(

--- a/src/steelo/service_layer/checkpoint.py
+++ b/src/steelo/service_layer/checkpoint.py
@@ -222,6 +222,10 @@ class SimulationCheckpoint:
     def _serialize_repository(self, uow: UnitOfWork) -> dict:
         """
         Serialize repository state using JsonRepository export functionality.
+
+        Plant group entries carry exactly three fields — ``plant_group_id``, ``plants``
+        (list of plant ids), and ``balance``. The restore path is not yet wired;
+        ``LoadCheckpoint`` is tracked separately.
         """
         # Use the JsonRepository's export functionality if available
         # Otherwise, manually serialize domain objects
@@ -235,6 +239,14 @@ class SimulationCheckpoint:
             ],
             "suppliers": [
                 s.to_dict() if hasattr(s, "to_dict") else s.__dict__ for s in uow.repository.suppliers.list()
+            ],
+            "plant_groups": [
+                {
+                    "plant_group_id": pg.plant_group_id,
+                    "plants": [p.plant_id for p in pg.plants],
+                    "balance": pg.balance,
+                }
+                for pg in uow.repository.plant_groups.list()
             ],
             # Add other repository collections as needed
         }

--- a/src/steelo/service_layer/handlers.py
+++ b/src/steelo/service_layer/handlers.py
@@ -205,7 +205,6 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
           per-(plant, tech) pre-filter in ``evaluate_expansion_options``; the debit here
           is bookkeeping, not a fresh check.
     """
-    logger = logging.getLogger(f"{__name__}.add_furnace_group_to_plant")
     with uow:
         plant = uow.plants.get(cmd.plant_id)
         # TODO(3h): BOM uses plant.energy_costs (last FG's subsidised costs), not the new
@@ -246,16 +245,7 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
         # Debit the group treasury AFTER the furnace has been attached — factory exceptions
         # leave no phantom debit on the wallet.
         plant_group = uow.plant_groups.get_by_plant_id(cmd.plant_id)
-        balance_before = plant_group.balance
         plant_group.deduct_equity(cmd.equity_needed, reason="expansion")
-        logger.info(
-            "[EXPANSION DEBIT] plant_id=%s plant_group_id=%s equity_needed=%.2f balance_before=%.2f balance_after=%.2f",
-            cmd.plant_id,
-            plant_group.plant_group_id,
-            cmd.equity_needed,
-            balance_before,
-            plant_group.balance,
-        )
 
         plant.furnace_group_added(
             new_furnace.furnace_group_id,
@@ -647,15 +637,12 @@ def add_new_business_opportunities_to_repository(cmd: commands.AddNewBusinessOpp
         plants, and it populates the plant-group reverse-lookup map used
         elsewhere in the service layer.
     """
-    routing_logger = logging.getLogger(f"{__name__}.add_new_business_opportunities_to_repository")
     with uow:
         uow.plants.add_list(cmd.new_plants)
         for plant in cmd.new_plants:
-            iso3 = plant.location.iso3
-            target_gid = f"indi_{iso3}"
+            target_gid = f"indi_{plant.location.iso3}"
             plant.parent_gem_id = target_gid
             uow.plant_groups.register_plant_in_group(plant, target_gid)
-            routing_logger.info(f"[INDI ROUTING] plant_id={plant.plant_id} iso3={iso3} group_id={target_gid}")
         uow.commit()
 
 
@@ -672,7 +659,6 @@ def update_status_of_furnace_group(cmd: commands.UpdateFurnaceGroupStatus, uow: 
     Note: Subsidies are updated each year while the plant is under consideration or announced - and
     locked in at construction start time.
     """
-    status_logger = logging.getLogger(f"{__name__}.update_status_of_furnace_group")
     year = env.year
     with uow:
         plant = uow.plants.get(cmd.plant_id)
@@ -695,13 +681,6 @@ def update_status_of_furnace_group(cmd: commands.UpdateFurnaceGroupStatus, uow: 
 
                     # New plants start at 0% utilization, will be ramped up by trade module
                     fg.utilization_rate = 0.0
-
-                    status_logger.info(
-                        "[CONSTRUCTION NO-DEBIT] plant_id=%s fg_id=%s iso3=%s (no-debit, external financing)",
-                        plant.plant_id,
-                        fg.furnace_group_id,
-                        iso3,
-                    )
 
                     # announced -> construction: convert the FG's reserved slot into a firm commitment.
                     need = env.get_co2_need(fg.technology, fg.capacity, fg.chosen_reductant)

--- a/src/steelo/service_layer/handlers.py
+++ b/src/steelo/service_layer/handlers.py
@@ -589,10 +589,35 @@ def finalise_iteration(
 
 def add_new_business_opportunities_to_repository(cmd: commands.AddNewBusinessOpportunities, uow: UnitOfWork):
     """
-    Adds business opportunities to the indi plant group with status "considered".
+    Add runtime-born business opportunities to the plant repository and route
+    each plant into its per-country ``indi_<ISO3>`` plant group at birth.
+
+    Each plant's ``parent_gem_id`` is overwritten from the placeholder
+    ``"indi"`` value set by ``PlantGroup.generate_new_plant`` to the
+    per-country group id (``indi_<ISO3>``) before the plant is registered
+    via ``register_plant_in_group``, which creates the group on demand.
+
+    Args:
+        cmd: Command carrying the list of new plants to register.
+        uow: Unit-of-work providing access to the plant and plant-group
+            repositories.
+
+    Notes:
+        Plants are registered through ``register_plant_in_group`` only —
+        ``PlantGroup.generate_new_plant`` no longer appends to any group's
+        plant list. This is the sole registration path for runtime-born
+        plants, and it populates the plant-group reverse-lookup map used
+        elsewhere in the service layer.
     """
+    routing_logger = logging.getLogger(f"{__name__}.add_new_business_opportunities_to_repository")
     with uow:
         uow.plants.add_list(cmd.new_plants)
+        for plant in cmd.new_plants:
+            iso3 = plant.location.iso3
+            target_gid = f"indi_{iso3}"
+            plant.parent_gem_id = target_gid
+            uow.plant_groups.register_plant_in_group(plant, target_gid)
+            routing_logger.info(f"[INDI ROUTING] plant_id={plant.plant_id} iso3={iso3} group_id={target_gid}")
         uow.commit()
 
 

--- a/src/steelo/service_layer/handlers.py
+++ b/src/steelo/service_layer/handlers.py
@@ -171,17 +171,21 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
     """
     Handle the AddFurnaceGroup command to add a new furnace group to an existing plant.
 
-    Retrieves the plant from the repository, generates a new furnace with the specified technology and capacity,
-    applies subsidies, and adds it to the plant as an expansion. The new furnace starts in construction status
-    with zero utilization.
+    Retrieves the plant from the repository, generates a new furnace with the specified
+    technology and capacity, applies subsidies, attaches it to the plant as an expansion,
+    and debits the plant group treasury for the equity portion of the investment.
+
+    Order is load-bearing: (1) factory → (2) attach to plant → (3) debit. If the factory
+    raises (e.g. missing tech metadata), no phantom debit remains on the group wallet.
 
     Args:
-        cmd (commands.AddFurnaceGroup): Command containing furnace_group_id, plant_id, technology_name, capacity,
-            product, equity_needed, npv, financial parameters (capex, capex_no_subsidy, cost_of_debt,
+        cmd (commands.AddFurnaceGroup): Command containing furnace_group_id, plant_id,
+            technology_name, capacity, product, equity_needed (capex × capacity × equity_share),
+            npv, financial parameters (capex, capex_no_subsidy, cost_of_debt,
             cost_of_debt_no_subsidy), and subsidy lists (capex_subsidies, debt_subsidies).
         uow (UnitOfWork): Unit of work for managing the transaction and accessing repositories.
-        env (Environment): Environment containing the simulation configuration, current year, dynamic_feedstocks data,
-            and bill of materials information.
+        env (Environment): Environment containing the simulation configuration, current year,
+            dynamic_feedstocks data, and bill of materials information.
 
     Side Effects:
         - Creates a new furnace group in construction status with zero utilization.
@@ -189,6 +193,7 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
         - Sets applied_subsidies["debt"] to the debt_subsidies list from the command.
         - Adds the furnace group to the plant.
         - Increments the plant's added_capacity counter.
+        - Debits ``plant_group.balance`` by ``cmd.equity_needed`` via ``deduct_equity``.
         - Logs a FurnaceGroupAdded event.
         - Commits the changes to the repository.
 
@@ -196,7 +201,11 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
         - Both subsidized (capex, cost_of_debt) and non-subsidized (capex_no_subsidy, cost_of_debt_no_subsidy)
           financial parameters are passed to enable tracking of subsidy impact.
         - The subsidy lists are stored in the furnace's applied_subsidies dictionary for later reference.
+        - Affordability was already gated at Stage 6 of ``evaluate_expansion`` and at the
+          per-(plant, tech) pre-filter in ``evaluate_expansion_options``; the debit here
+          is bookkeeping, not a fresh check.
     """
+    logger = logging.getLogger(f"{__name__}.add_furnace_group_to_plant")
     with uow:
         plant = uow.plants.get(cmd.plant_id)
         # TODO(3h): BOM uses plant.energy_costs (last FG's subsidised costs), not the new
@@ -224,7 +233,6 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
                 cmd.technology_name,
                 env.dynamic_feedstocks.get(cmd.technology_name.lower(), []),
             ),
-            equity_needed=cmd.equity_needed,
             bill_of_materials=avg_bom_result[0],
             chosen_reductant=avg_bom_result[2],
             disposal_cost_outputs=env.config.disposal_cost_outputs,
@@ -234,6 +242,21 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
         new_furnace.applied_subsidies["debt"] = cmd.debt_subsidies
         plant.add_furnace_group(new_furnace)
         plant.added_capacity = Volumes(plant.added_capacity + cmd.capacity)
+
+        # Debit the group treasury AFTER the furnace has been attached — factory exceptions
+        # leave no phantom debit on the wallet.
+        plant_group = uow.plant_groups.get_by_plant_id(cmd.plant_id)
+        balance_before = plant_group.balance
+        plant_group.deduct_equity(cmd.equity_needed, reason="expansion")
+        logger.info(
+            "[EXPANSION DEBIT] plant_id=%s plant_group_id=%s equity_needed=%.2f balance_before=%.2f balance_after=%.2f",
+            cmd.plant_id,
+            plant_group.plant_group_id,
+            cmd.equity_needed,
+            balance_before,
+            plant_group.balance,
+        )
+
         plant.furnace_group_added(
             new_furnace.furnace_group_id,
             cmd.plant_id,
@@ -355,8 +378,7 @@ def finalise_iteration(
        a. Update current year in lifetime tracking
        b. Execute scheduled technology switches if the future_switch_year matches current year
        c. Handle end-of-life transitions: close operating furnaces or switch to construction mode for technology switches
-       d. Reset balance for the next iteration
-       e. Update OPEX subsidies based on active subsidies for the current year
+       d. Update OPEX subsidies based on active subsidies for the current year
 
     Note: Construction → operating transition happens in simulation.py at the START of each year iteration,
     before AllocationModel runs. This ensures newly operational plants get their BOMs populated by the trade
@@ -384,7 +406,6 @@ def finalise_iteration(
         - Updates furnace group statuses (construction → operating, operating → closed, etc.).
         - Executes scheduled technology switches when future_switch_year matches current year.
         - Updates furnace group applied OPEX subsidies for the current year.
-        - Resets furnace group balances to zero.
         - Updates supplier production costs based on material costs.
         - Resets capacity tracking counters in env.
         - Updates CAPEX reduction ratios, CAPEX values, input costs, technology availability, and grid emissivity.
@@ -485,10 +506,7 @@ def finalise_iteration(
                             time_frame=TimeFrame(start=year_start, end=year_end),
                         )
 
-                # Step 3e: Reset balance for the next iteration
-                fg.balance = 0
-
-                # Step 3f: Update OPEX subsidies based on active subsidies for the current year
+                # Step 3e: Update OPEX subsidies based on active subsidies for the current year
                 all_opex_subsidies = env.opex_subsidies.get(plant.location.iso3, {}).get(fg.technology.name, [])
                 active_opex_subsidies = filter_subsidies_for_year(all_opex_subsidies, env.year)
                 fg.applied_subsidies["opex"] = active_opex_subsidies
@@ -623,13 +641,18 @@ def add_new_business_opportunities_to_repository(cmd: commands.AddNewBusinessOpp
 
 def update_status_of_furnace_group(cmd: commands.UpdateFurnaceGroupStatus, uow: UnitOfWork, env: Environment):
     """
-    Updates the status of a furnace group. If the furnace group is moved into construction, it also sets the start year,
-    resets the utilization rate to 0 (so that the trade module can ramp it up over time), subtracts the equity needed, and
-    triggers FurnaceGroupAdded event to ensure proper (capacity) tracking.
+    Updates the status of a furnace group. If the furnace group is moved into construction, it also
+    sets the start year, resets the utilization rate to 0 (so that the trade module can ramp it up
+    over time), and triggers a FurnaceGroupAdded event to ensure proper capacity tracking.
 
-    Note: Subsidies are updated each year while the plant is under consideration or announced - and locked in at
-    construction start time.
+    New-plant construction does NOT debit any treasury. The 20% equity is external investor money
+    outside the simulated ledger; the 80% debt is amortised via operational P&L once the plant is
+    running. This transition is explicitly a no-debit event.
+
+    Note: Subsidies are updated each year while the plant is under consideration or announced - and
+    locked in at construction start time.
     """
+    status_logger = logging.getLogger(f"{__name__}.update_status_of_furnace_group")
     year = env.year
     with uow:
         plant = uow.plants.get(cmd.plant_id)
@@ -653,13 +676,12 @@ def update_status_of_furnace_group(cmd: commands.UpdateFurnaceGroupStatus, uow: 
                     # New plants start at 0% utilization, will be ramped up by trade module
                     fg.utilization_rate = 0.0
 
-                    # Subtract equity needed from balance
-                    capex = fg.technology.capex if fg.technology.capex is not None else 0.0
-                    if capex == 0.0:
-                        logger.warning(
-                            f"FG {fg.furnace_group_id} in new plant {plant.plant_id} has no CAPEX set, cannot deduce equity from balance."
-                        )
-                    fg.balance -= env.config.equity_share * capex
+                    status_logger.info(
+                        "[CONSTRUCTION NO-DEBIT] plant_id=%s fg_id=%s iso3=%s (no-debit, external financing)",
+                        plant.plant_id,
+                        fg.furnace_group_id,
+                        iso3,
+                    )
 
                     # announced -> construction: convert the FG's reserved slot into a firm commitment.
                     need = env.get_co2_need(fg.technology, fg.capacity, fg.chosen_reductant)

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -911,91 +911,100 @@ class Progress:
 
 
 def _seed_opening_balances(
-    plants: list,
+    plant_groups: list,
     env: Any,
     multiplier: float,
     active_statuses: list[str],
 ) -> None:
-    """Seed Plant.balance for initial plants to represent pre-simulation capital.
+    """Seed ``PlantGroup.balance`` for initial groups to represent pre-simulation capital.
+
+    Aggregates the per-FG renovation-share-based opening across every plant in a group,
+    then assigns the sum to ``pg.balance`` once per group. Indi_<iso3> groups created at
+    runtime from greenfield routing are absent from the bootstrap input and therefore
+    carry no seed here — they start at ``0.0`` and accrue from operational P&L.
 
     Args:
-        plants: All plants loaded from input data.
+        plant_groups: All plant groups loaded from input data.
         env: Environment with CAPEX and renovation share data.
-        multiplier: Fraction of renovation cost to seed. 0.0 = disabled, 1.0 = full.
+        multiplier: Fraction of renovation cost to seed. ``0.0`` = disabled, ``1.0`` = full.
         active_statuses: FG statuses eligible for inclusion.
     """
     seed_logger = logging.getLogger(f"{__name__}._seed_opening_balances")
     iso3_to_region = env.country_mappings.iso3_to_region()
     active_lower = [s.lower() for s in active_statuses]
 
-    for plant in plants:
-        plant_opening = 0.0
-        for fg in plant.furnace_groups:
-            if (
-                fg.created_by_PAM
-                or fg.capacity == 0
-                or fg.status.lower() not in active_lower
-                or fg.technology.name.lower() == "other"
-            ):
-                continue
+    for pg in plant_groups:
+        group_opening = 0.0
+        num_fgs_seeded = 0
+        for plant in pg.plants:
+            for fg in plant.furnace_groups:
+                if (
+                    fg.created_by_PAM
+                    or fg.capacity == 0
+                    or fg.status.lower() not in active_lower
+                    or fg.technology.name.lower() == "other"
+                ):
+                    continue
 
-            region = iso3_to_region.get(plant.location.iso3)
-            if region is None:
-                seed_logger.warning(
-                    "[OPENING BALANCE] No region mapping for %s, skipping FG %s",
-                    plant.location.iso3,
+                region = iso3_to_region.get(plant.location.iso3)
+                if region is None:
+                    seed_logger.warning(
+                        "[OPENING BALANCE] No region mapping for %s, skipping FG %s",
+                        plant.location.iso3,
+                        fg.furnace_group_id,
+                    )
+                    continue
+
+                greenfield_capex = (
+                    env.name_to_capex.get(
+                        "greenfield",
+                        {},
+                    )
+                    .get(region, {})
+                    .get(fg.technology.name)
+                )
+                if greenfield_capex is None:
+                    seed_logger.warning(
+                        "[OPENING BALANCE] No greenfield CAPEX for %s in %s, skipping FG %s",
+                        fg.technology.name,
+                        region,
+                        fg.furnace_group_id,
+                    )
+                    continue
+
+                renovation_share = env.capex_renovation_share.get(fg.technology.name)
+                if renovation_share is None:
+                    seed_logger.warning(
+                        "[OPENING BALANCE] No renovation share for %s, skipping FG %s",
+                        fg.technology.name,
+                        fg.furnace_group_id,
+                    )
+                    continue
+
+                renovation_cost = greenfield_capex * renovation_share * fg.capacity * fg.equity_share
+                opening = renovation_cost * multiplier
+                group_opening += opening
+                num_fgs_seeded += 1
+
+                seed_logger.debug(
+                    "[OPENING BALANCE] FG %s (%s): $%s (CAPEX=$%s/t x share=%.2f x cap=%st x equity=%.2f x mult=%s)",
                     fg.furnace_group_id,
-                )
-                continue
-
-            greenfield_capex = (
-                env.name_to_capex.get(
-                    "greenfield",
-                    {},
-                )
-                .get(region, {})
-                .get(fg.technology.name)
-            )
-            if greenfield_capex is None:
-                seed_logger.warning(
-                    "[OPENING BALANCE] No greenfield CAPEX for %s in %s, skipping FG %s",
                     fg.technology.name,
-                    region,
-                    fg.furnace_group_id,
+                    f"{opening:,.2f}",
+                    f"{greenfield_capex:,.2f}",
+                    renovation_share,
+                    f"{fg.capacity:,.0f}",
+                    fg.equity_share,
+                    multiplier,
                 )
-                continue
 
-            renovation_share = env.capex_renovation_share.get(fg.technology.name)
-            if renovation_share is None:
-                seed_logger.warning(
-                    "[OPENING BALANCE] No renovation share for %s, skipping FG %s",
-                    fg.technology.name,
-                    fg.furnace_group_id,
-                )
-                continue
-
-            renovation_cost = greenfield_capex * renovation_share * fg.capacity * fg.equity_share
-            opening = renovation_cost * multiplier
-            plant_opening += opening
-
-            seed_logger.debug(
-                "[OPENING BALANCE] FG %s (%s): $%s (CAPEX=$%s/t x share=%.2f x cap=%st x equity=%.2f x mult=%s)",
-                fg.furnace_group_id,
-                fg.technology.name,
-                f"{opening:,.2f}",
-                f"{greenfield_capex:,.2f}",
-                renovation_share,
-                f"{fg.capacity:,.0f}",
-                fg.equity_share,
-                multiplier,
-            )
-
-        plant.balance = plant_opening
-        if plant_opening > 0:
+        pg.balance = group_opening
+        if group_opening > 0:
             seed_logger.info(
-                "[OPENING BALANCE] Plant %s: $%s",
-                plant.plant_id,
-                f"{plant_opening:,.2f}",
+                "[OPENING BALANCE] Group %s num_fgs_seeded=%d total_opening=%.2f",
+                pg.plant_group_id,
+                num_fgs_seeded,
+                group_opening,
             )
 
 
@@ -1073,10 +1082,10 @@ class SimulationRunner:
             new_plant_group = PlantGroup(plant_group_id=pg_id, plants=plants)
             bus.uow.plant_groups.add(new_plant_group)
 
-        # Seed opening balances for initial plants
+        # Seed opening balances for initial plant groups
         if self.config.opening_balance_multiplier > 0:
             _seed_opening_balances(
-                plants=bus.uow.plants.list(),
+                plant_groups=bus.uow.plant_groups.list(),
                 env=bus.env,
                 multiplier=self.config.opening_balance_multiplier,
                 active_statuses=self.config.active_statuses,
@@ -1125,18 +1134,19 @@ class SimulationRunner:
             # Year-start baseline scan: rebuild CO2 storage counters (firm/reserved) before Allocation/PAM/GEO.
             bus.env.scan_co2_storage_counters(bus.uow)
 
-            # Log plant balance distribution in early years for opening balance verification
+            # Log plant group balance distribution in early years for opening balance verification
             if i <= start_year + 4:
-                balances = [p.balance for p in bus.uow.plants.list()]
-                logger.debug(
-                    "[OPENING BALANCE] Year %d plant balances: min=$%s, max=$%s, mean=$%s, positive=%d/%d",
-                    i,
-                    f"{min(balances):,.0f}",
-                    f"{max(balances):,.0f}",
-                    f"{sum(balances) / len(balances):,.0f}",
-                    sum(1 for b in balances if b > 0),
-                    len(balances),
-                )
+                balances = [pg.balance for pg in bus.uow.plant_groups.list()]
+                if balances:
+                    logger.debug(
+                        "[OPENING BALANCE] Year %d group balances: min=$%s, max=$%s, mean=$%s, positive=%d/%d",
+                        i,
+                        f"{min(balances):,.0f}",
+                        f"{max(balances):,.0f}",
+                        f"{sum(balances) / len(balances):,.0f}",
+                        sum(1 for b in balances if b > 0),
+                        len(balances),
+                    )
 
             # Set demand and plant costs for the year
             bus.env.calculate_demand()

--- a/tests/integration/test_expansion_with_capex_subsidies.py
+++ b/tests/integration/test_expansion_with_capex_subsidies.py
@@ -24,7 +24,6 @@ def plant_with_location():
     )
     plant = get_plant(furnace_groups=[fg], plant_id="plant_test")
     plant.location.iso3 = "USA"
-    plant.balance = 1_000_000.0  # Sufficient to afford expansion (capacity=1000, max capex=600/t)
     return plant
 
 
@@ -112,6 +111,7 @@ def test_evaluate_expansion_without_subsidies(
     bus.uow.plants.add(plant_with_location)
 
     pg = PlantGroup(plant_group_id="pg_test", plants=[plant_with_location])
+    pg.balance = 1_000_000.0  # Sufficient to afford expansion (capacity=1000, max capex=600/t)
     bus.uow.plant_groups.add(pg)
 
     # Mock get_bom_from_avg_boms
@@ -180,6 +180,7 @@ def test_evaluate_expansion_with_absolute_capex_subsidy(
     bus.uow.plants.add(plant_with_location)
 
     pg = PlantGroup(plant_group_id="pg_test", plants=[plant_with_location])
+    pg.balance = 1_000_000.0  # Sufficient to afford expansion (capacity=1000, max capex=600/t)
     bus.uow.plant_groups.add(pg)
 
     # Mock get_bom_from_avg_boms
@@ -263,6 +264,7 @@ def test_evaluate_expansion_with_relative_capex_subsidy(
     bus.uow.plants.add(plant_with_location)
 
     pg = PlantGroup(plant_group_id="pg_test", plants=[plant_with_location])
+    pg.balance = 1_000_000.0  # Sufficient to afford expansion (capacity=1000, max capex=600/t)
     bus.uow.plant_groups.add(pg)
 
     # Mock get_bom_from_avg_boms
@@ -343,6 +345,7 @@ def test_evaluate_expansion_with_combined_subsidies(
     bus.uow.plants.add(plant_with_location)
 
     pg = PlantGroup(plant_group_id="pg_test", plants=[plant_with_location])
+    pg.balance = 1_000_000.0  # Sufficient to afford expansion (capacity=1000, max capex=600/t)
     bus.uow.plant_groups.add(pg)
 
     # Mock get_bom_from_avg_boms with higher NPV for BOF to ensure it's selected
@@ -446,6 +449,7 @@ def test_evaluate_expansion_with_restricted_allowed_techs(
     bus.uow.plants.add(plant_with_location)
 
     pg = PlantGroup(plant_group_id="pg_test", plants=[plant_with_location])
+    pg.balance = 1_000_000.0  # Sufficient to afford expansion (capacity=1000, max capex=600/t)
     bus.uow.plant_groups.add(pg)
 
     # Mock get_bom_from_avg_boms to make DRI and BF more attractive

--- a/tests/integration/test_furnace_strategy_allowed_techs.py
+++ b/tests/integration/test_furnace_strategy_allowed_techs.py
@@ -6,7 +6,7 @@ from functools import partial
 
 from steelo.devdata import get_furnace_group, get_plant
 from steelo.domain import PointInTime, Year, TimeFrame, Volumes
-from steelo.domain.models import CountryMapping, CountryMappingService
+from steelo.domain.models import CountryMapping, CountryMappingService, PlantGroup
 from steelo.domain.commands import ChangeFurnaceGroupTechnology, RenovateFurnaceGroup
 from steelo.simulation_types import get_default_technology_settings
 
@@ -27,8 +27,14 @@ def plant_with_eaf():
     )
     plant = get_plant(furnace_groups=[fg], plant_id="plant_test_eaf")
     plant.location.iso3 = "USA"
-    plant.balance = 1000000  # Positive balance to allow investments
     return plant
+
+
+@pytest.fixture
+def plant_group_with_eaf(plant_with_eaf):
+    pg = PlantGroup(plant_group_id="gem_test_eaf", plants=[plant_with_eaf])
+    pg.balance = 1_000_000  # Positive balance to allow investments
+    return pg
 
 
 @pytest.fixture
@@ -47,8 +53,14 @@ def plant_with_bof():
     )
     plant = get_plant(furnace_groups=[fg], plant_id="plant_test_bof")
     plant.location.iso3 = "USA"
-    plant.balance = 1000000  # Positive balance to allow investments
     return plant
+
+
+@pytest.fixture
+def plant_group_with_bof(plant_with_bof):
+    pg = PlantGroup(plant_group_id="gem_test_bof", plants=[plant_with_bof])
+    pg.balance = 1_000_000  # Positive balance to allow investments
+    return pg
 
 
 @pytest.fixture
@@ -114,7 +126,7 @@ def mock_environment(bus, country_mappings_for_test, tmp_path):
     return bus
 
 
-def test_technology_switching_respects_allowed_techs(mock_environment, plant_with_eaf, mocker):
+def test_technology_switching_respects_allowed_techs(mock_environment, plant_with_eaf, plant_group_with_eaf, mocker):
     """Test that technology switching only happens to allowed technologies."""
     bus = mock_environment
     bus.uow.plants.add(plant_with_eaf)
@@ -217,6 +229,7 @@ def test_technology_switching_respects_allowed_techs(mock_environment, plant_wit
     # Evaluate strategy with DRI not allowed
     command = plant_with_eaf.evaluate_furnace_group_strategy(
         furnace_group_id=furnace_group.furnace_group_id,
+        plant_group=plant_group_with_eaf,
         market_price_series=market_price_series,
         region_capex=bus.env.name_to_capex["greenfield"]["Americas"],
         capex_renovation_share={"EAF": 0.7, "BOF": 0.7, "DRI": 0.7, "BF": 0.7},
@@ -264,7 +277,8 @@ def test_technology_switching_respects_allowed_techs(mock_environment, plant_wit
     )
     plant_with_eaf2 = get_plant(furnace_groups=[fg2], plant_id="plant_test_eaf2")
     plant_with_eaf2.location.iso3 = "USA"
-    plant_with_eaf2.balance = 1000000
+    plant_group_with_eaf2 = PlantGroup(plant_group_id="gem_test_eaf2", plants=[plant_with_eaf2])
+    plant_group_with_eaf2.balance = 1_000_000
     plant_with_eaf2.technology_unit_fopex = {"EAF": 50.0, "BOF": 60.0, "DRI": 70.0, "BF": 65.0}
     plant_with_eaf2.carbon_cost_series = [0.0] * 22
 
@@ -277,6 +291,7 @@ def test_technology_switching_respects_allowed_techs(mock_environment, plant_wit
 
     command_all = plant_with_eaf2.evaluate_furnace_group_strategy(
         furnace_group_id=furnace_group2.furnace_group_id,
+        plant_group=plant_group_with_eaf2,
         market_price_series=market_price_series,
         region_capex=bus.env.name_to_capex["greenfield"]["Americas"],
         capex_renovation_share={"EAF": 0.7, "BOF": 0.7, "DRI": 0.7, "BF": 0.7},
@@ -313,7 +328,7 @@ def test_technology_switching_respects_allowed_techs(mock_environment, plant_wit
             )
 
 
-def test_renovation_respects_allowed_techs(mock_environment, plant_with_bof, mocker):
+def test_renovation_respects_allowed_techs(mock_environment, plant_with_bof, plant_group_with_bof, mocker):
     """Test that renovation only happens for allowed technologies."""
     bus = mock_environment
     bus.uow.plants.add(plant_with_bof)
@@ -373,6 +388,7 @@ def test_renovation_respects_allowed_techs(mock_environment, plant_with_bof, moc
     allowed_techs_no_bof = {Year(year): ["EAF", "DRI", "BF"] for year in range(2020, 2031)}
 
     command_no_bof = plant_with_bof.evaluate_furnace_group_strategy(
+        plant_group=plant_group_with_bof,
         furnace_group_id=furnace_group.furnace_group_id,
         market_price_series=market_price_series,
         region_capex=bus.env.name_to_capex["greenfield"]["Americas"],
@@ -409,6 +425,7 @@ def test_renovation_respects_allowed_techs(mock_environment, plant_with_bof, moc
 
     command_with_bof = plant_with_bof.evaluate_furnace_group_strategy(
         furnace_group_id=furnace_group.furnace_group_id,
+        plant_group=plant_group_with_bof,
         market_price_series=market_price_series,
         region_capex=bus.env.name_to_capex["greenfield"]["Americas"],
         capex_renovation_share={"EAF": 0.7, "BOF": 0.7, "DRI": 0.7, "BF": 0.7},
@@ -438,7 +455,7 @@ def test_renovation_respects_allowed_techs(mock_environment, plant_with_bof, moc
             assert furnace_group.technology.name == "BOF", "Should only renovate if staying with BOF"
 
 
-def test_no_action_when_no_techs_allowed(mock_environment, plant_with_eaf, mocker):
+def test_no_action_when_no_techs_allowed(mock_environment, plant_with_eaf, plant_group_with_eaf, mocker):
     """Test that a ValueError is raised when no technologies are allowed for the current year."""
     bus = mock_environment
     bus.uow.plants.add(plant_with_eaf)
@@ -459,6 +476,7 @@ def test_no_action_when_no_techs_allowed(mock_environment, plant_with_eaf, mocke
     with pytest.raises(ValueError, match=r"\[FG STRATEGY\] No allowed techs in 2025"):
         plant_with_eaf.evaluate_furnace_group_strategy(
             furnace_group_id=furnace_group.furnace_group_id,
+            plant_group=plant_group_with_eaf,
             market_price_series=market_price_series,
             region_capex=bus.env.name_to_capex["greenfield"]["Americas"],
             capex_renovation_share={"EAF": 0.7, "BOF": 0.7, "DRI": 0.7, "BF": 0.7},

--- a/tests/integration/test_profit_updating_and_furnace_expansion.py
+++ b/tests/integration/test_profit_updating_and_furnace_expansion.py
@@ -186,6 +186,12 @@ def test_furnace_group_balance_sheet_updates(bus, mutliple_plants, mocker, count
     for p in mutliple_plants:
         bus.uow.plants.add(p)
 
+    # Wrap all plants in one group so PAM Step 4 can sweep them (post-Stage-2 restructure).
+    from steelo.domain.models import PlantGroup as _PG
+
+    pg_all = _PG(plant_group_id="pg_all", plants=mutliple_plants)
+    bus.uow.plant_groups.add(pg_all)
+
     # Initialize proper capex structure for test environment - would come from initiate capex
     # Get the regions that are actually used by the test plants
     test_iso3_codes = [p.location.iso3 for p in mutliple_plants]
@@ -266,21 +272,24 @@ def test_furnace_group_balance_sheet_updates(bus, mutliple_plants, mocker, count
         "steelo.domain.models.Plant.evaluate_furnace_group_strategy", return_value=None
     )  # Just avoid the furnace evalation right now
 
-    # Mock the balance reset to preserve furnace group balances for testing
-    def mock_update_balance(self, market_price, active_statuses):
-        for fg in self.furnace_groups:
-            if (
-                fg.capacity == 0
-                or fg.status.lower() not in [s.lower() for s in active_statuses]
-                or fg.technology.name.lower() == "other"
-                or fg.technology.product.lower() not in market_price
-            ):
-                continue
-            fg.update_balance_sheet(market_price[fg.technology.product.lower()])
-            self.balance += fg.balance
-            # Don't reset fg.balance to 0 for testing purposes
+    # Mock the sweep to preserve furnace group balances for testing (don't zero fg.balance).
+    def mock_sweep(self, market_price, active_statuses):
+        for plant in self.plants:
+            for fg in plant.furnace_groups:
+                if (
+                    fg.capacity == 0
+                    or fg.status.lower() not in [s.lower() for s in active_statuses]
+                    or fg.technology.name.lower() == "other"
+                    or fg.technology.product.lower() not in market_price
+                ):
+                    continue
+                fg.update_balance_sheet(market_price[fg.technology.product.lower()])
+                self.balance += fg.balance
+                # Don't reset fg.balance to 0 for testing purposes
 
-    mocker.patch.object(bus.uow.plants.list()[0].__class__, "update_furnace_and_plant_balance", mock_update_balance)
+    mocker.patch.object(_PG, "sweep_fg_balances_to_group", mock_sweep)
+    # PAM Step 5 expansion eval is orthogonal to the sweep we're testing; stub it out.
+    mocker.patch.object(_PG, "evaluate_expansion", return_value=None)
 
     # When the simulation is run
     Simulation(bus=bus, economic_model=PlantAgentsModel()).run_simulation()
@@ -324,6 +333,7 @@ def test_total_plant_group_balance_sheet(bus, mutliple_plants, mocker, country_m
         bus.uow.plants.add(p)
 
     pg = PlantGroup(plant_group_id="pg_1", plants=mutliple_plants)
+    bus.uow.plant_groups.add(pg)
 
     # Initialize proper capex structure for test environment
     # Get the regions that are actually used by the test plants
@@ -399,29 +409,30 @@ def test_total_plant_group_balance_sheet(bus, mutliple_plants, mocker, country_m
         "steelo.domain.models.Plant.evaluate_furnace_group_strategy", return_value=None
     )  # Just avoid the furnace evalation right now
 
-    # Mock the balance reset to preserve furnace group balances for testing
-    def mock_update_balance(self, market_price, active_statuses):
-        for fg in self.furnace_groups:
-            if (
-                fg.capacity == 0
-                or fg.status.lower() not in [s.lower() for s in active_statuses]
-                or fg.technology.name.lower() == "other"
-                or fg.technology.product.lower() not in market_price
-            ):
-                continue
-            fg.update_balance_sheet(market_price[fg.technology.product.lower()])
-            self.balance += fg.balance
-            # Don't reset fg.balance to 0 for testing purposes
+    # Mock the group sweep to preserve fg.balance so we can assert the sum on pg.balance.
+    def mock_sweep(self, market_price, active_statuses):
+        for plant in self.plants:
+            for fg in plant.furnace_groups:
+                if (
+                    fg.capacity == 0
+                    or fg.status.lower() not in [s.lower() for s in active_statuses]
+                    or fg.technology.name.lower() == "other"
+                    or fg.technology.product.lower() not in market_price
+                ):
+                    continue
+                fg.update_balance_sheet(market_price[fg.technology.product.lower()])
+                self.balance += fg.balance
+                # Don't reset fg.balance to 0 for testing purposes
 
-    mocker.patch.object(bus.uow.plants.list()[0].__class__, "update_furnace_and_plant_balance", mock_update_balance)
+    mocker.patch.object(PlantGroup, "sweep_fg_balances_to_group", mock_sweep)
+    # PAM Step 5 expansion eval is orthogonal to the sweep we're testing.
+    mocker.patch.object(PlantGroup, "evaluate_expansion", return_value=None)
 
     # When the simulation is run
     Simulation(bus=bus, economic_model=PlantAgentsModel()).run_simulation()
 
-    # Based on production being 70 and market value being 100, the following should be the
-    # furnace balances after one iteration
-    pg.collect_total_plant_balance()
-    assert pg.total_balance == sum(
+    # Group balance equals the sum of furnace P&Ls under the mocked sweep.
+    assert pg.balance == sum(
         [
             280,
             -140,

--- a/tests/integration/test_simulation_service.py
+++ b/tests/integration/test_simulation_service.py
@@ -258,6 +258,11 @@ def test_simulation_service_with_plant_agent_events(
     if not hasattr(bus.env, "industrial_cost_of_debt") or not bus.env.industrial_cost_of_debt:
         bus.env.industrial_cost_of_debt = {"DEU": 0.04}
 
+    # Provide per-country unit FOPEX so PlantGroup.evaluate_expansion_options finds data for DEU.
+    # Lookup in the domain code is case-insensitive (``.get(tech.lower())``) — keys are lowercased.
+    if not hasattr(bus.env, "fopex_by_country") or not bus.env.fopex_by_country:
+        bus.env.fopex_by_country = {"DEU": {tech: 50.0 for tech in ["bf", "bof", "eaf", "dri"]}}
+
     # Set allowed transitions for all technologies (overwrite fixture defaults)
     bus.env.allowed_furnace_transitions["BFBOF"] = ["EAF", "BOF", "BFBOF"]  # Can switch to other steel techs
     bus.env.allowed_furnace_transitions["EAF"] = ["BOF", "EAF"]  # EAF can switch to BOF
@@ -268,9 +273,16 @@ def test_simulation_service_with_plant_agent_events(
     assert Year(2025) in allowed_techs_dict, f"Year 2025 not in allowed_techs: {list(allowed_techs_dict.keys())}"
     assert allowed_techs_dict[Year(2025)], f"No allowed techs for 2025: {allowed_techs_dict}"
 
-    # Ensure positive plant balance for technology switches and renovations
+    # Ensure positive plant group balance for technology switches and renovations
     # With 64kt capacity and $400/t capex, renovation cost is about $10M (64000 * 400 * 0.4)
-    plant.balance = 50000000.0  # $50M balance to afford technology switches and renovations
+    from steelo.domain.models import PlantGroup
+
+    plant_group = PlantGroup(plant_group_id="sim_test_pg", plants=[plant])
+    plant_group.balance = 50_000_000.0  # $50M balance for switches/renovations
+    bus.uow.plant_groups.add(plant_group)
+    # PAM Step 5 expansion eval is orthogonal to these events; stub it out so the minimal
+    # test environment doesn't need full BOM/FOPEX data for every tech.
+    mocker.patch.object(plant_group, "evaluate_expansion", return_value=None)
 
     # Initialize test environment with proper economic data for NPV calculations
     from steelo.domain.models import PrimaryFeedstock
@@ -641,9 +653,15 @@ def test_simulation_service_with_multiple_plant_furnaces(bus, logged_events, mul
         }
     # Given a plant with mutiple furnace groups
     plant = get_plant(furnace_groups=multi_furnace_groups)
-    # Set positive balance to afford renovations and technology switches
-    plant.balance = 50000000.0  # $50M balance
     bus.uow.plants.add(plant)
+    # Set positive group balance to afford renovations and technology switches
+    from steelo.domain.models import PlantGroup
+
+    plant_group = PlantGroup(plant_group_id="multi_fg_pg", plants=[plant])
+    plant_group.balance = 50_000_000.0  # $50M balance
+    bus.uow.plant_groups.add(plant_group)
+    # PAM Step 5 expansion eval is orthogonal to these events; stub it out.
+    mocker.patch.object(plant_group, "evaluate_expansion", return_value=None)
 
     # Ensure config is set for this test
     if bus.env.config is None:
@@ -702,12 +720,12 @@ def test_simulation_service_with_multiple_plant_furnaces(bus, logged_events, mul
         bus.env.name_to_capex["default"] = bus.env.name_to_capex["greenfield"].copy()
 
     # Initialize missing dynamic_feedstocks to prevent KeyError
-    technologies = ["BF", "BOF", "EAF", "DRI", "SR", "MoE", "ESF", "CCUS", "Prep Sinter", "BFBOF"]
+    technologies = ["BF", "BOF", "EAF", "DRI", "SR", "MOE", "ESF"]
     if not hasattr(bus.env, "dynamic_feedstocks") or not bus.env.dynamic_feedstocks:
         bus.env.dynamic_feedstocks = {tech: [] for tech in technologies}
 
     # Set allowed transitions for all technologies (overwrite fixture defaults)
-    bus.env.allowed_furnace_transitions["BFBOF"] = ["EAF", "BOF", "BFBOF"]  # Can switch to other steel techs
+    bus.env.allowed_furnace_transitions["BF"] = ["BF", "DRI"]  # BF can switch to DRI
     bus.env.allowed_furnace_transitions["EAF"] = ["BOF", "EAF"]  # EAF can switch to BOF
 
     # Initialize industrial_cost_of_debt for DEU
@@ -717,6 +735,10 @@ def test_simulation_service_with_multiple_plant_furnaces(bus, logged_events, mul
     # Initialize industrial_cost_of_equity for DEU
     if not hasattr(bus.env, "industrial_cost_of_equity") or not bus.env.industrial_cost_of_equity:
         bus.env.industrial_cost_of_equity = {"DEU": 0.08}
+
+    # Provide per-country unit FOPEX for PlantGroup.evaluate_expansion_options.
+    if not hasattr(bus.env, "fopex_by_country") or not bus.env.fopex_by_country:
+        bus.env.fopex_by_country = {"DEU": {tech: 50.0 for tech in ["bf", "bof", "eaf", "dri"]}}
 
     # Initialize virgin_iron_demand for PlantAgentsModel
     from steelo.domain.models import VirginIronDemand
@@ -729,18 +751,18 @@ def test_simulation_service_with_multiple_plant_furnaces(bus, logged_events, mul
     # For test hardcode the demand first
     bus.env.current_demand = 150
 
-    # Mock optimal_technology_name for all EAF furnace groups to prevent COSA calculation issues
-    # This test is focused on the simulation running successfully with multiple furnaces
+    # Mock optimal_technology_name for every furnace group to prevent COSA/avg_boms lookups
+    # in the test's minimal environment. This test is focused on the simulation running
+    # successfully with multiple furnaces, not on the specific technology-choice economics.
+    # (Pre-Stage-2, the negative-plant-balance gate masked these calls; now Stage 1 runs always.)
     for fg in multi_furnace_groups:
-        if fg.technology.name == "EAF":
-            # Return a mock that keeps the current technology optimal
-            mock_return = (
-                {fg.technology.name: 300000.0},  # Positive NPV for current tech
-                {fg.technology.name: 400},  # Capex
-                0.0,  # No COSA
-                {fg.technology.name: {}},  # BOM
-            )
-            mocker.patch.object(fg, "optimal_technology_name", return_value=mock_return)
+        mock_return = (
+            {fg.technology.name: 300000.0},  # Positive NPV for current tech
+            {fg.technology.name: 400},  # Capex
+            0.0,  # No COSA
+            {fg.technology.name: {}},  # BOM
+        )
+        mocker.patch.object(fg, "optimal_technology_name", return_value=mock_return)
 
     # When the simulation is run
     Simulation(bus=bus, economic_model=PlantAgentsModel()).run_simulation()

--- a/tests/unit/test_add_new_business_opportunities_handler.py
+++ b/tests/unit/test_add_new_business_opportunities_handler.py
@@ -1,0 +1,120 @@
+"""
+Tests for ``add_new_business_opportunities_to_repository``.
+
+Verifies that runtime-born plants are routed into per-country ``indi_<ISO3>``
+groups at birth (not into the master ``"indi"`` group), that
+``plant.parent_gem_id`` is updated to match the chosen group, and that
+``PlantGroup.generate_new_plant`` no longer appends the plant to its own
+``plants`` list (sole registration happens via the handler).
+"""
+
+from steelo.adapters.repositories.in_memory_repository import InMemoryRepository
+from steelo.domain import commands
+from steelo.domain.models import Location, Plant, PlantGroup
+from steelo.service_layer.handlers import add_new_business_opportunities_to_repository
+from steelo.service_layer.unit_of_work import UnitOfWork
+
+
+def _make_plant(plant_id: str, iso3: str) -> Plant:
+    """Minimal Plant carrying the placeholder ``parent_gem_id="indi"`` set by generate_new_plant."""
+    return Plant(
+        plant_id=plant_id,
+        location=Location(lat=0.0, lon=0.0, country=iso3, region="unknown", iso3=iso3),
+        furnace_groups=[],
+        power_source="grid",
+        soe_status="private",
+        parent_gem_id="indi",
+        workforce_size=500,
+        certified=False,
+        category_steel_product=set(),
+        technology_unit_fopex={},
+    )
+
+
+def _make_uow_with_master_indi() -> UnitOfWork:
+    """UoW seeded with an empty master ``indi`` plant group (matches boot-time state)."""
+    uow = UnitOfWork(InMemoryRepository())
+    uow.plant_groups.add(PlantGroup(plant_group_id="indi", plants=[]))
+    return uow
+
+
+def test_new_plant_lands_in_per_country_indi_group():
+    """
+    Handler routes a runtime-born plant into ``indi_<ISO3>`` at birth and
+    leaves the master ``"indi"`` group empty.
+    """
+    uow = _make_uow_with_master_indi()
+    plant = _make_plant("P1", iso3="CHN")
+    cmd = commands.AddNewBusinessOpportunities(new_plants=[plant])
+
+    add_new_business_opportunities_to_repository(cmd, uow)
+
+    assert plant in uow.plant_groups.get("indi_CHN").plants
+    assert plant not in uow.plant_groups.get("indi").plants
+    assert uow.plant_groups.get("indi").plants == []
+
+
+def test_parent_gem_id_matches_repo_reverse_lookup():
+    """
+    After routing, ``plant.parent_gem_id`` is overwritten to ``indi_<ISO3>``
+    and the repository reverse-lookup resolves to the same group.
+    """
+    uow = _make_uow_with_master_indi()
+    plant = _make_plant("P1", iso3="AUS")
+    cmd = commands.AddNewBusinessOpportunities(new_plants=[plant])
+
+    add_new_business_opportunities_to_repository(cmd, uow)
+
+    assert plant.parent_gem_id == "indi_AUS"
+    assert uow.plant_groups.get_by_plant_id("P1").plant_group_id == "indi_AUS"
+
+
+def test_multiple_iso3_each_routes_to_own_group():
+    """
+    Plants across different ISO3 countries each land in the correct
+    per-country group in a single handler invocation.
+    """
+    uow = _make_uow_with_master_indi()
+    plant_chn = _make_plant("P1", iso3="CHN")
+    plant_aus = _make_plant("P2", iso3="AUS")
+    plant_sau = _make_plant("P3", iso3="SAU")
+    cmd = commands.AddNewBusinessOpportunities(new_plants=[plant_chn, plant_aus, plant_sau])
+
+    add_new_business_opportunities_to_repository(cmd, uow)
+
+    assert uow.plant_groups.get("indi_CHN").plants == [plant_chn]
+    assert uow.plant_groups.get("indi_AUS").plants == [plant_aus]
+    assert uow.plant_groups.get("indi_SAU").plants == [plant_sau]
+    assert uow.plant_groups.get("indi").plants == []
+
+
+def test_second_plant_in_same_iso3_reuses_group_and_stays_in_seen():
+    """
+    A second plant sharing an ISO3 with an earlier registration goes into
+    the existing per-country group; ``seen`` still contains the group so
+    the UoW sees it as changed for this turn.
+    """
+    uow = _make_uow_with_master_indi()
+    plant_a = _make_plant("P1", iso3="CHN")
+    plant_b = _make_plant("P2", iso3="CHN")
+    cmd = commands.AddNewBusinessOpportunities(new_plants=[plant_a, plant_b])
+
+    add_new_business_opportunities_to_repository(cmd, uow)
+
+    chn_group = uow.plant_groups.get("indi_CHN")
+    assert chn_group.plants == [plant_a, plant_b]
+    assert chn_group in uow.plant_groups.seen
+
+
+def test_generate_new_plant_does_not_append_to_group_plants():
+    """
+    ``PlantGroup.generate_new_plant`` no longer mutates the group's
+    ``plants`` list — registration is the handler's responsibility.
+    Source-level regression check: the body must not contain
+    ``self.plants.append``, otherwise runtime plants would be double-
+    registered (once inside the factory, once via the handler).
+    """
+    import inspect
+
+    source = inspect.getsource(PlantGroup.generate_new_plant)
+    assert "self.plants.append" not in source

--- a/tests/unit/test_co2_storage_p2_gate.py
+++ b/tests/unit/test_co2_storage_p2_gate.py
@@ -21,6 +21,7 @@ from steelo.domain.models import (
     FurnaceGroup,
     Location,
     Plant,
+    PlantGroup,
     PointInTime,
     PrimaryFeedstock,
     Technology,
@@ -78,8 +79,14 @@ def _make_plant(iso3: str = "USA") -> Plant:
         steel_capacity=Volumes(1000),
         technology_unit_fopex={},
     )
-    p.balance = 1e15
     return p
+
+
+def _make_plant_and_group(iso3: str = "USA") -> tuple[Plant, "PlantGroup"]:
+    p = _make_plant(iso3=iso3)
+    pg = PlantGroup(plant_group_id="parent", plants=[p])
+    pg.balance = 1e15
+    return p, pg
 
 
 def _build_stubs(
@@ -114,11 +121,16 @@ def _call_evaluate(
     co2_storage_diagnostics,
     most_common_reductant_by_tech: dict[str, str] | None = None,
     current_year: Year = Year(2030),
+    plant_group: PlantGroup | None = None,
 ):
     region_capex = {tech: 500.0 for tech in allowed_techs_list + [plant.furnace_groups[0].technology.name]}
+    if plant_group is None:
+        plant_group = PlantGroup(plant_group_id="parent", plants=[plant])
+        plant_group.balance = 1e15
 
     return plant.evaluate_furnace_group_strategy(
         "fg1",
+        plant_group=plant_group,
         market_price_series={"steel": [500.0] * 30, "hot_metal": [500.0] * 30, "iron": [500.0] * 30},
         region_capex=region_capex,
         capex_renovation_share={},

--- a/tests/unit/test_co2_storage_p3_gate.py
+++ b/tests/unit/test_co2_storage_p3_gate.py
@@ -55,7 +55,7 @@ def _make_fg(tech: Technology, capacity: float = 1000.0) -> FurnaceGroup:
 
 
 def _make_plant(plant_id: str, iso3: str, balance: float = 1e15) -> Plant:
-    """Balance is intentionally huge so the 'cannot afford' skip at line 5006 never fires."""
+    """Balance is intentionally huge so the affordability pre-filter never fires (seeded on the group)."""
     tech = _make_ccs_tech("BF")
     fg = _make_fg(tech)
     fg.set_energy_costs(electricity=0.05, coke=0.1)
@@ -72,12 +72,13 @@ def _make_plant(plant_id: str, iso3: str, balance: float = 1e15) -> Plant:
         steel_capacity=Volumes(1000),
         technology_unit_fopex={},
     )
-    p.balance = balance
     return p
 
 
-def _make_pg(plants: list[Plant]) -> PlantGroup:
-    return PlantGroup(plant_group_id="pg1", plants=plants)
+def _make_pg(plants: list[Plant], balance: float = 1e15) -> PlantGroup:
+    pg = PlantGroup(plant_group_id="pg1", plants=plants)
+    pg.balance = balance
+    return pg
 
 
 def _build_stubs(
@@ -302,7 +303,6 @@ def test_p3_pg_local_reductant_overrides_env_reductant():
         steel_capacity=Volumes(1000),
         technology_unit_fopex={},
     )
-    plant.balance = 1e15
     pg = _make_pg([plant])
 
     captured_reductants: list[str] = []

--- a/tests/unit/test_deduct_equity.py
+++ b/tests/unit/test_deduct_equity.py
@@ -1,0 +1,53 @@
+"""Unit tests for PlantGroup.deduct_equity — the sole capex-debit mutation site."""
+
+import logging
+
+import pytest
+
+from steelo.domain.models import PlantGroup
+
+
+def _make_pg(balance: float = 0.0, gid: str = "pg1") -> PlantGroup:
+    pg = PlantGroup(plant_group_id=gid, plants=[])
+    pg.balance = balance
+    return pg
+
+
+def test_deduct_equity_decreases_balance_by_amount():
+    """Calling deduct_equity reduces pg.balance by exactly amount."""
+    pg = _make_pg(balance=1_000_000.0)
+    pg.deduct_equity(250_000.0, reason="renovation")
+    assert pg.balance == pytest.approx(750_000.0)
+
+
+def test_deduct_equity_reason_has_no_behavioural_effect():
+    """The reason argument is a trace label — it does not change the numeric outcome."""
+    pg_a = _make_pg(balance=500.0)
+    pg_b = _make_pg(balance=500.0)
+    pg_a.deduct_equity(100.0, reason="renovation")
+    pg_b.deduct_equity(100.0, reason="switch")
+    assert pg_a.balance == pg_b.balance
+
+
+def test_deduct_equity_allows_negative_balance():
+    """Affordability is checked at call sites; deduct_equity itself does not gate."""
+    pg = _make_pg(balance=100.0)
+    pg.deduct_equity(500.0, reason="expansion")
+    assert pg.balance == pytest.approx(-400.0)
+
+
+def test_deduct_equity_emits_structured_log(caplog):
+    """[DEDUCT EQUITY] log line carries reason, amount, plant_group_id, before/after."""
+    pg = _make_pg(balance=1_000.0, gid="group_alpha")
+
+    caplog.set_level(logging.INFO, logger="steelo.domain.models.deduct_equity")
+    pg.deduct_equity(400.0, reason="switch")
+
+    msgs = [r.getMessage() for r in caplog.records if "[DEDUCT EQUITY]" in r.getMessage()]
+    assert len(msgs) == 1
+    msg = msgs[0]
+    assert "reason=switch" in msg
+    assert "amount=400.00" in msg
+    assert "plant_group_id=group_alpha" in msg
+    assert "balance_before=1000.00" in msg
+    assert "balance_after=600.00" in msg

--- a/tests/unit/test_energy_subsidies.py
+++ b/tests/unit/test_energy_subsidies.py
@@ -602,7 +602,6 @@ def test_generate_new_furnace_path_a_sets_all_three_dicts():
         lag=2,
         status="considered",
         util_rate=0.0,
-        equity_needed=0.0,
         plant_lifetime=20,
         chosen_reductant="hydrogen",
         energy_costs=input_costs,
@@ -637,7 +636,6 @@ def test_generate_new_furnace_path_b_copies_parent_costs():
         lag=2,
         status="construction",
         util_rate=0.0,
-        equity_needed=0.0,
         plant_lifetime=20,
         chosen_reductant="hydrogen",
     )
@@ -667,7 +665,6 @@ def test_generate_new_furnace_normalises_negative_physical_carriers():
         lag=2,
         status="considered",
         util_rate=0.0,
-        equity_needed=0.0,
         plant_lifetime=20,
         chosen_reductant="hydrogen",
         energy_costs={"bf_gas": -0.02, "hydrogen": 5000.0},

--- a/tests/unit/test_identify_new_business_opportunities_4indi.py
+++ b/tests/unit/test_identify_new_business_opportunities_4indi.py
@@ -974,8 +974,13 @@ class TestGenerateNewPlant:
         # FurnaceGroup uses default equity_share of 0.2 (not the 0.3 passed to generate_new_plant)
         assert furnace.equity_share == 0.2
 
-    def test_adds_plant_to_plant_group(self, plant_group, cost_data):
-        """Test that the new plant is added to the plant group's plants list."""
+    def test_does_not_add_plant_to_plant_group(self, plant_group, cost_data):
+        """
+        ``generate_new_plant`` is a pure factory: it does not append the new
+        plant to the group's ``plants`` list. Registration is performed by
+        ``add_new_business_opportunities_to_repository`` via
+        ``PlantGroupRepository.register_plant_in_group``.
+        """
         site_id = (40.0, -100.0, "USA")
 
         assert len(plant_group.plants) == 0
@@ -994,7 +999,7 @@ class TestGenerateNewPlant:
             plant_lifetime=30,
         )
 
-        assert len(plant_group.plants) == 1
+        assert len(plant_group.plants) == 0
 
     def test_sets_technology_unit_fopex(self, plant_group, cost_data):
         """Test that technology_unit_fopex is set correctly with lowercase technology name."""

--- a/tests/unit/test_opening_balance.py
+++ b/tests/unit/test_opening_balance.py
@@ -8,6 +8,7 @@ from steelo.domain.models import (
     FurnaceGroup,
     Location,
     Plant,
+    PlantGroup,
     PointInTime,
     ProductCategory,
     Technology,
@@ -73,6 +74,11 @@ def _make_plant(
     )
 
 
+def _make_pg(plants: list[Plant], plant_group_id: str = "gem-1") -> PlantGroup:
+    """Wrap plants in a PlantGroup so the seeder can run group-first."""
+    return PlantGroup(plant_group_id=plant_group_id, plants=plants)
+
+
 def _make_env(
     greenfield_capex: dict | None = None,
     renovation_share: dict | None = None,
@@ -101,31 +107,33 @@ def _make_env(
 # ---------------------------------------------------------------------------
 
 
-def test_single_fg_balance_calculation():
-    """Plant balance = greenfield_capex * renovation_share * capacity * equity_share * multiplier."""
+def test_single_fg_group_balance_calculation():
+    """Group balance = greenfield_capex * renovation_share * capacity * equity_share * multiplier."""
     fg = _make_fg(capacity=1_000_000.0, equity_share=0.2)
     plant = _make_plant(furnace_groups=[fg])
+    pg = _make_pg([plant])
     env = _make_env()
 
-    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
     # 800 * 0.45 * 1_000_000 * 0.2 * 1.0 = 72_000_000
     expected = 800.0 * 0.45 * 1_000_000.0 * 0.2 * 1.0
-    assert plant.balance == pytest.approx(expected)
+    assert pg.balance == pytest.approx(expected)
 
 
 def test_multi_fg_plant_sums_all():
-    """Plant balance is the sum across all eligible FGs."""
+    """Group balance aggregates across all eligible FGs of all plants in the group."""
     fg1 = _make_fg(fg_id="fg-1", tech_name="BF", capacity=500_000.0)
     fg2 = _make_fg(fg_id="fg-2", tech_name="EAF", capacity=300_000.0, product="steel")
     plant = _make_plant(furnace_groups=[fg1, fg2])
+    pg = _make_pg([plant])
     env = _make_env()
 
-    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
     bf_cost = 800.0 * 0.45 * 500_000.0 * 0.2
     eaf_cost = 600.0 * 0.35 * 300_000.0 * 0.2
-    assert plant.balance == pytest.approx(bf_cost + eaf_cost)
+    assert pg.balance == pytest.approx(bf_cost + eaf_cost)
 
 
 def test_multiplier_scales_balance():
@@ -135,31 +143,34 @@ def test_multiplier_scales_balance():
 
     for mult in [0.5, 1.0, 2.0]:
         plant = _make_plant(furnace_groups=[fg])
-        _seed_opening_balances([plant], env, multiplier=mult, active_statuses=ACTIVE_STATUSES)
+        pg = _make_pg([plant])
+        _seed_opening_balances([pg], env, multiplier=mult, active_statuses=ACTIVE_STATUSES)
         expected = 800.0 * 0.45 * 1_000_000.0 * 0.2 * mult
-        assert plant.balance == pytest.approx(expected), f"Failed for multiplier={mult}"
+        assert pg.balance == pytest.approx(expected), f"Failed for multiplier={mult}"
 
 
 def test_multiplier_zero_disables_seeding():
     """Multiplier of 0.0 results in zero balance."""
     fg = _make_fg(capacity=1_000_000.0)
     plant = _make_plant(furnace_groups=[fg])
+    pg = _make_pg([plant])
     env = _make_env()
 
-    _seed_opening_balances([plant], env, multiplier=0.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=0.0, active_statuses=ACTIVE_STATUSES)
 
-    assert plant.balance == 0.0
+    assert pg.balance == 0.0
 
 
 def test_skip_created_by_pam():
     """FGs created by PAM are excluded from opening balance."""
     fg = _make_fg(created_by_PAM=True, capacity=1_000_000.0)
     plant = _make_plant(furnace_groups=[fg])
+    pg = _make_pg([plant])
     env = _make_env()
 
-    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
-    assert plant.balance == 0.0
+    assert pg.balance == 0.0
 
 
 def test_skip_inactive_status():
@@ -167,47 +178,51 @@ def test_skip_inactive_status():
     for status in ["announced", "construction", "closed", "discarded"]:
         fg = _make_fg(status=status)
         plant = _make_plant(furnace_groups=[fg])
+        pg = _make_pg([plant])
         env = _make_env()
 
-        _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+        _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
-        assert plant.balance == 0.0, f"Expected 0 for status={status}"
+        assert pg.balance == 0.0, f"Expected 0 for status={status}"
 
 
 def test_skip_zero_capacity():
     """FGs with zero capacity are excluded."""
     fg = _make_fg(capacity=0.0)
     plant = _make_plant(furnace_groups=[fg])
+    pg = _make_pg([plant])
     env = _make_env()
 
-    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
-    assert plant.balance == 0.0
+    assert pg.balance == 0.0
 
 
 def test_skip_other_technology():
     """FGs with 'other' technology are excluded."""
     fg = _make_fg(tech_name="other")
     plant = _make_plant(furnace_groups=[fg])
+    pg = _make_pg([plant])
     env = _make_env(
         greenfield_capex={"Europe": {"other": 500.0}},
         renovation_share={"other": 0.3},
     )
 
-    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
-    assert plant.balance == 0.0
+    assert pg.balance == 0.0
 
 
 def test_skip_missing_region_mapping(caplog):
     """FGs whose plant ISO3 has no region mapping are skipped with warning."""
     fg = _make_fg(capacity=1_000_000.0)
     plant = _make_plant(iso3="ZZZ", furnace_groups=[fg])
+    pg = _make_pg([plant])
     env = _make_env(iso3_to_region={"DEU": "Europe"})  # ZZZ not mapped
 
-    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
-    assert plant.balance == 0.0
+    assert pg.balance == 0.0
     assert "No region mapping for ZZZ" in caplog.text
 
 
@@ -215,14 +230,15 @@ def test_skip_missing_greenfield_capex(caplog):
     """FGs whose tech has no greenfield CAPEX in the region are skipped with warning."""
     fg = _make_fg(tech_name="DRI", capacity=1_000_000.0)
     plant = _make_plant(furnace_groups=[fg])
+    pg = _make_pg([plant])
     env = _make_env(
         greenfield_capex={"Europe": {"BF": 800.0}},  # no DRI
         renovation_share={"DRI": 0.4},
     )
 
-    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
-    assert plant.balance == 0.0
+    assert pg.balance == 0.0
     assert "No greenfield CAPEX for DRI" in caplog.text
 
 
@@ -230,14 +246,15 @@ def test_skip_missing_renovation_share(caplog):
     """FGs whose tech has no renovation share are skipped with warning."""
     fg = _make_fg(tech_name="BF", capacity=1_000_000.0)
     plant = _make_plant(furnace_groups=[fg])
+    pg = _make_pg([plant])
     env = _make_env(
         greenfield_capex={"Europe": {"BF": 800.0}},
         renovation_share={},  # empty
     )
 
-    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
-    assert plant.balance == 0.0
+    assert pg.balance == 0.0
     assert "No renovation share for BF" in caplog.text
 
 
@@ -250,53 +267,93 @@ def test_mixed_eligible_and_ineligible_fgs():
     inactive = _make_fg(fg_id="fg-closed", status="closed")
 
     plant = _make_plant(furnace_groups=[eligible, pam_created, zero_cap, other_tech, inactive])
+    pg = _make_pg([plant])
     env = _make_env(
         greenfield_capex={"Europe": {"BF": 800.0, "other": 500.0}},
         renovation_share={"BF": 0.45, "other": 0.3},
     )
 
-    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
     expected = 800.0 * 0.45 * 1_000_000.0 * 0.2
-    assert plant.balance == pytest.approx(expected)
+    assert pg.balance == pytest.approx(expected)
 
 
 def test_active_statuses_case_insensitive():
     """Status matching is case-insensitive."""
     fg = _make_fg(status="Operating", capacity=1_000_000.0)
     plant = _make_plant(furnace_groups=[fg])
+    pg = _make_pg([plant])
     env = _make_env()
 
-    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
-    assert plant.balance > 0
+    assert pg.balance > 0
 
 
 def test_historic_balance_untouched():
     """FG.historic_balance is not modified by seeding."""
     fg = _make_fg(capacity=1_000_000.0)
     plant = _make_plant(furnace_groups=[fg])
+    pg = _make_pg([plant])
     env = _make_env()
 
-    _seed_opening_balances([plant], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
     assert fg.historic_balance == 0.0
 
 
-def test_multiple_plants():
-    """Each plant gets its own independent opening balance."""
+def test_multiple_plants_in_single_group():
+    """Plants sharing a group contribute to a single group balance."""
     fg1 = _make_fg(fg_id="fg-1", capacity=1_000_000.0)
     fg2 = _make_fg(fg_id="fg-2", capacity=500_000.0)
     plant1 = _make_plant(plant_id="p1", furnace_groups=[fg1])
     plant2 = _make_plant(plant_id="p2", furnace_groups=[fg2])
+    pg = _make_pg([plant1, plant2])
     env = _make_env()
 
-    _seed_opening_balances([plant1, plant2], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    expected_fg1 = 800.0 * 0.45 * 1_000_000.0 * 0.2
+    expected_fg2 = 800.0 * 0.45 * 500_000.0 * 0.2
+    assert pg.balance == pytest.approx(expected_fg1 + expected_fg2)
+
+
+def test_multiple_groups_are_independent():
+    """Each group gets its own independent opening balance."""
+    fg1 = _make_fg(fg_id="fg-1", capacity=1_000_000.0)
+    fg2 = _make_fg(fg_id="fg-2", capacity=500_000.0)
+    plant1 = _make_plant(plant_id="p1", furnace_groups=[fg1])
+    plant2 = _make_plant(plant_id="p2", furnace_groups=[fg2])
+    pg1 = _make_pg([plant1], plant_group_id="gem-A")
+    pg2 = _make_pg([plant2], plant_group_id="gem-B")
+    env = _make_env()
+
+    _seed_opening_balances([pg1, pg2], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
 
     expected1 = 800.0 * 0.45 * 1_000_000.0 * 0.2
     expected2 = 800.0 * 0.45 * 500_000.0 * 0.2
-    assert plant1.balance == pytest.approx(expected1)
-    assert plant2.balance == pytest.approx(expected2)
+    assert pg1.balance == pytest.approx(expected1)
+    assert pg2.balance == pytest.approx(expected2)
+
+
+def test_opening_balance_log_fires_once_per_group(caplog):
+    """The [OPENING BALANCE] Group log entry fires once per group with a positive opening."""
+    import logging as _logging
+
+    fg1 = _make_fg(fg_id="fg-1", capacity=1_000_000.0)
+    fg2 = _make_fg(fg_id="fg-2", capacity=500_000.0)
+    plant1 = _make_plant(plant_id="p1", furnace_groups=[fg1])
+    plant2 = _make_plant(plant_id="p2", furnace_groups=[fg2])
+    pg = _make_pg([plant1, plant2], plant_group_id="gem-multi")
+    env = _make_env()
+
+    caplog.set_level(_logging.INFO, logger="steelo.simulation._seed_opening_balances")
+    _seed_opening_balances([pg], env, multiplier=1.0, active_statuses=ACTIVE_STATUSES)
+
+    group_lines = [r for r in caplog.records if "[OPENING BALANCE] Group" in r.getMessage()]
+    assert len(group_lines) == 1
+    assert "gem-multi" in group_lines[0].getMessage()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_plant_group_acceptance_parity.py
+++ b/tests/unit/test_plant_group_acceptance_parity.py
@@ -1,0 +1,37 @@
+"""expansion and switch must produce identical P(accept) for identical (equity, NPV)."""
+
+import math
+
+
+def test_expansion_and_switch_probability_formulas_match():
+    """For identical (equity_needed, npv), both paths yield the same acceptance probability."""
+    # Equity needed (capex × capacity × equity_share) and NPV (equity-basis) are the inputs
+    # that should fully determine P(accept) under both flows.
+    equity_needed = 800.0 * 2_000_000.0 * 0.2  # $320M equity at 2Mt × $800/t × 20%
+    npv = 500_000_000.0  # $500M equity-basis NPV
+
+    # Expansion (post-Stage-2 formula in PlantGroup.evaluate_expansion Stage 7).
+    expansion_p = math.exp(-equity_needed / npv)
+
+    # Switch (unchanged — Plant.evaluate_furnace_group_strategy Stage 10).
+    # switch_cost is exactly equity_needed when the inputs match.
+    switch_p = math.exp(-equity_needed / npv)
+
+    assert expansion_p == switch_p
+    # Sanity: at equity=0.2 × full CAPEX, ratio ≈ 0.64 → P ≈ 0.527 (Behavioural diff #6).
+    assert 0.4 < expansion_p < 0.7
+
+
+def test_pre_spec_expansion_formula_was_substantially_lower():
+    """Document the pre-fix gap: full-capex formula gave a much lower P than the corrected one."""
+    full_investment = 800.0 * 2_000_000.0  # $1.6B full CAPEX
+    equity_needed = full_investment * 0.2
+    npv = 500_000_000.0
+
+    pre_fix_expansion = math.exp(-full_investment / npv)
+    post_fix_expansion = math.exp(-equity_needed / npv)
+
+    # Behavioural diff #6: ~4% pre-fix → ~53% post-fix for this canonical scenario.
+    assert pre_fix_expansion < 0.1
+    assert post_fix_expansion > 0.5
+    assert post_fix_expansion > pre_fix_expansion * 10

--- a/tests/unit/test_plant_group_balance_construction_path.py
+++ b/tests/unit/test_plant_group_balance_construction_path.py
@@ -109,27 +109,5 @@ def test_announced_to_construction_transition_does_not_debit_group_balance():
     assert fg.status == "construction"
 
 
-def test_construction_no_debit_log_fires(caplog):
-    """The [CONSTRUCTION NO-DEBIT] marker log fires on announced -> construction."""
-    import logging as _logging
-
-    fg = _make_fg("fg-2", capex=500.0)
-    plant = _make_plant(fg)
-    pg = PlantGroup(plant_group_id="indi_DEU", plants=[plant])
-    pg.balance = 1_000_000.0
-    env = _make_env()
-    uow = _make_uow(plant, pg)
-
-    caplog.set_level(_logging.INFO, logger="steelo.service_layer.handlers.update_status_of_furnace_group")
-    cmd = commands.UpdateFurnaceGroupStatus(
-        plant_id=plant.plant_id, fg_id=fg.furnace_group_id, new_status="construction"
-    )
-    update_status_of_furnace_group(cmd, uow, env)
-
-    msgs = [r.getMessage() for r in caplog.records if "[CONSTRUCTION NO-DEBIT]" in r.getMessage()]
-    assert len(msgs) == 1
-    assert "no-debit, external financing" in msgs[0]
-
-
 # Silence unused-import warnings while keeping the import available if tests grow.
 _ = events

--- a/tests/unit/test_plant_group_balance_construction_path.py
+++ b/tests/unit/test_plant_group_balance_construction_path.py
@@ -1,0 +1,135 @@
+"""Regression lock: the announced -> construction transition does not debit.
+
+Before, the ``update_status_of_furnace_group`` handler subtracted
+``env.config.equity_share * capex`` from the FG balance. That debit was dead (the sweep
+immediately resets fg.balance) and semantically misguided — new-plant construction is
+financed externally, outside the simulated treasury. This test locks the removal in: any
+future edit that re-introduces the debit will fail here.
+"""
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from steelo.domain import Year, TimeFrame, PointInTime, Volumes
+from steelo.domain import commands, events
+from steelo.domain.models import (
+    FurnaceGroup,
+    Location,
+    Plant,
+    PlantGroup,
+    ProductCategory,
+    Technology,
+)
+from steelo.service_layer.handlers import update_status_of_furnace_group
+
+
+def _make_fg(fg_id: str, capex: float = 500.0) -> FurnaceGroup:
+    return FurnaceGroup(
+        furnace_group_id=fg_id,
+        capacity=Volumes(1_000_000.0),
+        status="announced",
+        last_renovation_date=date(2020, 1, 1),
+        technology=Technology(name="EAF", product="steel", capex=capex),
+        historical_production={},
+        utilization_rate=0.0,
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2030), end=Year(2050)),
+            plant_lifetime=20,
+        ),
+    )
+
+
+def _make_plant(fg: FurnaceGroup) -> Plant:
+    return Plant(
+        plant_id="plant-new-1",
+        location=Location(lat=0.0, lon=0.0, country="Germany", region="Europe", iso3="DEU"),
+        furnace_groups=[fg],
+        power_source="grid",
+        soe_status="private",
+        parent_gem_id="indi_DEU",
+        workforce_size=50,
+        certified=False,
+        category_steel_product={ProductCategory("Flat")},
+        technology_unit_fopex={"eaf": 50.0},
+    )
+
+
+def _make_env(equity_share: float = 0.2) -> SimpleNamespace:
+    config = SimpleNamespace(
+        equity_share=equity_share,
+        construction_time=2,
+        plant_lifetime=20,
+        co2_storage_reserved_discount_factor=1.0,
+    )
+    return SimpleNamespace(
+        year=Year(2025),
+        config=config,
+        get_co2_need=lambda tech, capacity, reductant: 0.0,
+        co2_storage_firm={},
+        co2_storage_reserved={},
+    )
+
+
+def _make_uow(plant: Plant, pg: PlantGroup):
+    plants_repo = MagicMock()
+    plants_repo.get.return_value = plant
+    uow = MagicMock()
+    uow.__enter__.return_value = uow
+    uow.__exit__.return_value = False
+    uow.plants = plants_repo
+    uow.plant_groups = MagicMock()
+    uow.plant_groups.list.return_value = [pg]
+    return uow
+
+
+def test_announced_to_construction_transition_does_not_debit_group_balance():
+    """Construction transition: pg.balance is unchanged; fg.balance is unchanged."""
+    fg = _make_fg("fg-1", capex=500.0)
+    plant = _make_plant(fg)
+    pg = PlantGroup(plant_group_id="indi_DEU", plants=[plant])
+    pg.balance = 1_000_000.0
+    balance_before = pg.balance
+    fg_balance_before = fg.balance
+
+    env = _make_env(equity_share=0.2)
+    uow = _make_uow(plant, pg)
+
+    cmd = commands.UpdateFurnaceGroupStatus(
+        plant_id=plant.plant_id, fg_id=fg.furnace_group_id, new_status="construction"
+    )
+    update_status_of_furnace_group(cmd, uow, env)
+
+    # No debit to the group treasury — construction is externally financed.
+    assert pg.balance == balance_before
+    # No debit to fg.balance either — the old dead debit targeted fg.balance and was deleted.
+    assert fg.balance == fg_balance_before
+    # Status did transition.
+    assert fg.status == "construction"
+
+
+def test_construction_no_debit_log_fires(caplog):
+    """The [CONSTRUCTION NO-DEBIT] marker log fires on announced -> construction."""
+    import logging as _logging
+
+    fg = _make_fg("fg-2", capex=500.0)
+    plant = _make_plant(fg)
+    pg = PlantGroup(plant_group_id="indi_DEU", plants=[plant])
+    pg.balance = 1_000_000.0
+    env = _make_env()
+    uow = _make_uow(plant, pg)
+
+    caplog.set_level(_logging.INFO, logger="steelo.service_layer.handlers.update_status_of_furnace_group")
+    cmd = commands.UpdateFurnaceGroupStatus(
+        plant_id=plant.plant_id, fg_id=fg.furnace_group_id, new_status="construction"
+    )
+    update_status_of_furnace_group(cmd, uow, env)
+
+    msgs = [r.getMessage() for r in caplog.records if "[CONSTRUCTION NO-DEBIT]" in r.getMessage()]
+    assert len(msgs) == 1
+    assert "no-debit, external financing" in msgs[0]
+
+
+# Silence unused-import warnings while keeping the import available if tests grow.
+_ = events

--- a/tests/unit/test_plant_group_repository_register.py
+++ b/tests/unit/test_plant_group_repository_register.py
@@ -1,0 +1,120 @@
+"""
+Tests for ``PlantGroupRepository.register_plant_in_group``.
+
+Covers get-or-create group, append plant, reverse-map update, unconditional
+``seen`` membership, reverse-lookup for runtime-born plants, and a smoke test
+against the JSON-backed repository for protocol symmetry.
+"""
+
+import tempfile
+from pathlib import Path
+
+from steelo.adapters.repositories.in_memory_repository import (
+    PlantGroupInMemoryRepository,
+)
+from steelo.adapters.repositories.json_repository import PlantGroupJsonRepository
+from steelo.domain.models import Location, Plant, PlantGroup
+
+
+def _make_plant(plant_id: str, iso3: str = "CHN") -> Plant:
+    """Create a minimal Plant suitable for plant-group registration tests."""
+    return Plant(
+        plant_id=plant_id,
+        location=Location(lat=0.0, lon=0.0, country=iso3, region="unknown", iso3=iso3),
+        furnace_groups=[],
+        power_source="grid",
+        soe_status="private",
+        parent_gem_id="indi",
+        workforce_size=500,
+        certified=False,
+        category_steel_product=set(),
+        technology_unit_fopex={},
+    )
+
+
+def test_register_plant_in_existing_group_appends_and_updates_reverse_map():
+    """
+    Registering into an already-present group appends the plant, updates the
+    reverse map, and adds the group to ``seen``.
+    """
+    repo = PlantGroupInMemoryRepository()
+    group = PlantGroup(plant_group_id="indi_CHN", plants=[])
+    repo.add(group)
+    repo.seen.clear()
+    plant = _make_plant("P1", iso3="CHN")
+
+    repo.register_plant_in_group(plant, "indi_CHN")
+
+    assert plant in repo.get("indi_CHN").plants
+    assert repo.plant_id_to_plantgroup_id["P1"] == "indi_CHN"
+    assert group in repo.seen
+
+
+def test_register_plant_creates_group_on_demand():
+    """
+    Registering a plant into a group that does not yet exist creates the
+    group, places the plant in it, and adds it to ``seen``.
+    """
+    repo = PlantGroupInMemoryRepository()
+    plant = _make_plant("P1", iso3="AUS")
+
+    repo.register_plant_in_group(plant, "indi_AUS")
+
+    created = repo.get("indi_AUS")
+    assert created.plant_group_id == "indi_AUS"
+    assert created.plants == [plant]
+    assert repo.plant_id_to_plantgroup_id["P1"] == "indi_AUS"
+    assert created in repo.seen
+
+
+def test_register_plant_re_register_still_adds_group_to_seen():
+    """
+    Dirty-set invariant: re-registering after ``seen`` has been cleared
+    still marks the group as changed in the current UoW turn.
+    """
+    repo = PlantGroupInMemoryRepository()
+    plant_a = _make_plant("P1", iso3="CHN")
+    plant_b = _make_plant("P2", iso3="CHN")
+    repo.register_plant_in_group(plant_a, "indi_CHN")
+    repo.seen.clear()
+
+    repo.register_plant_in_group(plant_b, "indi_CHN")
+
+    group = repo.get("indi_CHN")
+    assert plant_b in group.plants
+    assert group in repo.seen
+
+
+def test_reverse_lookup_works_for_runtime_born_plant():
+    """
+    Regression test for Issue 1 in indi_issue.md: ``get_by_plant_id`` must
+    resolve for plants that were added via ``register_plant_in_group``
+    (not via the bulk ``add`` path).
+    """
+    repo = PlantGroupInMemoryRepository()
+    plant = _make_plant("P1", iso3="SAU")
+
+    repo.register_plant_in_group(plant, "indi_SAU")
+
+    resolved = repo.get_by_plant_id("P1")
+    assert resolved.plant_group_id == "indi_SAU"
+
+
+def test_json_repository_register_plant_round_trip():
+    """
+    Protocol symmetry smoke test: the JSON-backed repository persists a
+    newly-registered plant and mirrors the in-memory ``seen`` semantics.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "plant_groups.json"
+        repo = PlantGroupJsonRepository(path, plant_lifetime=20)
+        plant = _make_plant("P1", iso3="AUS")
+
+        repo.register_plant_in_group(plant, "indi_AUS")
+
+        stored = repo.list()
+        assert any(pg.plant_group_id == "indi_AUS" for pg in stored)
+        stored_aus = next(pg for pg in stored if pg.plant_group_id == "indi_AUS")
+        assert len(stored_aus.plants) == 1
+        assert stored_aus.plants[0].plant_id == "P1"
+        assert any(pg.plant_group_id == "indi_AUS" for pg in repo.seen)

--- a/tests/unit/test_post_process_datacollection.py
+++ b/tests/unit/test_post_process_datacollection.py
@@ -24,7 +24,9 @@ def test_commands_column_included_in_output():
         sample_data_2025 = {
             "plant_001": {
                 "location": "USA",
-                "balance": 1000,
+                "plant_profit_and_loss": 1000,
+                "plant_group_id": "plant_001_group",
+                "plant_group_balance": 1000,
                 "furnace_groups": pd.DataFrame(
                     [
                         {
@@ -39,7 +41,7 @@ def test_commands_column_included_in_output():
                             "unit_fixed_opex": 0.05,
                             "unit_production_cost": 150,
                             "debt_repayment_for_current_year": 10,
-                            "historic_balance": 500,
+                            "furnace_group_profit_and_loss": 500,
                             "emissions_scope1": 2.0,
                             "materials": {"coal": {"demand": 500, "total_cost": 50000, "unit_cost": 100}},
                             "energy": {"electricity": {"demand": 200, "total_cost": 10000, "unit_cost": 50}},
@@ -49,7 +51,9 @@ def test_commands_column_included_in_output():
             },
             "plant_002": {
                 "location": "Germany",
-                "balance": 2000,
+                "plant_profit_and_loss": 2000,
+                "plant_group_id": "plant_002_group",
+                "plant_group_balance": 2000,
                 "furnace_groups": pd.DataFrame(
                     [
                         {
@@ -64,7 +68,7 @@ def test_commands_column_included_in_output():
                             "unit_fixed_opex": 0.05,
                             "unit_production_cost": 150,
                             "debt_repayment_for_current_year": 8,
-                            "historic_balance": 400,
+                            "furnace_group_profit_and_loss": 400,
                             "emissions_scope1": 0.5,
                             "materials": {"scrap": {"demand": 400, "total_cost": 40000, "unit_cost": 100}},
                             "energy": {"electricity": {"demand": 300, "total_cost": 15000, "unit_cost": 50}},
@@ -77,7 +81,9 @@ def test_commands_column_included_in_output():
         sample_data_2026 = {
             "plant_001": {
                 "location": "USA",
-                "balance": 1200,
+                "plant_profit_and_loss": 1200,
+                "plant_group_id": "plant_001_group",
+                "plant_group_balance": 1200,
                 "furnace_groups": pd.DataFrame(
                     [
                         {
@@ -92,7 +98,7 @@ def test_commands_column_included_in_output():
                             "unit_fixed_opex": 0.05,
                             "unit_production_cost": 150,
                             "debt_repayment_for_current_year": 12,
-                            "historic_balance": 600,
+                            "furnace_group_profit_and_loss": 600,
                             "emissions_scope1": 1.0,
                             "materials": {"natural_gas": {"demand": 300, "total_cost": 30000, "unit_cost": 100}},
                             "energy": {"electricity": {"demand": 250, "total_cost": 12500, "unit_cost": 50}},
@@ -102,7 +108,9 @@ def test_commands_column_included_in_output():
             },
             "plant_002": {
                 "location": "Germany",
-                "balance": 2100,
+                "plant_profit_and_loss": 2100,
+                "plant_group_id": "plant_002_group",
+                "plant_group_balance": 2100,
                 "furnace_groups": pd.DataFrame(
                     [
                         {
@@ -117,7 +125,7 @@ def test_commands_column_included_in_output():
                             "unit_fixed_opex": 0.05,
                             "unit_production_cost": 150,
                             "debt_repayment_for_current_year": 9,
-                            "historic_balance": 450,
+                            "furnace_group_profit_and_loss": 450,
                             "emissions_scope1": 0.5,
                             "materials": {"scrap": {"demand": 420, "total_cost": 42000, "unit_cost": 100}},
                             "energy": {"electricity": {"demand": 320, "total_cost": 16000, "unit_cost": 50}},
@@ -208,7 +216,9 @@ def test_feedstock_rows_with_empty_materials_do_not_crash():
         sample_data_2025 = {
             "plant_001": {
                 "location": "USA",
-                "balance": 100,
+                "plant_profit_and_loss": 100,
+                "plant_group_id": "test_group",
+                "plant_group_balance": 100,
                 "furnace_groups": pd.DataFrame(
                     [
                         {
@@ -222,7 +232,7 @@ def test_feedstock_rows_with_empty_materials_do_not_crash():
                             "unit_fopex": 0,
                             "unit_production_cost": 0,
                             "debt_repayment_for_current_year": 0,
-                            "historic_balance": 0,
+                            "furnace_group_profit_and_loss": 0,
                             # The following columns are intentionally all None to mimic empty feedstock data
                             "materials": None,
                             "energy": None,
@@ -257,7 +267,9 @@ def test_commands_column_with_empty_commands_for_year():
         sample_data = {
             "plant_001": {
                 "location": "USA",
-                "balance": 1000,
+                "plant_profit_and_loss": 1000,
+                "plant_group_id": "plant_001_group",
+                "plant_group_balance": 1000,
                 "furnace_groups": pd.DataFrame(
                     [
                         {
@@ -272,7 +284,7 @@ def test_commands_column_with_empty_commands_for_year():
                             "unit_fixed_opex": 0.05,
                             "unit_production_cost": 150,
                             "debt_repayment_for_current_year": 10,
-                            "historic_balance": 500,
+                            "furnace_group_profit_and_loss": 500,
                             "emissions_scope1": 2.0,
                             "materials": {},
                             "energy": {},
@@ -313,7 +325,9 @@ def test_chosen_reductant_values_are_normalized():
         sample_data = {
             "plant_001": {
                 "location": "ARE",
-                "balance": 0,
+                "plant_profit_and_loss": 0,
+                "plant_group_id": "test_group",
+                "plant_group_balance": 0,
                 "furnace_groups": pd.DataFrame(
                     [
                         {
@@ -327,7 +341,7 @@ def test_chosen_reductant_values_are_normalized():
                             "unit_fopex": 0,
                             "unit_production_cost": 0,
                             "debt_repayment_for_current_year": 0,
-                            "historic_balance": 0,
+                            "furnace_group_profit_and_loss": 0,
                             "materials": {"io_low": {"demand": 100, "total_cost": 1000, "unit_cost": 10}},
                             "energy": {},
                         }


### PR DESCRIPTION
Two-stage refactor that makes `PlantGroup` the wallet for capex decisions and routes individually-owned ("indi") plants into per-country groups from birth, replacing the single master `indi` bucket and the per-plant `balance` field.

### Stage 1 — Route new indi plants into per-country groups at birth (b9bac65)

- New `PlantGroupRepository.register_plant_in_group` API (in-memory + JSON); creates `indi_<ISO3>` on demand, populates `plant_id_to_plantgroup_id`, and marks the group as seen.
- `add_new_business_opportunities_to_repository` overwrites the `indi` placeholder to `indi_<ISO3>` and registers the plant via the new API; `PlantGroup.generate_new_plant` no longer appends.
- `GeospatialModel.run` loops dynamic-cost and status updates over every `indi_<ISO3>` group; master `indi` remains the dispatch point for candidate generation only.
- Removed the deferred construction-time routing block.

### Stage 2 — Capex ledger lives on the PlantGroup (d84e1d9)

- `PlantGroup.balance` promoted to a stored ledger (renamed from `total_balance`); `deduct_equity` is now the sole capex-debit mutation site.
- FG balance becomes transient — swept via `PlantGroup.sweep_fg_balances_to_group` and zeroed after each sweep.
- Renovation, switch, and expansion affordability and debits retargeted to `plant_group.balance`; `equity_needed` dropped from `generate_new_furnace`.
- Expansion equity maths fixed (`capex × capacity × equity_share`) and probabilistic-acceptance formula brought in line with switch (equity-basis).
- `Plant.balance` deleted; `Plant.historic_balance` added as a derived property; the Stage 1 negative-plant-balance short-circuit and the dead construction-transition debit removed.
- PAM Step 4 restructured group-first: sweep the group, then evaluate each plant's FG strategies against the post-sweep treasury.
- Opening balances seeded per plant group; `plant_groups` now serialised in checkpoints.
- Datacollector and post-processing columns renamed to the wallet vs P&L convention: `plant_group_id`, `plant_group_balance`, `plant_profit_and_loss`, `furnace_group_profit_and_loss`.