### PR TITLE
cost curve plotting and improved cutoff

### DIFF
--- a/docs/domain_simulation_logic/plant_agent_model/market_price_calculation.md
+++ b/docs/domain_simulation_logic/plant_agent_model/market_price_calculation.md
@@ -113,17 +113,17 @@ Two `SimulationConfig` parameters control where the dispatchable slice ends:
 
 Setting either to `1.0` reproduces today's behaviour for that product (no truncation; the full curve clears the market).
 
-**Strict-inequality boundary rule.** The dispatchable slice keeps every furnace whose cumulative capacity is *at most* `share × total`. The first furnace to *strictly* exceed that threshold is the "boundary" furnace; it is excluded along with everything more expensive.
+**Strict-inequality boundary rule.** The dispatchable slice keeps every furnace whose cumulative capacity is *at most* `share × total`. The first furnace to *strictly* exceed that threshold is the "boundary" furnace; it is excluded from the truncated slice (so it cannot be the buffer reference), but it is still reachable through the in-band merit-order walk when demand lands inside it.
 
 ```python
 threshold = config.<product>_market_clearing_share * total_capacity
 truncated = [e for e in cost_curve if e.cumulative_capacity <= threshold]
 
-if demand <= truncated[-1].cumulative_capacity:
-    # Merit-order dispatch on the truncated slice.
-    market_price = first(e.production_cost for e in truncated if e.cumulative_capacity >= demand)
+if demand <= threshold:
+    # Merit-order dispatch on the full curve — boundary furnace included at its own cost.
+    market_price = first(e.production_cost for e in cost_curve if e.cumulative_capacity >= demand)
 else:
-    # Shortage band: demand is past the dispatchable slice but may still be below total capacity.
+    # Shortage band: demand exceeds the dispatchable cap.
     market_price = truncated[-1].production_cost + config.<product>_price_buffer
 ```
 
@@ -134,10 +134,12 @@ Two `SimulationConfig` parameters control the shortage premium added when demand
 - `steel_price_buffer` — applied when steel demand exceeds the dispatchable steel slice.
 - `iron_price_buffer` — applied when iron demand exceeds the dispatchable iron slice.
 
-The buffer represents the extra willingness-to-pay required to incentivise new capacity when the market is supply-constrained. It now fires for two distinct cases, both of which emit a `WARNING`-level log line:
+The buffer represents the extra willingness-to-pay required to incentivise new capacity when the market is supply-constrained. It fires when `demand > share × total` and emits a `WARNING`-level log line in two distinct regimes:
 
-1. **Shortage band** — demand sits between `share × total` and `total`. There is unused capacity past the dispatchable slice, but the engine has chosen not to dispatch it (the long tail).
-2. **Demand exceeds total** — no unused capacity remains.
+1. **Shortage band** — `share × total < demand ≤ total`. There is unused capacity past the dispatchable cap, but the engine has chosen not to dispatch it (the long tail).
+2. **Demand exceeds total** — `demand > total`. No unused capacity remains.
+
+When `demand ≤ share × total` the boundary furnace (whose end-cumulative crosses the threshold but whose start fits within it) is reachable at its own production cost via the in-band merit-order walk on the full curve — no buffer is added, even though the furnace itself is excluded from the truncated slice.
 
 ### Worked Example
 
@@ -150,11 +152,12 @@ Building on the 3-plant scenario above (Plants A/B/C with capacities 50/40/30 Mt
 
 | Demand   | Branch                                | Market price                       |
 |----------|---------------------------------------|------------------------------------|
-| 80 Mt    | Merit-order on truncated slice        | $500 (Plant B clears the demand)   |
-| 100 Mt   | Shortage band (90 < 100 ≤ 120)        | $500 + $200 = $700                 |
+| 80 Mt    | Merit-order on full curve             | $500 (Plant B clears the demand)   |
+| 100 Mt   | Merit-order on full curve (100 ≤ 114) | $600 (Plant C clears the demand)   |
+| 116 Mt   | Shortage band (114 < 116 ≤ 120)       | $500 + $200 = $700                 |
 | 130 Mt   | Demand exceeds total (130 > 120)      | $500 + $200 = $700                 |
 
-At `share = 1.0` the dispatchable slice equals the full curve, and the worked example reverts to today's behaviour: 100 Mt clears at $600 (Plant C), 130 Mt triggers $600 + $200.
+At `share = 1.0` the threshold equals total capacity, so the shortage gate only fires when demand strictly exceeds total: 100 Mt clears at $600 (Plant C), 130 Mt triggers $600 + $200.
 
 ---
 

--- a/src/steelo/adapters/dataprocessing/postprocessing/generate_post_run_plots.py
+++ b/src/steelo/adapters/dataprocessing/postprocessing/generate_post_run_plots.py
@@ -4,10 +4,7 @@ import pandas as pd
 from typing import Optional, TYPE_CHECKING
 
 from steelo.domain.constants import T_TO_KT, T_TO_MT
-from steelo.utilities.plotting import (
-    plot_added_capacity_by_technology,
-    plot_cost_curve_step_from_dataframe,
-)
+from steelo.utilities.plotting import plot_added_capacity_by_technology
 from steelo.utilities.steeliq_plotter import SteelPlotter, PlotConfig
 
 logger = logging.getLogger(__name__)
@@ -128,70 +125,65 @@ def generate_post_run_cap_prod_plots(
                 buffer = steel_price_buffer if product_type == "steel" else iron_price_buffer
                 for aggregation in ["region", "technology"]:
                     try:
-                        plot_cost_curve_step_from_dataframe(
-                            output_df,
-                            product_type,
-                            year_demand,
-                            year,
-                            capacity_limit,
-                            units,
+                        plotter.plot_cost_curve_step(
+                            data_file=output_df,
+                            product_type=product_type,
+                            product_demand=year_demand,
+                            year=year,
+                            capacity_limit=capacity_limit,
+                            units=units,
                             clearing_share=share,
                             price_buffer=buffer,
                             aggregation=aggregation,
-                            plot_paths=plot_paths,
                         )
                         logger.info(f"Generated {product_type} cost curve by {aggregation} for {year}")
                     except Exception as e:
                         logger.warning(f"Could not generate {product_type} cost curve by {aggregation} for {year}: {e}")
 
         # Also generate the simple cost curve for the last year (backward compatibility)
-        plot_cost_curve_step_from_dataframe(
-            output_df,
-            "steel",
-            steel_demand,
-            last_year,
-            capacity_limit,
-            units,
+        plotter.plot_cost_curve_step(
+            data_file=output_df,
+            product_type="steel",
+            product_demand=steel_demand,
+            year=last_year,
+            capacity_limit=capacity_limit,
+            units=units,
             clearing_share=steel_market_clearing_share,
             price_buffer=steel_price_buffer,
             aggregation="region",
-            plot_paths=plot_paths,
         )
-        plot_cost_curve_step_from_dataframe(
-            output_df,
-            "iron",
-            iron_demand,
-            last_year,
-            capacity_limit,
-            units,
+        plotter.plot_cost_curve_step(
+            data_file=output_df,
+            product_type="iron",
+            product_demand=iron_demand,
+            year=last_year,
+            capacity_limit=capacity_limit,
+            units=units,
             clearing_share=iron_market_clearing_share,
             price_buffer=iron_price_buffer,
             aggregation="region",
-            plot_paths=plot_paths,
         )
-        plot_cost_curve_step_from_dataframe(
-            output_df,
-            "steel",
-            steel_demand,
-            last_year,
-            capacity_limit,
-            units,
+        plotter.plot_cost_curve_step(
+            data_file=output_df,
+            product_type="steel",
+            product_demand=steel_demand,
+            year=last_year,
+            capacity_limit=capacity_limit,
+            units=units,
             clearing_share=steel_market_clearing_share,
             price_buffer=steel_price_buffer,
             aggregation="technology",
-            plot_paths=plot_paths,
         )
-        plot_cost_curve_step_from_dataframe(
-            output_df,
-            "iron",
-            iron_demand,
-            last_year,
-            capacity_limit,
-            units,
+        plotter.plot_cost_curve_step(
+            data_file=output_df,
+            product_type="iron",
+            product_demand=iron_demand,
+            year=last_year,
+            capacity_limit=capacity_limit,
+            units=units,
             clearing_share=iron_market_clearing_share,
             price_buffer=iron_price_buffer,
             aggregation="technology",
-            plot_paths=plot_paths,
         )
 
     # BY REGION - Using SteelPlotter for consistent styling and footers

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -8094,11 +8094,14 @@ class Environment:
         """
         Return the market-clearing price for ``demand`` on the cost curve for ``product``.
 
-        Walks a truncated slice of the cost curve (capped at ``share * total``, where ``share`` is
-        ``steel_market_clearing_share`` or ``iron_market_clearing_share``). Returns the production
-        cost of the first entry whose cumulative capacity meets demand. When demand falls past the
-        truncated slice (shortage band, including the case where it also exceeds total capacity),
-        returns ``last_truncated.production_cost + price_buffer`` for that product.
+        The shortage gate is ``demand > share * total`` (where ``share`` is
+        ``steel_market_clearing_share`` or ``iron_market_clearing_share``). When demand fits within
+        the dispatchable cap, walks the **full** cost curve and returns the production cost of the
+        first entry whose cumulative capacity meets demand — so the boundary furnace (whose
+        end-cumulative crosses the threshold but whose start fits within it) is reachable at its
+        own cost rather than triggering the premium. When demand exceeds the threshold, returns
+        ``last_truncated.production_cost + price_buffer``, where ``last_truncated`` is the highest
+        furnace whose end-cumulative still fits under the cap.
 
         For iron with ``peg_iron_to_steel_price`` enabled, the pegging branch's steel reference price
         is computed against the **truncated** steel slice using ``steel_market_clearing_share``, so
@@ -8156,21 +8159,24 @@ class Environment:
         truncated, last_full = self._truncate_curve(cost_curve[product], share)
         # `last_full` is non-None here because the empty-curve case returned 100.0 above.
         assert last_full is not None
+        total = last_full["cumulative_capacity"]
+        threshold = share * total
 
         if not truncated:
             logger.warning(
                 f"Empty truncated {product} curve at share={share} in the {year}; degrading to full-curve merit-order."
             )
+            # Degenerate share — fall back to legacy full-curve merit-order with no premium.
             truncated = list(cost_curve[product])
+            threshold = total
 
         last_truncated = truncated[-1]
 
         if last_truncated["production_cost"] == float("inf"):
             logger.error(f"[COST CURVE]: Infinite production cost for {product}.")
 
-        if demand > last_truncated["cumulative_capacity"]:
+        if demand > threshold:
             label = product.capitalize()
-            total = last_full["cumulative_capacity"]
             regime = "exceeds total" if demand > total else f"in shortage band (above {share:.0%})"
             logger.warning(
                 f"{label} demand {regime} in {year}: "
@@ -8181,15 +8187,15 @@ class Environment:
             )
             base_price = last_truncated["production_cost"] + buffer
         else:
-            for entry in truncated:
+            # Walk full curve so the boundary furnace is reachable when demand lands inside it.
+            for entry in cost_curve[product]:
                 if entry["cumulative_capacity"] >= demand:
                     base_price = entry["production_cost"]
                     break
             else:
-                # Unreachable: the shortage branch above already covers demand > last_truncated.cumulative.
+                # Unreachable: demand <= threshold <= total, and the full curve ends at total.
                 raise ValueError(
-                    f"Unreachable: walked the truncated {product} curve without finding an entry "
-                    f"meeting demand={demand}."
+                    f"Unreachable: walked the {product} curve without finding an entry meeting demand={demand}."
                 )
 
         if product == "iron" and not future and self.config.peg_iron_to_steel_price:
@@ -8202,16 +8208,19 @@ class Environment:
                 # No steel curve — preserve legacy behaviour (no pegging applied).
                 return base_price
 
+            steel_total = steel_last_full["cumulative_capacity"]
+            steel_threshold = steel_share * steel_total
+
             if not steel_truncated:
                 logger.warning(
                     f"Empty truncated steel curve for iron pegging at share={steel_share} in {year}; "
                     f"degrading to full-curve merit-order for pegging reference."
                 )
                 steel_truncated = list(cost_curve["steel"])
+                steel_threshold = steel_total
 
             last_steel_truncated = steel_truncated[-1]
-            if steel_demand > last_steel_truncated["cumulative_capacity"]:
-                steel_total = steel_last_full["cumulative_capacity"]
+            if steel_demand > steel_threshold:
                 regime = (
                     "exceeds total"
                     if steel_demand > steel_total
@@ -8224,14 +8233,15 @@ class Environment:
                 )
                 steel_price = last_steel_truncated["production_cost"] + steel_buffer
             else:
-                for entry in steel_truncated:
+                # Walk full steel curve so the boundary furnace is reachable when steel_demand lands inside it.
+                for entry in cost_curve["steel"]:
                     if entry["cumulative_capacity"] >= steel_demand:
                         steel_price = entry["production_cost"]
                         break
                 else:
-                    # Unreachable: the shortage branch above already covers steel_demand > last_steel_truncated.
+                    # Unreachable: steel_demand <= steel_threshold <= steel_total.
                     raise ValueError(
-                        f"Unreachable: walked the truncated steel curve without finding an entry "
+                        f"Unreachable: walked the steel curve without finding an entry "
                         f"meeting steel_demand={steel_demand}."
                     )
 

--- a/src/steelo/utilities/plotting.py
+++ b/src/steelo/utilities/plotting.py
@@ -22,8 +22,6 @@ import pydeck as pdk
 import xarray as xr
 import matplotlib.patches as mpatches
 
-from matplotlib.patches import Patch
-
 from steelo.domain import Year
 from steelo.domain.models import CommodityAllocations, DemandCenter, Supplier, Plant, Location, Volumes
 from steelo.domain.trade_modelling.trade_lp_modelling import TradeLPModel
@@ -3008,13 +3006,19 @@ def plot_cost_curve_with_breakdown(
     ax.axvline(x=demand_line_x, color="r", linestyle="--", linewidth=1.5, label="Demand")
     share_pct = int(round(clearing_share * 100))
     if clearing_share < 1.0 and total_capacity > 0:
-        ax.axvline(
-            x=clearing_share * total_capacity,
+        marker_x = clearing_share * total_capacity
+        ax.axvline(x=marker_x, color="gray", linestyle="--", linewidth=1.0, zorder=6)
+        ax.text(
+            marker_x,
+            0.98,
+            f" Market clearing share ({share_pct}%)",
+            transform=ax.get_xaxis_transform(),
+            rotation=90,
+            ha="left",
+            va="top",
             color="gray",
-            linestyle="--",
-            linewidth=1.0,
-            zorder=6,
-            label=f"Market clearing share ({share_pct}%)",
+            fontsize=9,
+            zorder=7,
         )
 
     annotation_text = f"Market clearing price = {clearing_cost:.1f} $/t"
@@ -3180,12 +3184,13 @@ def _compute_market_clearing(
     """
     Determine the displayed clearing cost, vertical demand marker, and total capacity.
 
-    Mirrors ``Environment.extract_price_from_costcurve``: the cost curve is truncated at
-    ``clearing_share * total_capacity`` (entries with ``clearing_capacity <= threshold`` are kept;
-    the boundary furnace and everything above are excluded). When demand falls past the truncated
-    slice (shortage band, including the case where it also exceeds total capacity), the clearing
-    cost is ``last_truncated.production_cost + price_buffer``. At ``clearing_share = 1.0`` (legacy
-    mode) the slice equals the full curve.
+    Mirrors ``Environment.extract_price_from_costcurve``: the shortage gate is
+    ``demand > clearing_share * total_capacity``. When demand fits within the dispatchable cap, the
+    full cost curve is walked and the first entry whose cumulative capacity meets demand sets the
+    price — so the boundary furnace (whose end-cumulative crosses the threshold but whose start
+    fits within it) is reachable at its own cost rather than triggering the premium. When demand
+    exceeds the threshold, the clearing cost is ``last_truncated.production_cost + price_buffer``.
+    At ``clearing_share = 1.0`` (legacy mode) the slice equals the full curve.
 
     Args:
         cost_df: Per-furnace dataframe with ``clearing_capacity`` and ``production_cost`` columns,
@@ -3214,217 +3219,18 @@ def _compute_market_clearing(
             f"Empty truncated cost curve at clearing_share={clearing_share}; "
             f"degrading to full-curve merit-order for this query."
         )
+        # Degenerate share — fall back to legacy full-curve merit-order with no premium.
         truncated = cost_df
+        threshold = total_capacity
 
-    match_demand = truncated[truncated["clearing_capacity"] >= demand]
-    if match_demand.empty:
-        # Shortage band (or beyond): demand exceeds the truncated slice's cumulative.
+    if demand > threshold:
         clearing_cost = float(truncated["production_cost"].iloc[-1]) + price_buffer
     else:
+        # Walk full curve so the boundary furnace is reachable when demand lands inside it.
+        match_demand = cost_df[cost_df["clearing_capacity"] >= demand]
         clearing_cost = float(match_demand.iloc[0]["production_cost"])
 
     return clearing_cost, demand_line_x, total_capacity
-
-
-def plot_cost_curve_step_from_dataframe(
-    data_file,
-    product_type,
-    product_demand,
-    year,
-    capacity_limit,
-    units,
-    clearing_share: float,
-    price_buffer: float,
-    aggregation="region",
-    plot_paths: Optional["PlotPaths"] = None,
-):
-    """
-    cost_df must contain at least:
-      - 'production_cost' (y-value)
-      - 'capacity' (width of each step)
-      - 'region'
-      - 'clearing_capacity' (cumsum of 'capacity', but we only need it to know boundaries)
-    region_to_color should map each region string to an (R, G, B, A) tuple or hex string.
-    """
-    demand = product_demand
-    if (demand is None) or (isinstance(demand, (int, float, np.floating)) and demand <= 0):
-        if "production" in data_file.columns:
-            mask = (data_file["product"] == product_type) & (data_file["year"] == year)
-            demand = float(data_file.loc[mask, "production"].sum())
-        else:
-            demand = 0.0
-
-    if "year" in data_file.columns:
-        available_years = sorted(set(int(y) for y in data_file["year"].dropna()))
-        if year not in available_years and available_years:
-            logger.warning(f"Year {year} not found in data. Available years: {available_years}")
-            lower_years = [y for y in available_years if y <= year]
-            year = max(lower_years) if lower_years else min(available_years)
-            logger.info(f"Using year {year} instead for cost curve plot")
-
-    if aggregation == "region":
-        colour_scheme = region2colours
-    elif aggregation == "technology":
-        colour_scheme = tech2colours
-    else:
-        logger.warning(f"Unsupported aggregation '{aggregation}' for cost curve plot. Defaulting to 'region'.")
-        aggregation = "region"
-        colour_scheme = region2colours
-
-    cost_df = _prepare_cost_curve_dataframe(
-        data_frame=data_file,
-        product_type=product_type,
-        year=year,
-        aggregation=aggregation,
-        capacity_limit=capacity_limit,
-    )
-
-    if cost_df.empty:
-        logger.warning(f"No data for {product_type} in year {year}. Skipping cost curve plot.")
-        return
-
-    clearing_cost, demand_line_x, total_capacity = _compute_market_clearing(
-        cost_df, demand, clearing_share, price_buffer
-    )
-
-    fig, ax = plt.subplots(figsize=(10, 6))
-    cum_x = 0.0
-
-    # Loop over each plant (row) in ascending‐cost order, drawing one “filled rectangle” per row:
-    for _, row in cost_df.iterrows():
-        cost = row["production_cost"]
-        cap = row["capacity"]
-        agg_object = row[aggregation]
-
-        color = colour_scheme.get(agg_object, "#8c8c8c")
-
-        x0 = cum_x
-        x1 = cum_x + cap
-
-        # Fill the rectangle from y=0 up to y=cost, between x0 and x1:
-        ax.fill_between(
-            [x0, x1],  # x‐coordinates for the two corners of this step
-            [cost, cost],  # y‐value of the top edge
-            [0, 0],  # y=0 for the bottom edge
-            color=color,
-            step="pre",  # ensures a vertical drop at x0 if needed
-            linewidth=0,  # no border on the fill itself
-        )
-
-        # (Optional) draw a thin black line on top of the fill, to emphasize the step:
-        ax.hlines(y=cost, xmin=x0, xmax=x1, colors="black", linewidth=0.4, zorder=2)
-
-        cum_x = x1
-
-    costs = cost_df["production_cost"].values
-    cum_caps = cost_df["clearing_capacity"].values
-    for i in range(len(cost_df) - 1):
-        boundary_x = cum_caps[i]
-        y0 = costs[i]
-        y1 = costs[i + 1]
-        ax.vlines(x=boundary_x, ymin=y0, ymax=y1, colors="gray", linewidth=0.6, linestyle="--", zorder=1)
-
-    # Set x‐ and y‐limits so the plot is tight:
-
-    # Build a legend that maps each region → its fill color:
-    legend_handles = [
-        Patch(color=color, label=agg) for agg, color in colour_scheme.items() if agg in cost_df[aggregation].values
-    ]
-    ax.legend(handles=legend_handles, title=aggregation, loc="upper left", frameon=False)
-    annotation_text = f"Market clearing price = {clearing_cost:.1f} $/t"
-    share_pct = int(round(clearing_share * 100))
-    if demand > total_capacity:
-        annotation_text += f"\n(Demand exceeds total supply: boundary cost + ${int(price_buffer)} shortage premium)"
-    elif demand_line_x > clearing_share * total_capacity:
-        annotation_text += (
-            f"\n(Demand exceeds dispatchable {share_pct}%: boundary cost + ${int(price_buffer)} shortage premium)"
-        )
-
-    ax.set_title(f"Cost curve for {product_type} in {year}")
-
-    # Set x limits
-    if cum_x > 0:
-        if demand > total_capacity:
-            x_padding = max(total_capacity * 0.02, 1e-6)
-            ax.set_xlim(0, total_capacity + x_padding)
-        else:
-            ax.set_xlim(0, total_capacity)
-    else:
-        ax.set_xlim(0, 1)  # Default if no capacity
-
-    # Set y limits safely
-    max_cost = cost_df["production_cost"].max()
-    if pd.isna(max_cost) or np.isinf(max_cost) or max_cost <= 0:
-        logger.warning(f"Invalid max production cost: {max_cost}. Using default y-axis range.")
-        ax.set_ylim(0, 1000)  # Default reasonable range
-    else:
-        outlier_cap = 2000.0
-        if max_cost > outlier_cap:
-            y_limit = outlier_cap
-        else:
-            upper_percentile = cost_df["production_cost"].quantile(0.995)
-            if pd.notna(upper_percentile) and upper_percentile > 0 and max_cost > upper_percentile * 1.5:
-                y_limit = upper_percentile * 1.1
-            else:
-                y_limit = max_cost * 1.1
-        ax.set_ylim(0, y_limit)
-
-    ax.set_xlabel(f"Cumulative Capacity [{units}]")
-    ax.set_ylabel("Production Cost ($/t)")
-    display_clearing_cost = min(clearing_cost, ax.get_ylim()[1])
-    ax.axhline(y=display_clearing_cost, color="r", linestyle="--", linewidth=1.2, zorder=7, clip_on=False)
-    ax.axvline(x=demand_line_x, color="r", linestyle="--", linewidth=1.2, zorder=7, clip_on=False)
-    if clearing_share < 1.0 and total_capacity > 0:
-        ax.axvline(
-            x=clearing_share * total_capacity,
-            color="gray",
-            linestyle="--",
-            linewidth=1.0,
-            zorder=6,
-            label=f"Market clearing share ({share_pct}%)",
-        )
-    if display_clearing_cost < clearing_cost:
-        annotation_text += "\n(clipped for scale)"
-
-    # Draw market clearing annotation after axis limits are final
-    x_min, x_max = ax.get_xlim()
-    y_min, y_max = ax.get_ylim()
-    x_span = max(x_max - x_min, 1e-6)
-    y_span = max(y_max - y_min, 1e-6)
-    text_x = min(demand_line_x - 0.1 * x_span, x_max - 0.05 * x_span)
-    if text_x <= x_min:
-        text_x = x_min + 0.05 * x_span
-    text_y = display_clearing_cost + 0.15 * y_span
-    if text_y >= y_max:
-        text_y = y_max - 0.05 * y_span
-    ax.text(
-        text_x,
-        text_y,
-        annotation_text,
-        ha="right",
-        va="bottom",
-        color="black",
-        fontsize=10,
-        bbox=dict(boxstyle="round,pad=0.2", fc="white", ec="gray", alpha=0.8),
-        zorder=6,
-    )
-    if plot_paths is None or plot_paths.pam_plots_dir is None:
-        raise ValueError("plot_paths with pam_plots_dir must be provided when saving plots")
-    pam_plots_dir = plot_paths.pam_plots_dir
-    pam_plots_dir.mkdir(parents=True, exist_ok=True)
-
-    # Save PNG
-    filename = f"{product_type}_cost_curve_by_{aggregation}_{year}"
-    fig.savefig(pam_plots_dir / f"{filename}.png", dpi=300)
-    plt.close()
-
-    # Export CSV with the cost curve data
-    try:
-        csv_path = pam_plots_dir / f"{filename}.csv"
-        cost_df.to_csv(csv_path)
-        logger.info(f"Saved chart data to {csv_path}")
-    except Exception as e:
-        logger.error(f"Failed to save CSV for cost curve plot: {e}")
 
 
 def plot_geo_layers(

--- a/src/steelo/utilities/steeliq_plotter.py
+++ b/src/steelo/utilities/steeliq_plotter.py
@@ -12,6 +12,8 @@ import logging
 from matplotlib.figure import Figure
 from matplotlib.ticker import MaxNLocator
 from matplotlib.container import BarContainer
+from matplotlib.lines import Line2D
+from matplotlib.patches import Patch
 from pathlib import Path
 from typing import Any, Optional, TYPE_CHECKING, cast
 from dataclasses import dataclass, field
@@ -22,7 +24,12 @@ if TYPE_CHECKING:
     from steelo.adapters.repositories.interface import PlantRepository
 
 # Import global color schemes and constants
-from steelo.utilities.plotting import tech2colours, region2colours
+from steelo.utilities.plotting import (
+    tech2colours,
+    region2colours,
+    _prepare_cost_curve_dataframe,
+    _compute_market_clearing,
+)
 from steelo.domain.constants import T_TO_MT
 
 logger = logging.getLogger(__name__)
@@ -159,7 +166,7 @@ class SteelPlotter:
             style="italic",
         )
 
-    def _style_legend(self, ax, title: str = "", handles=None, labels=None) -> None:
+    def _style_legend(self, ax, title: str = "", handles=None, labels=None):
         """Apply consistent legend styling to an axes.
 
         Args:
@@ -167,6 +174,9 @@ class SteelPlotter:
             title: Legend title
             handles: Optional custom legend handles
             labels: Optional custom legend labels
+
+        Returns:
+            The Legend artist created (or None if no legend was produced).
         """
         if handles is not None and labels is not None:
             legend = ax.legend(
@@ -188,6 +198,7 @@ class SteelPlotter:
             )
         if legend and title:
             legend.get_title().set_fontweight("bold")
+        return legend
 
     def _save_figure(self, fig: Figure, filename: str, subdir: str = "pam_plots_dir") -> Path:
         """Save figure with consistent settings.
@@ -1367,6 +1378,230 @@ class SteelPlotter:
             csv_columns = [col for col in csv_columns if col in cost_df.columns]
             df_export = cost_df[csv_columns].copy()
             self._save_chart_data_to_csv(df_export, filename)
+
+        return self._save_figure(fig, filename)
+
+    def plot_cost_curve_step(
+        self,
+        data_file: pd.DataFrame,
+        product_type: str,
+        product_demand: float,
+        year: int,
+        capacity_limit: float,
+        units: str,
+        clearing_share: float,
+        price_buffer: float,
+        aggregation: str = "region",
+        filename: Optional[str] = None,
+        export_csv: bool = True,
+    ) -> Optional[Path]:
+        """Plot a per-furnace stepped cost curve aggregated by region or technology.
+
+        Args:
+            data_file: Post-processed DataFrame with per-furnace rows for the simulation.
+            product_type: 'steel' or 'iron'.
+            product_demand: Tonnes demanded for the product/year (used to draw the demand line).
+                If None or non-positive, falls back to the sum of `production` for the product/year.
+            year: Year to plot. Falls back to the closest earlier available year if absent.
+            capacity_limit: Multiplier applied to capacity in `_prepare_cost_curve_dataframe`.
+            units: Unit string for the x-axis label (e.g. 'Mt', 'kt', 't').
+            clearing_share: Fraction of cumulative capacity that participates in clearing
+                (must match the engine value for the same product).
+            price_buffer: USD/tonne shortage premium added when demand exceeds the dispatchable
+                slice (must match the engine value for the same product).
+            aggregation: 'region' or 'technology' — drives colour scheme and legend title.
+            filename: Optional override; defaults to `{product_type}_cost_curve_by_{aggregation}_{year}.png`.
+            export_csv: If True, also export the prepared cost-curve dataframe to CSV.
+
+        Returns:
+            Path to saved plot, or None if there is no data to plot.
+
+        Notes:
+            Y-axis is clipped to a 99.5th-percentile band (capped at $2000/t) to keep extreme
+            outliers from compressing the visible range; the clearing-price line annotates
+            "(clipped for scale)" if it falls beyond the visible y-limit.
+        """
+        demand = product_demand
+        if (demand is None) or (isinstance(demand, (int, float, np.floating)) and demand <= 0):
+            if "production" in data_file.columns:
+                mask = (data_file["product"] == product_type) & (data_file["year"] == year)
+                demand = float(data_file.loc[mask, "production"].sum())
+            else:
+                demand = 0.0
+
+        if "year" in data_file.columns:
+            available_years = sorted(set(int(y) for y in data_file["year"].dropna()))
+            if year not in available_years and available_years:
+                self.logger.warning(f"Year {year} not found in data. Available years: {available_years}")
+                lower_years = [y for y in available_years if y <= year]
+                year = max(lower_years) if lower_years else min(available_years)
+                self.logger.info(f"Using year {year} instead for cost curve plot")
+
+        if aggregation == "region":
+            colour_scheme = self.config.region_colors
+        elif aggregation == "technology":
+            colour_scheme = self.config.tech_colors
+        else:
+            self.logger.warning(f"Unsupported aggregation '{aggregation}' for cost curve plot. Defaulting to 'region'.")
+            aggregation = "region"
+            colour_scheme = self.config.region_colors
+
+        cost_df = _prepare_cost_curve_dataframe(
+            data_frame=data_file,
+            product_type=product_type,
+            year=year,
+            aggregation=aggregation,
+            capacity_limit=capacity_limit,
+        )
+
+        if cost_df.empty:
+            self.logger.warning(f"No data for {product_type} in year {year}. Skipping cost curve plot.")
+            return None
+
+        clearing_cost, demand_line_x, total_capacity = _compute_market_clearing(
+            cost_df, demand, clearing_share, price_buffer
+        )
+
+        fig, ax = plt.subplots(figsize=(10, 6))
+        cum_x = 0.0
+
+        for _, row in cost_df.iterrows():
+            cost = row["production_cost"]
+            cap = row["capacity"]
+            agg_object = row[aggregation]
+
+            color = colour_scheme.get(agg_object, "#8c8c8c")
+
+            x0 = cum_x
+            x1 = cum_x + cap
+
+            ax.fill_between(
+                [x0, x1],
+                [cost, cost],
+                [0, 0],
+                color=color,
+                step="pre",
+                linewidth=0,
+            )
+
+            ax.hlines(y=cost, xmin=x0, xmax=x1, colors="black", linewidth=0.4, zorder=2)
+
+            cum_x = x1
+
+        costs = cost_df["production_cost"].values
+        cum_caps = cost_df["clearing_capacity"].values
+        for i in range(len(cost_df) - 1):
+            boundary_x = cum_caps[i]
+            y0 = costs[i]
+            y1 = costs[i + 1]
+            ax.vlines(x=boundary_x, ymin=y0, ymax=y1, colors="gray", linewidth=0.6, linestyle="--", zorder=1)
+
+        legend_handles = [
+            Patch(color=color, label=agg) for agg, color in colour_scheme.items() if agg in cost_df[aggregation].values
+        ]
+        first_legend = self._style_legend(
+            ax,
+            title=aggregation.capitalize(),
+            handles=legend_handles,
+            labels=[h.get_label() for h in legend_handles],
+        )
+
+        annotation_text = f"Market clearing price = {clearing_cost:.1f} $/t"
+        share_pct = int(round(clearing_share * 100))
+        if demand > total_capacity:
+            annotation_text += f"\n(Demand exceeds total supply: boundary cost + ${int(price_buffer)} shortage premium)"
+        elif demand_line_x > clearing_share * total_capacity:
+            annotation_text += (
+                f"\n(Demand exceeds dispatchable {share_pct}%: boundary cost + ${int(price_buffer)} shortage premium)"
+            )
+
+        ax.set_title(f"Cost curve for {product_type} in {year}", fontsize=14, fontweight="bold")
+
+        if cum_x > 0:
+            if demand > total_capacity:
+                x_padding = max(total_capacity * 0.02, 1e-6)
+                ax.set_xlim(0, total_capacity + x_padding)
+            else:
+                ax.set_xlim(0, total_capacity)
+        else:
+            ax.set_xlim(0, 1)
+
+        max_cost = cost_df["production_cost"].max()
+        if pd.isna(max_cost) or np.isinf(max_cost) or max_cost <= 0:
+            self.logger.warning(f"Invalid max production cost: {max_cost}. Using default y-axis range.")
+            ax.set_ylim(0, 1000)
+        else:
+            outlier_cap = 2000.0
+            if max_cost > outlier_cap:
+                y_limit = outlier_cap
+            else:
+                upper_percentile = cost_df["production_cost"].quantile(0.995)
+                if pd.notna(upper_percentile) and upper_percentile > 0 and max_cost > upper_percentile * 1.5:
+                    y_limit = upper_percentile * 1.1
+                else:
+                    y_limit = max_cost * 1.1
+            ax.set_ylim(0, y_limit)
+
+        ax.set_xlabel(f"Cumulative Capacity [{units}]", fontsize=12)
+        ax.set_ylabel("Production Cost ($/t)", fontsize=12)
+        ax.grid(True, alpha=self.config.grid_alpha, linestyle=self.config.grid_linestyle)
+
+        display_clearing_cost = min(clearing_cost, ax.get_ylim()[1])
+        ax.axhline(y=display_clearing_cost, color="r", linestyle="--", linewidth=1.2, zorder=7, clip_on=False)
+        ax.axvline(x=demand_line_x, color="green", linestyle="--", linewidth=1.2, zorder=7, clip_on=False)
+        share_marker_drawn = clearing_share < 1.0 and total_capacity > 0
+        if share_marker_drawn:
+            marker_x = clearing_share * total_capacity
+            ax.axvline(x=marker_x, color="dimgray", linestyle="--", linewidth=1.2, zorder=6)
+        if display_clearing_cost < clearing_cost:
+            annotation_text += "\n(clipped for scale)"
+
+        ref_handles = [
+            Line2D([0], [0], color="r", linestyle="--", linewidth=1.5, label="Market clearing price"),
+            Line2D([0], [0], color="green", linestyle="--", linewidth=1.5, label="Demand"),
+        ]
+        if share_marker_drawn:
+            ref_handles.append(
+                Line2D(
+                    [0],
+                    [0],
+                    color="dimgray",
+                    linestyle="--",
+                    linewidth=1.5,
+                    label=f"Market clearing share ({share_pct}%)",
+                ),
+            )
+        if first_legend is not None:
+            ax.add_artist(first_legend)
+        ref_legend = ax.legend(
+            handles=ref_handles,
+            title="Reference lines",
+            bbox_to_anchor=(1.05, 0.0),
+            loc="lower left",
+            frameon=self.config.legend_frameon,
+            fontsize=self.config.legend_fontsize,
+        )
+        if ref_legend:
+            ref_legend.get_title().set_fontweight("bold")
+
+        ax.text(
+            0.02,
+            0.98,
+            annotation_text,
+            transform=ax.transAxes,
+            ha="left",
+            va="top",
+            color="black",
+            fontsize=11,
+            bbox=dict(boxstyle="round,pad=0.4", fc="white", ec="gray", alpha=0.85),
+            zorder=6,
+        )
+
+        if filename is None:
+            filename = f"{product_type}_cost_curve_by_{aggregation}_{year}.png"
+
+        if export_csv:
+            self._save_chart_data_to_csv(cost_df, filename)
 
         return self._save_figure(fig, filename)
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -941,18 +941,33 @@ def test_clearing_share_includes_furnace_at_exact_threshold():
     assert env.extract_price_from_costcurve(demand=195.0, product="steel") == 70.0 + 200.0
 
 
-def test_clearing_share_excludes_straddler_when_threshold_falls_inside_furnace():
-    """When threshold falls strictly inside a furnace's contribution, that furnace and above are excluded."""
-    # share=0.95, total=210 ⇒ threshold=199.5. Furnace 2 cumulative=200 strictly exceeds 199.5 ⇒ marginal,
-    # excluded along with everything above.
+def test_demand_inside_boundary_furnace_uses_boundary_cost():
+    """Demand below threshold but above last_truncated.cumulative still clears at boundary furnace cost."""
+    # share=0.95, total=210 ⇒ threshold=199.5. Furnace 2 cumulative=200 strictly exceeds 199.5 so it is the
+    # boundary furnace — excluded from the truncated slice but reachable via the full-curve walk.
     curve = [
         {"cumulative_capacity": 100.0, "production_cost": 50.0},
         {"cumulative_capacity": 200.0, "production_cost": 70.0},
         {"cumulative_capacity": 210.0, "production_cost": 999.0},
     ]
     env = _make_price_env(steel_curve=curve, steel_share=0.95, steel_buffer=200.0)
-    # last_truncated is the first furnace (cumulative=100, cost=50). Demand=150 lands in shortage band.
-    assert env.extract_price_from_costcurve(demand=150.0, product="steel") == 50.0 + 200.0
+    # Demand=150 sits in the gap (last_truncated.cum=100 < 150 ≤ threshold=199.5). Walks the full curve
+    # and clears on the boundary furnace at its own cost — no buffer applied.
+    assert env.extract_price_from_costcurve(demand=150.0, product="steel") == 70.0
+
+
+def test_clearing_share_excludes_straddler_from_buffer_reference():
+    """When demand exceeds the threshold, the boundary furnace is excluded from the buffer reference."""
+    # share=0.95, total=210 ⇒ threshold=199.5. Boundary furnace (cum=200, cost=70) is excluded from the
+    # truncated slice, so last_truncated is furnace 1 (cum=100, cost=50). Buffer fires off cost=50, not 70.
+    curve = [
+        {"cumulative_capacity": 100.0, "production_cost": 50.0},
+        {"cumulative_capacity": 200.0, "production_cost": 70.0},
+        {"cumulative_capacity": 210.0, "production_cost": 999.0},
+    ]
+    env = _make_price_env(steel_curve=curve, steel_share=0.95, steel_buffer=200.0)
+    # Demand=205 lies strictly above threshold (199.5) ⇒ shortage band ⇒ last_truncated.cost + buffer.
+    assert env.extract_price_from_costcurve(demand=205.0, product="steel") == 50.0 + 200.0
 
 
 def test_demand_below_clearing_share_returns_merit_order_price():
@@ -969,17 +984,17 @@ def test_demand_below_clearing_share_returns_merit_order_price():
 
 
 def test_demand_in_shortage_band_triggers_buffer():
-    """Demand between truncated cumulative and total triggers last_truncated.cost + buffer."""
-    # share=0.95, total=300 ⇒ threshold=285. Furnace 3 cumulative=300 strictly exceeds 285 ⇒ marginal,
-    # excluded. last_truncated is furnace 2 (cumulative=200, cost=70).
+    """Demand strictly above threshold but ≤ total triggers last_truncated.cost + buffer."""
+    # share=0.95, total=300 ⇒ threshold=285. Furnace 3 cumulative=300 strictly exceeds 285 ⇒ boundary,
+    # excluded from the truncated slice. last_truncated is furnace 2 (cumulative=200, cost=70).
     curve = [
         {"cumulative_capacity": 100.0, "production_cost": 50.0},
         {"cumulative_capacity": 200.0, "production_cost": 70.0},
         {"cumulative_capacity": 300.0, "production_cost": 999.0},
     ]
     env = _make_price_env(steel_curve=curve, steel_share=0.95, steel_buffer=200.0)
-    # Demand=250 lies in the shortage band: 200 < 250 ≤ 300.
-    assert env.extract_price_from_costcurve(demand=250.0, product="steel") == 70.0 + 200.0
+    # Demand=290 lies in the shortage band: threshold=285 < 290 ≤ total=300.
+    assert env.extract_price_from_costcurve(demand=290.0, product="steel") == 70.0 + 200.0
 
 
 def test_demand_above_total_capacity_triggers_buffer():
@@ -1034,8 +1049,8 @@ def test_steel_and_iron_clearing_shares_are_independent():
         steel_buffer=200.0,
         iron_buffer=100.0,
     )
-    # Steel: demand=250 in shortage band (last_truncated=200, cost=70) ⇒ 70 + 200.
-    assert env.extract_price_from_costcurve(demand=250.0, product="steel") == 70.0 + 200.0
+    # Steel: demand=290 in shortage band (threshold=285 < 290 ≤ total=300; last_truncated cost=70) ⇒ 70 + 200.
+    assert env.extract_price_from_costcurve(demand=290.0, product="steel") == 70.0 + 200.0
     # Iron at share=1.0: demand=250 walks the full curve and clears at 50/t (third furnace).
     assert env.extract_price_from_costcurve(demand=250.0, product="iron") == 50.0
 
@@ -1076,14 +1091,14 @@ def test_iron_pegging_applies_uniformly_in_shortage_band(caplog):
 
     # Iron curve: total=100, share=0.95 ⇒ threshold=95. Furnace 2 cum=100 > 95 ⇒ excluded.
     # last_truncated_iron has cum=50, cost=30. iron_buffer=200.
-    # Iron demand=80 lies in iron shortage band (50 < 80 ≤ 100).
+    # Iron demand=98 lies strictly above threshold (95 < 98 ≤ 100) ⇒ iron shortage band.
     # ⇒ base_price = last_truncated_iron.cost + iron_buffer = 30 + 200 = 230.
     iron = [
         {"cumulative_capacity": 50.0, "production_cost": 30.0},
         {"cumulative_capacity": 100.0, "production_cost": 999.0},
     ]
     # Steel curve: total=1000, share=0.95 ⇒ threshold=950. Furnace 2 cum=1000 > 950 ⇒ excluded.
-    # last_truncated_steel has cum=950, cost=500. Steel demand=500 clears in merit order ⇒ steel_price=500.
+    # Steel demand=500 ≤ threshold ⇒ walks full curve, clears on furnace 1 (cum=950, cost=500).
     # Pegged floor = 500 * 0.8 = 400. Final iron = max(230, 400) = 400.
     steel = [
         {"cumulative_capacity": 950.0, "production_cost": 500.0},
@@ -1101,7 +1116,7 @@ def test_iron_pegging_applies_uniformly_in_shortage_band(caplog):
         current_demand=500.0,
     )
     with caplog.at_level(logging.WARNING):
-        result = env.extract_price_from_costcurve(demand=80.0, product="iron")
+        result = env.extract_price_from_costcurve(demand=98.0, product="iron")
     # Return value alone proves pegging fired: without pegging the answer would be 30 + 200 = 230
     # (iron in shortage); with pegging applied uniformly, the steel-driven floor of 400 wins.
     assert result == pytest.approx(400.0)

--- a/tests/unit/test_plotting.py
+++ b/tests/unit/test_plotting.py
@@ -12,10 +12,10 @@ import tempfile
 from steelo.utilities.plotting import (
     plot_added_capacity_by_technology,
     plot_year_on_year_technology_development,
-    plot_cost_curve_step_from_dataframe,
     plot_area_chart_of_column_by_region_or_technology,
     _copy_deckgl_to_output_dir,
 )
+from steelo.utilities.steeliq_plotter import SteelPlotter, PlotConfig
 from steelo.domain.models import PlotPaths
 
 
@@ -91,24 +91,21 @@ def test_plot_year_on_year_technology_development(sample_output_df, temp_plot_di
 
 def test_plot_cost_curve_with_missing_year(sample_output_df, temp_plot_dir):
     """Test cost curve plot handles missing years gracefully."""
-    # Create PlotPaths object for the test
     plot_paths = PlotPaths(pam_plots_dir=temp_plot_dir / "pam")
+    plotter = SteelPlotter(config=PlotConfig(), plot_paths=plot_paths)
 
-    # Test with a year that doesn't exist (2035). Legacy mode (share=1.0, no buffer) keeps assertions
-    # focused on the missing-year fallback rather than truncation behaviour.
-    plot_cost_curve_step_from_dataframe(
-        sample_output_df,
-        "steel",
+    # Year 2035 is absent from the fixture; the method should fall back to the closest earlier year.
+    plotter.plot_cost_curve_step(
+        data_file=sample_output_df,
+        product_type="steel",
         product_demand=1000,
         year=2035,
         capacity_limit=0.95,
         units="Mt",
         clearing_share=1.0,
         price_buffer=0.0,
-        plot_paths=plot_paths,
     )
 
-    # Should create plot with closest available year (2030)
     plot_files = list((temp_plot_dir / "pam").glob("steel_cost_curve_by_*.png"))
     assert len(plot_files) > 0, "No cost curve plot created"
     assert "2030" in plot_files[0].name, "Should use year 2030 when 2035 not available"
@@ -116,19 +113,18 @@ def test_plot_cost_curve_with_missing_year(sample_output_df, temp_plot_dir):
 
 def test_plot_cost_curve_with_existing_year(sample_output_df, temp_plot_dir):
     """Test cost curve plot with existing year."""
-    # Create PlotPaths object for the test
     plot_paths = PlotPaths(pam_plots_dir=temp_plot_dir / "pam")
+    plotter = SteelPlotter(config=PlotConfig(), plot_paths=plot_paths)
 
-    plot_cost_curve_step_from_dataframe(
-        sample_output_df,
-        "steel",
+    plotter.plot_cost_curve_step(
+        data_file=sample_output_df,
+        product_type="steel",
         product_demand=1000,
         year=2028,
         capacity_limit=0.95,
         units="Mt",
         clearing_share=1.0,
         price_buffer=0.0,
-        plot_paths=plot_paths,
     )
 
     plot_file = temp_plot_dir / "pam" / "steel_cost_curve_by_region_2028.png"

--- a/tests/unit/test_postprocessing.py
+++ b/tests/unit/test_postprocessing.py
@@ -66,9 +66,8 @@ def mock_plot_paths():
 
 @patch("steelo.adapters.dataprocessing.postprocessing.generate_post_run_plots.SteelPlotter")
 @patch("steelo.adapters.dataprocessing.postprocessing.generate_post_run_plots.plot_added_capacity_by_technology")
-@patch("steelo.adapters.dataprocessing.postprocessing.generate_post_run_plots.plot_cost_curve_step_from_dataframe")
 def test_generate_post_run_cap_prod_plots_calls_all_functions_with_plot_paths(
-    mock_cost_curve, mock_added_capacity, mock_plotter_class, temp_csv_file, mock_plot_paths
+    mock_added_capacity, mock_plotter_class, temp_csv_file, mock_plot_paths
 ):
     """Test that generate_post_run_cap_prod_plots passes plot_paths to all plotting functions."""
     mock_plotter_instance = mock_plotter_class.return_value
@@ -97,17 +96,14 @@ def test_generate_post_run_cap_prod_plots_calls_all_functions_with_plot_paths(
     mock_plotter_instance.plot_capacity_development_by_technology.assert_called_once()
     assert mock_plotter_instance.plot_area_chart_by_region_or_technology.call_count == 8
 
-    # plot_cost_curve is called multiple times (for different years/products)
-    assert mock_cost_curve.call_count >= 1
-    for call_args in mock_cost_curve.call_args_list:
-        assert call_args.kwargs["plot_paths"] == mock_plot_paths
+    # plot_cost_curve_step is called multiple times (for different years/products/aggregations)
+    assert mock_plotter_instance.plot_cost_curve_step.call_count >= 1
 
 
 @patch("steelo.adapters.dataprocessing.postprocessing.generate_post_run_plots.SteelPlotter")
 @patch("steelo.adapters.dataprocessing.postprocessing.generate_post_run_plots.plot_added_capacity_by_technology")
-@patch("steelo.adapters.dataprocessing.postprocessing.generate_post_run_plots.plot_cost_curve_step_from_dataframe")
 def test_generate_post_run_cap_prod_plots_works_without_plot_paths(
-    mock_cost_curve, mock_added_capacity, mock_plotter_class, temp_csv_file
+    mock_added_capacity, mock_plotter_class, temp_csv_file
 ):
     """Test that generate_post_run_cap_prod_plots works when plot_paths is None."""
     mock_plotter_instance = mock_plotter_class.return_value
@@ -135,10 +131,8 @@ def test_generate_post_run_cap_prod_plots_works_without_plot_paths(
     mock_plotter_instance.plot_capacity_development_by_technology.assert_called_once()
     assert mock_plotter_instance.plot_area_chart_by_region_or_technology.call_count == 8
 
-    # plot_cost_curve is called multiple times (for different years/products)
-    assert mock_cost_curve.call_count >= 1
-    for call_args in mock_cost_curve.call_args_list:
-        assert call_args.kwargs["plot_paths"] is None
+    # plot_cost_curve_step is called multiple times (for different years/products/aggregations)
+    assert mock_plotter_instance.plot_cost_curve_step.call_count >= 1
 
 
 def test_plotting_function_signatures():
@@ -146,7 +140,6 @@ def test_plotting_function_signatures():
     from steelo.utilities.plotting import (
         plot_added_capacity_by_technology,
         plot_year_on_year_technology_development,
-        plot_cost_curve_step_from_dataframe,
         plot_area_chart_of_column_by_region_or_technology,
     )
 
@@ -156,7 +149,6 @@ def test_plotting_function_signatures():
     functions_to_check = [
         plot_added_capacity_by_technology,
         plot_year_on_year_technology_development,
-        plot_cost_curve_step_from_dataframe,
         plot_area_chart_of_column_by_region_or_technology,
     ]
 


### PR DESCRIPTION
- Moved `plot_cost_curve_step_from_dataframe` onto `SteelPlotter` so cost-curve PNGs inherit the standard legend-on-side layout and "Generated by Steel-IQ" footer; deleted the standalone function and updated its five call sites in `generate_post_run_plots`.
- Repositioned the clearing-price annotation to the top-left and added a "Reference lines" legend (red / green / dimgray dashed) to stop the in-axes label overlapping the chart.
- Fixed the shortage gate in `extract_price_from_costcurve` and `_compute_market_clearing` to fire on `demand > share * total` rather than on the last truncated furnace's cumulative capacity.
- Reworked the in-band branch to walk the full cost curve so a boundary furnace whose start fits within the threshold is reachable at its own cost, instead of falsely triggering the buffer premium for a furnace only marginally more expensive than its predecessor.
- Mirrored the same fix on the iron-pegging branch, and updated the `market_price_calculation` doc plus tests in `test_models`, `test_plotting`, and `test_postprocessing`.