### PR TITLE
Fix NPV secondary output adjustment leaking into construction years

### DIFF
--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -1157,8 +1157,9 @@ def calculate_npv_full(
         unit_carbon_costs_lagged = zeros + unit_carbon_costs
         unit_opex_lagged = [x + y for x, y in zip(unit_opex_lagged, unit_carbon_costs_lagged)]
 
-    # Add secondary output cost adjustment (by-product revenue/cost) to OPEX
-    unit_opex_lagged = [x + secondary_output_adjustment for x in unit_opex_lagged]
+    # Add secondary output cost adjustment (by-product revenue/cost) to OPEX during operational years only
+    secondary_adjustment_lagged = zeros + [secondary_output_adjustment] * len(unit_total_opex_list)
+    unit_opex_lagged = [x + y for x, y in zip(unit_opex_lagged, secondary_adjustment_lagged)]
     func_logger.debug(f"[NPV FULL] Secondary output adjustment: ${secondary_output_adjustment:,.4f}/t applied to OPEX")
 
     # Calculate cash flows

--- a/tests/unit/test_calculate_costs.py
+++ b/tests/unit/test_calculate_costs.py
@@ -364,6 +364,65 @@ def test_npv_flow_wrapper(mocker, technology, material_bill):  # FIXME: This tes
     assert pytest.approx(result, rel=0.1) == expected_npv  # 10% tolerance due to calculation differences
 
 
+def test_calculate_npv_full_secondary_adjustment_skips_construction_years():
+    """Regression test for the construction-year leakage bug in calculate_npv_full.
+
+    secondary_output_adjustment must only be applied to operational years. If applied to
+    the zero-prefix entries of the lagged OPEX list, it bypasses the zero-OPEX guard in
+    calculate_gross_cash_flow and produces phantom revenue from a plant that does not
+    yet exist.
+
+    Approach: run calculate_npv_full twice with identical inputs except for
+    secondary_output_adjustment (0.0 vs -50.0) and assert the NPV delta equals the
+    discounted contribution over operational years only. Under the bug, the delta would
+    additionally include two construction-year terms and the assertion would fail.
+    """
+    capex = 1000.0
+    capacity = 100.0
+    unit_total_opex = 200.0
+    expected_utilisation_rate = 0.8
+    price = 600.0
+    lifetime = 20
+    construction_time = 2
+    cost_of_debt = 0.05
+    cost_of_equity = 0.05
+    equity_share = 0.2
+    secondary_adjustment = -50.0  # negative => by-product revenue
+
+    unit_total_opex_list = [unit_total_opex] * lifetime
+    price_series = [price] * (lifetime + construction_time)
+
+    common_kwargs = dict(
+        capex=capex,
+        capacity=capacity,
+        unit_total_opex_list=unit_total_opex_list,
+        expected_utilisation_rate=expected_utilisation_rate,
+        price_series=price_series,
+        lifetime=lifetime,
+        construction_time=construction_time,
+        cost_of_debt=cost_of_debt,
+        cost_of_equity=cost_of_equity,
+        equity_share=equity_share,
+    )
+
+    npv_baseline = calculate_npv_full(**common_kwargs, secondary_output_adjustment=0.0)
+    npv_with_adjustment = calculate_npv_full(**common_kwargs, secondary_output_adjustment=secondary_adjustment)
+
+    # Per-year gross-cash-flow change for operational years:
+    # (price - (opex + secondary)) * production - (price - opex) * production = -secondary * production
+    # Cash-flow index i is discounted at period t = i + 1 in calculate_npv_costs, so operational
+    # years (i = construction_time .. construction_time + lifetime - 1) map to t = construction_time + 1
+    # .. construction_time + lifetime.
+    expected_production = expected_utilisation_rate * capacity
+    per_year_delta = -secondary_adjustment * expected_production
+    expected_delta = sum(
+        per_year_delta / ((1 + cost_of_equity) ** t)
+        for t in range(construction_time + 1, construction_time + lifetime + 1)
+    )
+
+    assert npv_with_adjustment - npv_baseline == pytest.approx(expected_delta)
+
+
 def test_stranding_asset_cost():
     debt_repayment = [
         43000.0,


### PR DESCRIPTION
- `calculate_npv_full` was adding `secondary_output_adjustment` to every entry of the lagged OPEX list, including the construction-year zero-prefix. This bypassed the zero-OPEX guard in `calculate_gross_cash_flow` and produced phantom revenue from plants that don't yet exist.
- Fix: zero-prefix the secondary adjustment vector to match the construction-time lag (mirrors the carbon-cost pattern just above at `calculate_costs.py:1156-1158`).
- Bug introduced in `fa0547f` ("Add secondary output cost adjustment to all NPV calculations") — fires on every greenfield NPV with non-zero by-product economics.
