### PR TITLE
Grid emissivity scenario dropdown

### DIFF
--- a/src/steeloweb/forms.py
+++ b/src/steeloweb/forms.py
@@ -485,6 +485,14 @@ class ModelRunCreateForm(forms.ModelForm):
         widget=forms.Select(attrs={"class": "form-select field-connected"}),
     )
 
+    chosen_grid_emissions_scenario = forms.ChoiceField(
+        choices=[],
+        initial="Business As Usual",
+        required=False,
+        help_text="Trajectory of grid electricity emissivity used to compute indirect emissions for each furnace group.",
+        widget=forms.Select(attrs={"class": "form-select"}),
+    )
+
     # Placeholder for circularity file selection
     CIRCULARITY_CHOICES = [
         ("", "Default circularity data"),
@@ -723,6 +731,23 @@ class ModelRunCreateForm(forms.ModelForm):
         else:
             self.fields["data_preparation"].empty_label = "No data preparations available"
 
+        # Populate grid emissivity scenario choices from the resolved data preparation.
+        active_prep = None
+        prep_id = (self.data.get("data_preparation") if self.data else None) or self.initial.get("data_preparation")
+        if prep_id:
+            try:
+                active_prep = DataPreparation.objects.get(pk=prep_id, status=DataPreparation.Status.READY)
+            except (DataPreparation.DoesNotExist, ValueError, TypeError):
+                active_prep = None
+        if active_prep is None and ready_preparations.exists():
+            active_prep = ready_preparations.first()
+
+        scenarios = active_prep.get_region_emissivity_scenarios() if active_prep is not None else []
+        self.fields["chosen_grid_emissions_scenario"].choices = [(s, s) for s in scenarios]
+        # Override field-level "Business As Usual" only when it is missing from the prep
+        if scenarios and "Business As Usual" not in scenarios:
+            self.fields["chosen_grid_emissions_scenario"].initial = scenarios[0]
+
     class Meta:
         model = ModelRun
         fields = [
@@ -763,6 +788,7 @@ class ModelRunCreateForm(forms.ModelForm):
             "include_tariffs",
             "enable_furnace_group_clustering",
             "cluster_hot_metal_techs_by_plant_group",
+            "chosen_grid_emissions_scenario",
             # Demand and Circularity
             "total_steel_demand_scenario",
             "green_steel_demand_scenario",

--- a/src/steeloweb/models.py
+++ b/src/steeloweb/models.py
@@ -1029,6 +1029,28 @@ class ModelRun(models.Model):
 
             config = SimulationConfig(**sim_config_data)
 
+        # Write simulation_config.json and preparation_metadata.json alongside the
+        # other run outputs, mirroring the terminal `run_simulation` CLI layout.
+        if output_path:
+            import json
+            from datetime import datetime
+
+            try:
+                config_dict = {k: str(v) if isinstance(v, Path) else v for k, v in config.__dict__.items()}
+                (output_path / "simulation_config.json").write_text(json.dumps(config_dict, indent=2, default=str))
+
+                prep_metadata = {
+                    "preparation_time": datetime.now().isoformat(),
+                    "cache_used": True,
+                    "master_excel": str(master_excel_path) if master_excel_path else None,
+                    "cached_from": str(data_dir) if data_dir else None,
+                }
+                (output_path / "preparation_metadata.json").write_text(json.dumps(prep_metadata, indent=2))
+            except Exception as e:
+                logger.warning(
+                    f"Failed to write simulation_config/preparation_metadata JSON for ModelRun {self.id}: {e}"
+                )
+
         def progress_callback(progress):
             # Convert Year objects to integers for JSON serialization
             progress_data = {

--- a/src/steeloweb/models.py
+++ b/src/steeloweb/models.py
@@ -412,6 +412,72 @@ class DataPreparation(models.Model):
             logger.error(f"Unexpected error loading technologies: {e}")
             return {}
 
+    def get_region_emissivity_scenarios(self) -> list[str]:
+        """
+        Get available grid emissivity scenarios from prepared data.
+
+        Reads region_emissivity.json and returns distinct scenario names that have
+        at least one year-of-data ≥ 2025. The cutoff filters out backwards-only
+        scenarios (e.g. "Historical") that would zero out the grid emissivity for
+        every simulated forecast year.
+
+        Returns:
+            Sorted list of scenario names. "Business As Usual" comes first when
+            present, then alphabetical. Empty list if data_directory unset, file
+            missing, or JSON malformed.
+
+        Notes:
+            - Mirrors the defensive pattern used by get_technologies above.
+            - Sheet of origin is the master Excel "Power grid emissivity" tab;
+              scenario names are derived from each unique projection_scenario
+              column value via removeprefix("projection_").replace("_"," ").title().
+        """
+        import json
+        import logging
+
+        logger = logging.getLogger("steeloweb.grid_emissions.ui")
+
+        if not self.data_directory:
+            logger.warning(f"DataPreparation {self.id} has no data_directory")
+            return []
+
+        path = Path(self.data_directory) / "data" / "fixtures" / "region_emissivity.json"
+        if not path.exists():
+            logger.info(f"region_emissivity.json not found at {path}")
+            return []
+
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON in region_emissivity.json: {e}")
+            return []
+        except Exception as e:
+            logger.error(f"Unexpected error reading region_emissivity.json: {e}")
+            return []
+
+        records = data.get("root", []) if isinstance(data, dict) else []
+
+        # Collect scenarios with at least one year ≥ 2025
+        scenarios_with_forecast: set[str] = set()
+        for rec in records:
+            scenario = rec.get("scenario")
+            grid = rec.get("grid_emissivity") or {}
+            if not scenario or not isinstance(grid, dict):
+                continue
+            try:
+                latest_year = max((int(y) for y in grid.keys()), default=0)
+            except (TypeError, ValueError):
+                continue
+            if latest_year >= 2025:
+                scenarios_with_forecast.add(scenario)
+
+        scenarios = sorted(scenarios_with_forecast)
+        if "Business As Usual" in scenarios:
+            scenarios.remove("Business As Usual")
+            scenarios.insert(0, "Business As Usual")
+        return scenarios
+
 
 @dataclass
 class Progress:

--- a/src/steeloweb/templates/steeloweb/create_modelrun.html
+++ b/src/steeloweb/templates/steeloweb/create_modelrun.html
@@ -82,6 +82,10 @@ function resetPolicySettings() {
     document.getElementById('id_include_tariffs').checked = true;
     document.getElementById('id_enable_furnace_group_clustering').checked = false;
     document.getElementById('id_cluster_hot_metal_techs_by_plant_group').checked = false;
+    const gridScenario = document.getElementById('id_chosen_grid_emissions_scenario');
+    if (gridScenario && !gridScenario.disabled) {
+        gridScenario.value = 'Business As Usual';
+    }
     // Trigger change to update dependent field disabled state
     document.getElementById('id_enable_furnace_group_clustering').dispatchEvent(new Event('change'));
 }
@@ -1194,6 +1198,48 @@ document.head.appendChild(style);
                                             {{ form.cluster_hot_metal_techs_by_plant_group.errors }}
                                         </div>
                                         {% endif %}
+                                    </div>
+                                </div>
+
+                                <div class="mb-3 row">
+                                    <label for="id_chosen_grid_emissions_scenario" class="col-sm-3 col-form-label">
+                                        Grid emissivity scenario:
+                                    </label>
+                                    <div class="col-sm-9"
+                                         id="grid-emissions-scenario-wrapper"
+                                         hx-get="{% url 'create-modelrun-grid-emissions-fragment' %}"
+                                         hx-trigger="change from:#id_data_preparation"
+                                         hx-target="this"
+                                         hx-swap="innerHTML"
+                                         hx-include="#id_data_preparation, #id_chosen_grid_emissions_scenario">
+                                        {% if form.fields.chosen_grid_emissions_scenario.choices %}
+                                            {{ form.chosen_grid_emissions_scenario }}
+                                        {% else %}
+                                            <div class="alert alert-warning py-2 mb-2">
+                                                <strong>No grid emissivity scenarios found.</strong>
+                                                Add a <code>projection_&lt;name&gt;</code> row group to the <strong>Power grid emissivity</strong> sheet of the master Excel and re-prepare the data.
+                                            </div>
+                                            <select id="id_chosen_grid_emissions_scenario" class="form-select" disabled>
+                                                <option>No scenarios available — re-prepare data</option>
+                                            </select>
+                                        {% endif %}
+                                        {% if form.chosen_grid_emissions_scenario.errors %}
+                                        <div class="invalid-feedback d-block">
+                                            {{ form.chosen_grid_emissions_scenario.errors }}
+                                        </div>
+                                        {% endif %}
+                                        <small class="form-text text-muted d-block mt-1">
+                                            <strong>Adding a custom scenario:</strong>
+                                            <ul class="mb-0 ps-3">
+                                                <li>Open a new Master Excel (use the provided template)</li>
+                                                <li>Navigate to the <strong>Power grid emissivity</strong> sheet</li>
+                                                <li>Copy the rows for <code>projection_business_as_usual</code></li>
+                                                <li>Paste the rows below and change the values in the carbon-intensity column (<code>ghg_factor_scope_2</code>)</li>
+                                                <li>Rename the <code>projection_scenario</code> cells to <code>projection_&lt;your_name&gt;</code> (e.g. <code>projection_high_renewables</code>)</li>
+                                                <li>Save your new Master Excel, upload and prepare it</li>
+                                                <li>The new scenario will appear here as <strong>"Your Name"</strong> (e.g. <strong>"High Renewables"</strong>)</li>
+                                            </ul>
+                                        </small>
                                     </div>
                                 </div>
 

--- a/src/steeloweb/templates/steeloweb/modelrun_detail.html
+++ b/src/steeloweb/templates/steeloweb/modelrun_detail.html
@@ -246,6 +246,9 @@
                             <dt class="col-sm-4">Plant agents:</dt>
                             <dd class="col-sm-8">{{ modelrun.config.probabilistic_agents|yesno:"Probabilistic,Deterministic,—" }}</dd>
 
+                            <dt class="col-sm-4">Grid emissivity scenario:</dt>
+                            <dd class="col-sm-8">{{ modelrun.config.chosen_grid_emissions_scenario|default:"—" }}</dd>
+
                             <dt class="col-sm-4">Iron capacity limit:</dt>
                             <dd class="col-sm-8">
                                 {% if capacity_limit_iron_mt is not None %}{{ capacity_limit_iron_mt|floatformat:"-1" }} Mt{% else %}—{% endif %}

--- a/src/steeloweb/templates/steeloweb/partials/_grid_emissions_scenario_select.html
+++ b/src/steeloweb/templates/steeloweb/partials/_grid_emissions_scenario_select.html
@@ -1,0 +1,27 @@
+{% if scenarios %}
+    <select name="chosen_grid_emissions_scenario" id="id_chosen_grid_emissions_scenario" class="form-select">
+        {% for scenario in scenarios %}
+            <option value="{{ scenario }}"{% if scenario == selected %} selected{% endif %}>{{ scenario }}</option>
+        {% endfor %}
+    </select>
+{% else %}
+    <div class="alert alert-warning py-2 mb-2">
+        <strong>No grid emissivity scenarios found.</strong>
+        Add a <code>projection_&lt;name&gt;</code> row group to the <strong>Power grid emissivity</strong> sheet of the master Excel and re-prepare the data.
+    </div>
+    <select id="id_chosen_grid_emissions_scenario" class="form-select" disabled>
+        <option>No scenarios available — re-prepare data</option>
+    </select>
+{% endif %}
+<small class="form-text text-muted d-block mt-1">
+    <strong>Adding a custom scenario:</strong>
+    <ul class="mb-0 ps-3">
+        <li>Open a new Master Excel (use the provided template)</li>
+        <li>Navigate to the <strong>Power grid emissivity</strong> sheet</li>
+        <li>Copy the rows for <code>projection_business_as_usual</code></li>
+        <li>Paste the rows below and change the values in the carbon-intensity column (<code>ghg_factor_scope_2</code>)</li>
+        <li>Rename the <code>projection_scenario</code> cells to <code>projection_&lt;your_name&gt;</code> (e.g. <code>projection_high_renewables</code>)</li>
+        <li>Save your new Master Excel, upload and prepare it</li>
+        <li>The new scenario will appear here as <strong>"Your Name"</strong> (e.g. <strong>"High Renewables"</strong>)</li>
+    </ul>
+</small>

--- a/src/steeloweb/urls.py
+++ b/src/steeloweb/urls.py
@@ -54,6 +54,11 @@ urlpatterns = [
     path(
         "modelrun/dataset-metadata-fragment/", views.dataset_metadata_fragment, name="create-modelrun-metadata-fragment"
     ),
+    path(
+        "modelrun/grid-emissions-fragment/",
+        views.grid_emissions_scenario_fragment,
+        name="create-modelrun-grid-emissions-fragment",
+    ),
     # Master Excel URLs
     path("master-excel/", views.MasterExcelFileListView.as_view(), name="master-excel-list"),
     path("master-excel/create/", views.MasterExcelFileCreateView.as_view(), name="master-excel-create"),

--- a/src/steeloweb/views.py
+++ b/src/steeloweb/views.py
@@ -761,6 +761,9 @@ def create_modelrun(request):
                     "green_steel_demand_scenario", "business_as_usual"
                 ),
                 "scrap_generation_scenario": form.cleaned_data.get("scrap_generation_scenario", "business_as_usual"),
+                "chosen_grid_emissions_scenario": form.cleaned_data.get(
+                    "chosen_grid_emissions_scenario", "Business As Usual"
+                ),
                 "circularity_file": form.cleaned_data.get("circularity_file", ""),
                 # Technology fields will be added after extraction from POST data
                 "hydrogen_subsidies": form.cleaned_data.get("hydrogen_subsidies", False),
@@ -966,6 +969,38 @@ def technologies_fragment(request):
 
 
 @require_http_methods(["GET"])
+@require_http_methods(["GET"])
+def grid_emissions_scenario_fragment(request):
+    """
+    HTMX endpoint: returns the grid emissivity scenario <select> for a given prep.
+
+    Always returns 200 with valid HTML to avoid HTMX error states. Falls back to
+    a disabled empty-state select with instructions when no prep is selected,
+    the prep is not ready, or its region_emissivity.json holds no forecast
+    scenarios.
+    """
+    from django.template.loader import render_to_string
+    from django.http import HttpResponse
+
+    prep_id = request.GET.get("data_preparation")
+    selected = request.GET.get("chosen_grid_emissions_scenario", "Business As Usual")
+
+    scenarios: list[str] = []
+    if prep_id:
+        try:
+            prep = DataPreparation.objects.get(pk=prep_id, status=DataPreparation.Status.READY)
+            scenarios = prep.get_region_emissivity_scenarios()
+        except (DataPreparation.DoesNotExist, ValueError, TypeError):
+            scenarios = []
+
+    html = render_to_string(
+        "steeloweb/partials/_grid_emissions_scenario_select.html",
+        {"scenarios": scenarios, "selected": selected},
+        request=request,
+    )
+    return HttpResponse(html, status=200)
+
+
 def dataset_metadata_fragment(request):
     """
     HTMX endpoint: returns dataset metadata information for a given data preparation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -539,6 +539,23 @@ def ready_data_preparation(db, tmp_path):
     tech_file = fixtures_dir / "technologies.json"
     tech_file.write_text(json.dumps(technologies, indent=2))
 
+    # Minimal region_emissivity.json so the form's grid emissions scenario
+    # ChoiceField has at least "Business As Usual" available. Years must be ≥ 2025
+    # to pass the forecast-scenario filter in get_region_emissivity_scenarios().
+    region_emissivity = {
+        "root": [
+            {
+                "iso3": "POL",
+                "country_name": "Poland",
+                "scenario": "Business As Usual",
+                "grid_emissivity": {"2025": {"Electricity": 0.5}, "2050": {"Electricity": 0.3}},
+                "coke_emissivity": {},
+                "gas_emissivity": {},
+            }
+        ]
+    }
+    (fixtures_dir / "region_emissivity.json").write_text(json.dumps(region_emissivity))
+
     # Create required data packages
     core_package, _ = DataPackage.objects.get_or_create(
         name=DataPackage.PackageType.CORE_DATA,

--- a/tests/web/test_grid_emissions_scenario.py
+++ b/tests/web/test_grid_emissions_scenario.py
@@ -1,0 +1,157 @@
+"""Tests for grid emissivity scenario discovery and filtering."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from steeloweb.models import DataPreparation
+
+
+def _write_region_emissivity(tmpdir: str, records: list[dict]) -> None:
+    """Write a region_emissivity.json fixture under {tmpdir}/data/fixtures/.
+
+    Args:
+        tmpdir: Temporary directory acting as a prepared data directory.
+        records: List of record dicts in the schema produced by the data prep step.
+
+    Notes:
+        Mirrors the layout DataPreparation.get_region_emissivity_scenarios expects.
+    """
+    path = Path(tmpdir) / "data" / "fixtures" / "region_emissivity.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"root": records}, f)
+
+
+@pytest.mark.django_db
+def test_get_region_emissivity_scenarios_returns_distinct_forecast_scenarios():
+    """Should return distinct scenario names with at least one year >= 2025."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_region_emissivity(
+            tmpdir,
+            [
+                {
+                    "iso3": "POL",
+                    "country_name": "Poland",
+                    "scenario": "Business As Usual",
+                    "grid_emissivity": {"2025": {"Electricity": 0.5}, "2050": {"Electricity": 0.3}},
+                    "coke_emissivity": {},
+                    "gas_emissivity": {},
+                },
+                {
+                    "iso3": "DEU",
+                    "country_name": "Germany",
+                    "scenario": "Net Zero",
+                    "grid_emissivity": {"2030": {"Electricity": 0.2}, "2050": {"Electricity": 0.0}},
+                    "coke_emissivity": {},
+                    "gas_emissivity": {},
+                },
+            ],
+        )
+
+        prep = DataPreparation(data_directory=tmpdir)
+        scenarios = prep.get_region_emissivity_scenarios()
+
+        assert scenarios == ["Business As Usual", "Net Zero"]
+
+
+@pytest.mark.django_db
+def test_get_region_emissivity_scenarios_excludes_pre_2025_only_scenarios():
+    """A scenario whose latest year is < 2025 (e.g. 'Historical') is filtered out."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_region_emissivity(
+            tmpdir,
+            [
+                {
+                    "iso3": "POL",
+                    "country_name": "Poland",
+                    "scenario": "Business As Usual",
+                    "grid_emissivity": {"2025": {"Electricity": 0.5}},
+                    "coke_emissivity": {},
+                    "gas_emissivity": {},
+                },
+                {
+                    "iso3": "POL",
+                    "country_name": "Poland",
+                    "scenario": "Historical",
+                    "grid_emissivity": {"2010": {"Electricity": 0.7}, "2020": {"Electricity": 0.6}},
+                    "coke_emissivity": {},
+                    "gas_emissivity": {},
+                },
+            ],
+        )
+
+        prep = DataPreparation(data_directory=tmpdir)
+        scenarios = prep.get_region_emissivity_scenarios()
+
+        assert "Historical" not in scenarios
+        assert scenarios == ["Business As Usual"]
+
+
+@pytest.mark.django_db
+def test_get_region_emissivity_scenarios_promotes_business_as_usual_to_first_position():
+    """'Business As Usual' should sort first; remaining scenarios alphabetical."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _write_region_emissivity(
+            tmpdir,
+            [
+                {
+                    "iso3": "USA",
+                    "country_name": "USA",
+                    "scenario": "Net Zero",
+                    "grid_emissivity": {"2050": {"Electricity": 0.0}},
+                    "coke_emissivity": {},
+                    "gas_emissivity": {},
+                },
+                {
+                    "iso3": "USA",
+                    "country_name": "USA",
+                    "scenario": "Business As Usual",
+                    "grid_emissivity": {"2025": {"Electricity": 0.4}},
+                    "coke_emissivity": {},
+                    "gas_emissivity": {},
+                },
+                {
+                    "iso3": "USA",
+                    "country_name": "USA",
+                    "scenario": "Aggressive Decarbonisation",
+                    "grid_emissivity": {"2050": {"Electricity": 0.0}},
+                    "coke_emissivity": {},
+                    "gas_emissivity": {},
+                },
+            ],
+        )
+
+        prep = DataPreparation(data_directory=tmpdir)
+        scenarios = prep.get_region_emissivity_scenarios()
+
+        assert scenarios == ["Business As Usual", "Aggressive Decarbonisation", "Net Zero"]
+
+
+@pytest.mark.django_db
+def test_get_region_emissivity_scenarios_returns_empty_when_no_data_directory():
+    """Should return empty list when data_directory is unset."""
+    prep = DataPreparation(data_directory="")
+    assert prep.get_region_emissivity_scenarios() == []
+
+
+@pytest.mark.django_db
+def test_get_region_emissivity_scenarios_returns_empty_when_file_missing():
+    """Should return empty list when region_emissivity.json is absent."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        prep = DataPreparation(data_directory=tmpdir)
+        assert prep.get_region_emissivity_scenarios() == []
+
+
+@pytest.mark.django_db
+def test_get_region_emissivity_scenarios_returns_empty_when_json_malformed():
+    """Should swallow JSON errors and return empty list rather than raising."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "data" / "fixtures" / "region_emissivity.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not valid json")
+
+        prep = DataPreparation(data_directory=tmpdir)
+        assert prep.get_region_emissivity_scenarios() == []

--- a/tests/web/test_modelrun_output_isolation_integration.py
+++ b/tests/web/test_modelrun_output_isolation_integration.py
@@ -133,6 +133,59 @@ class TestModelRunOutputIsolationIntegration(TransactionTestCase):
                 assert str(model_run.output_directory) in str(config.output_dir)
 
     @patch("steelo.validation.validate_technology_settings")  # Skip validation
+    @patch("steelo.bootstrap.bootstrap_simulation")
+    def test_simulation_writes_config_and_prep_metadata_json(self, mock_bootstrap_simulation, mock_validate):
+        """ModelRun.run() should drop simulation_config.json and preparation_metadata.json
+        into the isolated output directory, mirroring the terminal CLI layout."""
+        import json
+
+        mock_runner_instance = MagicMock()
+        mock_runner_instance.progress_callback = None
+        mock_runner_instance.modelrun_id = None
+        mock_runner_instance.run.return_value = {"status": "success"}
+        mock_bootstrap_simulation.return_value = mock_runner_instance
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.object(settings, "MEDIA_ROOT", temp_dir):
+                tech_settings = {
+                    "BF": {"allowed": True, "from_year": 2025, "to_year": None},
+                    "BOF": {"allowed": True, "from_year": 2025, "to_year": None},
+                    "EAF": {"allowed": True, "from_year": 2025, "to_year": None},
+                    "DRING": {"allowed": True, "from_year": 2025, "to_year": None},
+                }
+
+                model_run = ModelRun.objects.create(
+                    name="Config JSON Test",
+                    config={
+                        "start_year": 2025,
+                        "end_year": 2026,
+                        "technology_settings": tech_settings,
+                    },
+                    data_preparation=self.data_prep,
+                )
+                model_run.ensure_output_directories()
+
+                model_run.run()
+
+                output_path = Path(model_run.output_directory)
+
+                config_json = output_path / "simulation_config.json"
+                prep_json = output_path / "preparation_metadata.json"
+
+                assert config_json.exists(), "simulation_config.json was not written"
+                assert prep_json.exists(), "preparation_metadata.json was not written"
+
+                config_payload = json.loads(config_json.read_text())
+                assert config_payload["start_year"] == 2025
+                assert config_payload["end_year"] == 2026
+                assert str(output_path) in config_payload["output_dir"]
+
+                prep_payload = json.loads(prep_json.read_text())
+                assert prep_payload["cache_used"] is True
+                assert "preparation_time" in prep_payload
+                assert "master_excel" in prep_payload
+
+    @patch("steelo.validation.validate_technology_settings")  # Skip validation
     @patch("steelo.domain.datacollector.DataCollector")
     @patch("steelo.bootstrap.bootstrap_simulation")
     def test_datacollector_uses_isolated_directory(


### PR DESCRIPTION
Two related front-end changes for app-driven model runs:

- **Grid emissivity scenario dropdown** (`68c14da`): exposes `Config.chosen_grid_emissions_scenario` as a Policy Settings dropdown on the create-modelrun page. Choices are populated dynamically from the selected DataPreparation's `region_emissivity.json`, so custom scenarios coming from a user-supplied master Excel appear automatically without any frontend code changes. Scenarios with no year ≥ 2025 (e.g. "Historical") are filtered out so they can't silently zero the grid emissivity for forecast years. An HTMX endpoint refreshes the dropdown when the user switches data preparation.
- **Per-app-run config artefacts** (`66ea5b4`): writes `simulation_config.json` and `preparation_metadata.json` to each app run's output directory so app runs leave the same on-disk artefacts as terminal CLI runs. Also fixes the `ready_data_preparation` fixture to stub `region_emissivity.json` so tests submitting "Business As Usual" pass the dynamic grid-emissions choice validation introduced with the scenario dropdown.
