### PR TITLE
Change COSA to foregone operating margin (remove debt double-count)

### DIFF
--- a/docs/domain_simulation_logic/plant_agent_model/calculate_costs.md
+++ b/docs/domain_simulation_logic/plant_agent_model/calculate_costs.md
@@ -151,7 +151,6 @@ Calculates cash flows over time for profitability analysis and stranded asset co
 **Functions:**
 - `calculate_gross_cash_flow()` - Cash flow as (Revenue - OPEX) per period
 - `calculate_net_cash_flow()` - Subtracts debt from gross cash flow (for NPV)
-- `calculate_lost_cash_flow()` - Adds debt to gross cash flow (for COSA)
 
 **Note:** If unit OPEX == 0 for a period, the model assumes no production and sets cash flow to 0 (revenue is not realized).
 
@@ -166,19 +165,17 @@ Provides tools to calculate net present value (NPV) for technology investments, 
 **Note:** `construction_time` years are prepended to OPEX and debt schedules. `price_series` must include the same lead periods so its length matches the lagged OPEX/debt.
 
 ### Stranded Asset Analysis
-Calculates the Cost of Stranded Asset (COSA) when switching technologies before end-of-life, accounting for remaining debt obligations and foregone operating profits.
+Calculates the Cost of Stranded Asset (COSA) when switching technologies before end-of-life: the foregone operating margin of the current technology.
 
-When switching technologies before end-of-life, COSA represents the NPV of:
-1. **Remaining debt obligations** - Must still be repaid even if asset is abandoned
-2. **Foregone operating profits** - Lost future revenue from current technology
+When switching technologies before end-of-life, COSA represents the NPV of the **foregone operating profits** — the gross cash flow (revenue − OPEX) the current asset would have earned over its remaining life. The remaining debt is *excluded*: it persists post-switch via the `legacy_debt_schedule` (and is paid whether the plant stays or switches), so it cancels from the switch-vs-stay comparison.
 
-Formula: `COSA = NPV(Gross_Cash_Flow + Remaining_Debt)`
+Formula: `COSA = NPV(Gross_Cash_Flow)`
 
-COSA is subtracted from the NPV of the new technology to determine if a switch is economically viable.
+COSA is subtracted from the NPV of the new technology to determine if a switch is economically viable. For a loss-making incumbent (gross cash flow < 0) COSA is negative, which correctly rewards exit.
 
 **Functions:**
 - `calculate_cost_of_stranded_asset()` - NPV of losses from stranding an asset
-- `stranding_asset_cost()` - Full COSA calculation combining debt obligations and foregone profits
+- `stranding_asset_cost()` - COSA calculation: discounted foregone operating margin
 
 ### CAPEX Calculations
 Handles capital expenditure calculations including subsidies and learning-by-doing cost reductions. Returns 1.0 (no reduction) when capacity_zero is 0 to avoid division by zero.

--- a/docs/domain_simulation_logic/plant_agent_model/debt_accumulation_impact.md
+++ b/docs/domain_simulation_logic/plant_agent_model/debt_accumulation_impact.md
@@ -49,28 +49,51 @@ Total debt burden: $2,600M ($400M legacy + $2,200M)
 
 ## Behavioral Impacts
 
+> **Correction (2026-06)**: COSA and the legacy-debt schedule previously
+> double-counted the remaining debt. The old code added remaining debt inside
+> COSA *and* carried that same debt forward via the `legacy_debt_schedule` in the
+> post-switch P&L. But the old debt is paid whether the plant stays or switches,
+> so it cancels from the switch-vs-stay comparison. This has been fixed: **COSA is
+> now the foregone operating margin only** — `COSA = NPV(foregone_operating_profits)`
+> — and the persisting debt lives solely in the `legacy_debt_schedule`. The
+> magnitude of the switch penalty therefore drops, so modelled transitions are
+> somewhat faster than previously documented. The behavioural conclusions below
+> (waiting, clustering at renovation boundaries, no technology "hopping", gradual
+> 30–50 year transition) still hold, but the cause has been re-attributed: lock-in
+> now comes from (a) the foregone operating margin being large when remaining life
+> is long and small near end-of-life, and (b) the realised legacy-debt burden
+> carried by the schedule post-switch — explicitly **not** from debt being charged
+> inside COSA.
+
 ### 1. Technology Switching Timing
 
 **Observation**: Plants wait longer before switching technologies
 
-**Why**: Cost of Stranded Assets (COSA) increases with remaining debt
+**Why**: Cost of Stranded Assets (COSA) — the foregone operating margin — is large
+when many years of profitable operation remain, and shrinks towards zero near
+end-of-life. Switching early therefore forfeits more margin.
 
-**Example NPV Comparison**:
+**Example NPV Comparison** (BF margin $50M/year, r=0.08):
 
-| Switch Year | Remaining Debt | COSA | NPV (new tech) | Net Benefit |
-|-------------|----------------|------|----------------|-------------|
-| Year 5      | $600M          | $650M| $800M          | $150M       |
-| Year 10     | $400M          | $450M| $800M          | $350M       |
-| Year 15     | $200M          | $250M| $800M          | $550M       |
-| Year 20     | $0M            | $50M | $800M          | $750M       |
+| Switch Year | Years Remaining | Foregone Margin (COSA) | NPV (new tech) | Net Benefit |
+|-------------|-----------------|------------------------|----------------|-------------|
+| Year 5      | 15              | $428M                  | $800M          | $372M       |
+| Year 10     | 10              | $335M                  | $800M          | $465M       |
+| Year 15     | 5               | $200M                  | $800M          | $600M       |
+| Year 20     | 0               | $0M                    | $800M          | $800M       |
 
-**Result**: Waiting until year 20 (debt paid off) yields $600M more benefit than switching at year 5.
+**Result**: Waiting until year 20 (no remaining margin to forgo) yields more net
+benefit than switching at year 5, because COSA tracks the foregone operating
+margin, which falls as the plant approaches end-of-life. The legacy-debt schedule
+adds a further post-switch burden that bites if the plant switches before its debt
+is repaid.
 
 ### 2. Renovation Boundary Clustering
 
 **Observation**: Most technology switches occur at 20-year boundaries
 
-**Why**: Debt fully repaid → COSA minimized → Maximum net benefit
+**Why**: At end-of-life there is no remaining operating margin to forgo → COSA ≈ 0,
+and the debt is fully repaid so no legacy burden is carried forward → Maximum net benefit
 
 **Visualization**:
 ```
@@ -81,7 +104,7 @@ Year 6-10:  ▓▓ (5%)
 Year 11-15: ▓▓▓ (8%)
 Year 16-19: ▓▓▓▓ (12%)
 Year 20:    ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ (60%)  ← Majority at renovation boundary
-Year 21+:   ▓▓▓▓ (13%) ← Some delay due to affordability/capacity limits
+Year 21+:   ▓▓▓▓ (13%) ← Switches at later renovation cycles
 ```
 
 **Interpretation**:
@@ -90,38 +113,39 @@ Year 21+:   ▓▓▓▓ (13%) ← Some delay due to affordability/capacity limi
   - NPV advantage is very large (e.g., carbon price spike makes current tech uneconomical)
   - Subsidies offset the high COSA
   - Plant has excess balance to absorb the loss
+- A switch blocked in a given year by affordability or the annual capacity limit is **not** deferred to the next year: the call simply returns no action, and the furnace group is re-evaluated independently in later years (NPV and COSA recomputed for that year's economics). Any subsequent switch is therefore a fresh decision, not a queued one.
 
-### 3. Cost of Stranded Assets (COSA) Elevation
+### 3. Cost of Stranded Assets (COSA)
 
-**Observation**: COSA values are higher for mid-lifetime switches
+**Observation**: COSA is larger when more years of profitable operation remain
 
 **Formula**:
 ```python
-COSA = NPV(remaining_debt_payments + foregone_operating_profits)
+COSA = NPV(foregone_operating_profits)
 ```
+
+COSA is the **foregone operating margin only** — the discounted gross cash flow
+(revenue − OPEX) over the remaining life. The remaining debt is *not* included:
+the old debt is paid whether the plant stays or switches (it persists via the
+`legacy_debt_schedule`), so it cancels from the switch-vs-stay comparison.
 
 **Example Calculation** (switching from BF to DRI at year 10):
 
 ```
-Remaining Debt Payments:
-  Years 11-20: $400M legacy ÷ 10 = $40M/year
-
 Foregone Operating Profits:
-  BF margin: $50/t × 100 kt/year × 10 years = $50M/year
+  BF margin: $50/t × 100 kt/year = $50M/year, for 10 remaining years
 
 NPV at 8% discount rate:
-  COSA = NPV([$40M + $50M] × 10 years, r=0.08)
-  COSA = $90M × 6.71 (PV factor for 10 years)
-  COSA ≈ $604M
+  COSA = NPV($50M × 10 years, r=0.08)
+  COSA = $50M × 6.71 (PV factor for 10 years)
+  COSA ≈ $335M
 ```
 
-**Without Debt Accumulation**:
-```
-Remaining Debt: $0 (assumed paid off or written off)
-COSA = NPV($50M × 10 years, r=0.08) = $335M
-```
-
-**Impact**: Debt accumulation increases COSA by **80%** ($604M vs $335M), making switches much less attractive.
+**The legacy debt's real effect** is captured by the `legacy_debt_schedule` — the
+realised post-switch P&L carries the $400M remaining BF debt forward as actual
+debt-service payments. It is not double-counted by inflating COSA. For a
+loss-making incumbent (gross cash flow < 0) COSA is negative, correctly rewarding
+exit.
 
 ### 4. Capital Requirements
 
@@ -330,9 +354,9 @@ DEBUG   | PAM  | change_furnace_group_technology: Technology switch BF-BOF → D
 
 Debt accumulation creates realistic technology transition dynamics by:
 
-1. **Increasing COSA for mid-lifetime switches**: Making early transitions expensive
-2. **Clustering switches at renovation boundaries**: Most transitions occur when debt paid off
-3. **Preventing technology hopping**: Multiple switches lead to unsustainable debt burdens
+1. **Carrying a realised legacy-debt burden post-switch**: The `legacy_debt_schedule` keeps charging the old debt through realised P&L, making early transitions expensive (this is *not* COSA — COSA is the foregone operating margin only)
+2. **Clustering switches at renovation boundaries**: Most transitions occur at end-of-life, when there is no remaining margin to forgo (COSA ≈ 0) and the debt is fully repaid (no legacy burden)
+3. **Preventing technology hopping**: Multiple switches lead to unsustainable accumulated debt burdens via the schedule
 4. **Creating path dependency**: Early decisions have lasting financial consequences
 5. **Requiring larger capital reserves**: Plants need strong balance sheets to afford transitions
 

--- a/docs/domain_simulation_logic/plant_agent_model/furnace_group_strategy.md
+++ b/docs/domain_simulation_logic/plant_agent_model/furnace_group_strategy.md
@@ -136,9 +136,8 @@ Start
 
 ### Stage 4: Calculate Cost of Stranded Assets (COSA)
 - **Purpose**: Determine the cost of abandoning current technology
-- **Key calculation**: NPV of remaining debt + operating costs
-- **Decision**: COSA = max(calculated_COSA, remaining_debt)
-- **Rationale**: Must at minimum pay off remaining debt
+- **Key calculation**: NPV of the foregone operating margin (discounted gross cash flow over the remaining life)
+- **Rationale**: Remaining debt is excluded — it persists via the `legacy_debt_schedule` (realised P&L / closure), so it cancels from the switch-vs-stay comparison
 
 ### Stage 5: Check for Allowed Technology Transitions
 - **Decision point**: Are transitions defined for current technology?
@@ -274,7 +273,7 @@ Start
 ### Issue 4: Negative NPV After COSA
 - **Symptom**: All technologies show negative NPV
 - **Explanation**: COSA exceeds benefits of switching
-- **Debug**: Check COSA calculation and remaining debt
+- **Debug**: Check COSA calculation (foregone operating margin)
 
 # Part 2: Strategic Decision-Making
 
@@ -619,7 +618,7 @@ if expansion_and_switch_capacity + furnace_capacity > expansion_limit:
 
 # Glossary
 
-- **COSA**: Cost of Stranded Assets - economic loss from abandoning existing technology (includes remaining debt and foregone profits)
+- **COSA**: Cost of Stranded Assets - economic loss from abandoning existing technology (the foregone operating margin)
 - **NPV**: Net Present Value - present value of future cash flows minus initial investment
 - **BOM**: Bill of Materials - resource requirements for production (materials and energy)
 - **Brownfield**: Retrofit/upgrade of existing facility (reduced CAPEX)

--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -979,41 +979,15 @@ def calculate_net_cash_flow(total_debt_repayment: list[float], gross_cash_flow: 
     return [gross - debt for gross, debt in zip(gross_cash_flow, total_debt_repayment)]
 
 
-def calculate_lost_cash_flow(
-    total_debt_repayment: list[float] | list[int], gross_cash_flow: list[float] | list[int]
-) -> list[float]:
-    """
-    Calculate the lost cash flow by adding debt repayment to gross cash flow for each period.
-
-    This function is used in Cost of Stranded Asset (COSA) calculations where both the foregone
-    operating cash flows and the remaining debt obligations represent total losses from stranding.
-
-    Args:
-        total_debt_repayment (list[float] | list[int]): List of debt repayment amounts per period.
-        gross_cash_flow (list[float] | list[int]): List of gross cash flows per period.
-
-    Returns:
-        list[float]: Lost cash flow values for each period.
-
-    Note: Debt is added because remaining debt obligations represent additional losses when an asset is stranded.
-    """
-    # Validate input lists have matching lengths
-    if len(total_debt_repayment) != len(gross_cash_flow):
-        raise ValueError("The lengths of total_debt_repayment and gross_cash_flow must be the same.")
-
-    # Add debt repayment to gross cash flow for each period
-    return [gross + debt for gross, debt in zip(gross_cash_flow, total_debt_repayment)]
-
-
 def calculate_cost_of_stranded_asset(lost_cash_flow: list[float], cost_of_equity: float) -> float:
     """
     Calculate the net present value (NPV) of losses due to stranding an asset (COSA).
 
-    Discounts future lost cash flows (including both foregone operating profits and remaining
-    debt obligations) to present value using the cost of equity as the discount rate.
+    Discounts the future foregone operating cash flows to present value using the cost of equity
+    as the discount rate.
 
     Args:
-        lost_cash_flow (list[float]): Future lost cash flows per period.
+        lost_cash_flow (list[float]): Future foregone operating cash flows per period.
         cost_of_equity (float): The discount rate (cost of equity).
 
     Returns:
@@ -1188,7 +1162,6 @@ def calculate_npv_full(
 
 
 def stranding_asset_cost(
-    debt_repayment_per_year: list[float],
     unit_total_opex_list: list[float],
     remaining_time: int,
     market_price_series: list[float],
@@ -1198,18 +1171,17 @@ def stranding_asset_cost(
     """
     Calculate the Cost of Stranded Asset (COSA) when switching technologies.
 
-    COSA represents the NPV of losses from abandoning the current technology before its planned
-    end of life. This includes both remaining debt obligations (current + legacy debt) and the
-    opportunity cost of foregone profitable operations.
+    COSA is the foregone operating margin: the NPV of the gross operating cash flow the current
+    asset would have earned over its remaining life. The remaining debt is deliberately excluded —
+    it is owed whether the agent stays or switches (it persists post-switch via the legacy-debt
+    schedule), so it cancels from the switch-vs-stay comparison and must not be charged here.
 
     Steps:
-    1. Extract remaining debt payments, OPEX, and prices for the remaining asset lifetime
+    1. Extract OPEX and prices for the remaining asset lifetime
     2. Calculate gross cash flow (revenue - OPEX) for remaining periods
-    3. Calculate lost cash flow (gross cash flow + debt obligations)
-    4. Discount lost cash flows to present value using cost of equity
+    3. Discount the gross cash flow to present value using cost of equity
 
     Args:
-        debt_repayment_per_year (list[float]): Total yearly debt repayments (current + legacy debt combined).
         unit_total_opex_list (list[float]): Yearly unit total OPEX expenditures ($/unit).
         remaining_time (int): Remaining asset lifetime in years.
         market_price_series (list[float]): Market price per unit product per year ($/unit).
@@ -1217,36 +1189,29 @@ def stranding_asset_cost(
         cost_of_equity (float): Annual cost of equity as discount rate (e.g., 0.08 for 8%).
 
     Returns:
-        float: The net present value of losses due to the stranded asset (COSA).
-
-    Note: See FurnaceGroup.debt_repayment_per_year for full details on debt accumulation logic.
+        float: The NPV of the foregone operating margin (COSA). Negative for a loss-making
+        incumbent, which correctly rewards exit.
     """
     # Use function-specific logger that respects the centralized configuration
     func_logger = logging.getLogger(f"{__name__}.stranding_asset_cost")
 
-    # Extract remaining time periods for all inputs (last N years of debt, first N years of OPEX/prices)
-    remaining_debt = debt_repayment_per_year[-remaining_time:]
+    # Extract remaining time periods (first N years of OPEX/prices)
     remaining_opex = unit_total_opex_list[:remaining_time]
     remaining_price_series = market_price_series[:remaining_time]
 
-    # Calculate gross cash flow from operations for remaining periods
+    # Foregone operating margin: gross cash flow from operations for the remaining periods
     gross_cash_flow = calculate_gross_cash_flow(remaining_opex, remaining_price_series, expected_production)
-
-    # Calculate lost cash flow (both foregone profits and debt obligations)
-    lost_cash_flow = calculate_lost_cash_flow(remaining_debt, gross_cash_flow)
 
     # Log all intermediate calculations together for easier debugging
     func_logger.debug(
         f"[STRANDING ASSET COST] Remaining time: {remaining_time}, Expected production: {expected_production:,.0f} kt"
     )
     func_logger.debug(f"[STRANDING ASSET COST] Price per unit per year ($/t): {market_price_series}")
-    func_logger.debug(f"[STRANDING ASSET COST] Remaining debt: {remaining_debt}")
     func_logger.debug(f"[STRANDING ASSET COST] Remaining unit total OPEX: {remaining_opex}")
-    func_logger.debug(f"[STRANDING ASSET COST] Gross cash flow: {gross_cash_flow}")
-    func_logger.debug(f"[STRANDING ASSET COST] Lost cash flow: {lost_cash_flow}")
+    func_logger.debug(f"[STRANDING ASSET COST] Gross cash flow (foregone margin): {gross_cash_flow}")
 
-    # Discount lost cash flows to present value
-    return calculate_cost_of_stranded_asset(lost_cash_flow, cost_of_equity)
+    # Discount the foregone operating margin to present value
+    return calculate_cost_of_stranded_asset(gross_cash_flow, cost_of_equity)
 
 
 def calculate_business_opportunity_npvs(

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -2387,9 +2387,8 @@ class FurnaceGroup:
         )
         logger.debug(f"[OPTIMAL TECH] Price series ($/t): {market_price_series.get(self.technology.product)}")
 
-        # Calculate economic COSA based on remaining cash flows
-        original_cosa = stranding_asset_cost(
-            debt_repayment_per_year=self.debt_repayment_per_year,
+        # COSA = foregone operating margin only; remaining debt is excluded (carried by the legacy-debt schedule).
+        cosa = stranding_asset_cost(
             unit_total_opex_list=unit_opex_carbon_costs,
             remaining_time=self.lifetime.remaining_number_of_years,
             market_price_series=market_price_series[self.technology.product],
@@ -2397,17 +2396,7 @@ class FurnaceGroup:
             cost_of_equity=cost_of_equity,
         )
 
-        # COSA must be at least the remaining debt (can't walk away from debt obligations)
-        remaining_debt = sum(self.debt_repayment_per_year[: self.lifetime.remaining_number_of_years])
-        cosa = max(remaining_debt, original_cosa)
-
-        logger.debug(
-            f"[OPTIMAL TECH] COSA calculation - Original: ${original_cosa:,.0f}, "
-            f"Remaining debt: ${remaining_debt:,.0f}, Final COSA: ${cosa:,.0f}"
-        )
-        logger.debug(
-            f"[OPTIMAL TECH] COSA decision - Using {'remaining debt' if cosa == remaining_debt else 'calculated COSA'} as final value"
-        )
+        logger.debug(f"[OPTIMAL TECH] COSA (foregone operating margin): ${cosa:,.0f}")
 
         # ========== STAGE 5: Check for Allowed Technology Transitions ==========
         npv_dict = {}

--- a/tests/unit/test_calculate_costs.py
+++ b/tests/unit/test_calculate_costs.py
@@ -8,7 +8,6 @@ from steelo.domain.calculate_costs import (
     calculate_cost_of_stranded_asset,
     calculate_npv_costs,
     calculate_gross_cash_flow,
-    calculate_lost_cash_flow,
     calculate_npv_full,
     calculate_net_cash_flow,
     stranding_asset_cost,
@@ -200,21 +199,14 @@ def setup_cosa_data():
 
 def test_calculate_cost_of_stranded_asset_with_list_OPEX(setup_cosa_data):
     _, OPEX_list, price, expected_production, lifetime_remaining, cost_of_equity = setup_cosa_data
-    # Expected values for test
-    total_debt_repayment = calculate_debt_repayment(
-        total_investment=1400, equity_share=0.2, lifetime=4, cost_of_debt=0.05
-    )
+    # COSA discounts the foregone operating margin (gross cash flow) only; debt is excluded.
     opex_list = OPEX_list[-lifetime_remaining:]
     gross_cash_flows = calculate_gross_cash_flow(opex_list, [price] * len(opex_list), expected_production)
-    lost_cash_flows = calculate_lost_cash_flow(total_debt_repayment, gross_cash_flows)
-    discount_list = [(1 + cost_of_equity) ** i for i in range(1, len(OPEX_list) + 1)]
-    expected_npv = sum([n / d for n, d in zip(lost_cash_flows, discount_list)])
+    discount_list = [(1 + cost_of_equity) ** i for i in range(1, len(gross_cash_flows) + 1)]
+    expected_npv = sum([n / d for n, d in zip(gross_cash_flows, discount_list)])
 
-    # Run the function
-    result = calculate_cost_of_stranded_asset(lost_cash_flows, cost_of_equity)
+    result = calculate_cost_of_stranded_asset(gross_cash_flows, cost_of_equity)
 
-    # Assertion
-    # assert result == pytest.approx(175289.2, abs=0.5)
     assert pytest.approx(result, 0.01) == expected_npv
 
 
@@ -424,64 +416,64 @@ def test_calculate_npv_full_secondary_adjustment_skips_construction_years():
 
 
 def test_stranding_asset_cost():
-    debt_repayment = [
-        43000.0,
-        41000.0,
-        39000.0,
-        37000.0,
-        35000.0,
-        33000.0,
-        31000.0,
-        29000.0,
-        27000.0,
-        25000.0,
-        23000.0,
-        21000.0,
-        19000.0,
-        17000.0,
-        15000.0,
-        13000.0,
-        11000.0,
-        9000.0,
-        7000.0,
-        5000.0,
-    ]
-
-    Opex = [200] * len(debt_repayment)
-    remaining_time = 20
+    # COSA is the foregone operating margin only (discounted gross cash flow); debt is excluded.
+    Opex = [200] * 20
     price = 600
     capacity = 100
-
     cost_of_equity = 0.05
-    # equity_share = 0.05
+    expected_production = capacity * 0.8
 
-    gcf = calculate_gross_cash_flow(Opex, [price] * len(Opex), expected_production=capacity * 0.8)
-    lost_cf = calculate_lost_cash_flow(debt_repayment, gcf)
-    expected_stranding_cost = calculate_cost_of_stranded_asset(lost_cf, cost_of_equity)
+    gcf_20 = calculate_gross_cash_flow(Opex, [price] * len(Opex), expected_production=expected_production)
+    expected_20 = calculate_cost_of_stranded_asset(gcf_20, cost_of_equity)
 
-    result = stranding_asset_cost(
-        debt_repayment,
+    result_20 = stranding_asset_cost(
         Opex,
-        remaining_time,
-        [price] * remaining_time,
-        expected_production=capacity * 0.8,
+        20,
+        [price] * 20,
+        expected_production=expected_production,
         cost_of_equity=cost_of_equity,
     )
 
-    expected_stranding_cost == result
-    int(result) == 737688
+    assert result_20 == pytest.approx(expected_20)
+    assert result_20 == pytest.approx(398790.7, abs=1.0)
 
-    remaining_time = 10
-    result = stranding_asset_cost(
-        debt_repayment,
+    gcf_10 = calculate_gross_cash_flow(Opex[:10], [price] * 10, expected_production=expected_production)
+    expected_10 = calculate_cost_of_stranded_asset(gcf_10, cost_of_equity)
+
+    result_10 = stranding_asset_cost(
         Opex,
-        remaining_time,
-        [price] * remaining_time,
-        expected_production=capacity * 0.8,
+        10,
+        [price] * 10,
+        expected_production=expected_production,
         cost_of_equity=cost_of_equity,
     )
 
-    int(result) == 361391
+    assert result_10 == pytest.approx(expected_10)
+    assert result_10 == pytest.approx(247095.5, abs=1.0)
+
+
+def test_stranding_asset_cost_loss_making_incumbent_is_negative():
+    """A loss-making incumbent has a negative COSA, so switching away is rewarded, not penalised.
+
+    Regression guard for the foregone-margin fix: COSA previously carried (and was floored at) the
+    remaining debt, giving a large positive penalty that blocked value-improving switches away from
+    loss-making, indebted plants. With COSA = foregone operating margin only, a negative operating
+    margin (price below OPEX) makes COSA negative.
+    """
+    opex = [300] * 10  # OPEX above price -> negative operating margin
+    price = 200
+    production = 80
+    cost_of_equity = 0.05
+
+    cosa = stranding_asset_cost(
+        opex,
+        10,
+        [price] * 10,
+        expected_production=production,
+        cost_of_equity=cost_of_equity,
+    )
+
+    assert cosa < 0
 
 
 @pytest.mark.skip(reason="derive_best_technology_switch function was removed")

--- a/tests/unit/test_debt_accumulation.py
+++ b/tests/unit/test_debt_accumulation.py
@@ -114,7 +114,7 @@ def test_debt_accumulation_on_technology_switch():
 
 
 def test_npv_calculation_with_accumulated_debt():
-    """Test that NPV calculation properly accounts for accumulated debt through COSA."""
+    """Test that accumulated legacy debt flows through the debt-repayment schedule."""
 
     # Create a furnace group with some remaining debt
     furnace_group = FurnaceGroup(
@@ -156,8 +156,8 @@ def test_npv_calculation_with_accumulated_debt():
     current_debt = furnace_group.debt_repayment_for_current_year
     assert current_debt > 0, "Current year debt should include legacy debt"
 
-    # The total debt burden affects the COSA calculation and NPV for technology switches
-    # This ensures that switching technologies is less attractive when carrying old debt
+    # Legacy debt persists post-switch via this schedule (realised P&L), not via COSA.
+    # COSA itself is the foregone operating margin only and no longer carries the debt.
 
 
 def test_renovation_does_not_need_legacy_debt_clearing():


### PR DESCRIPTION
## Summary
- `stranding_asset_cost` now discounts the gross (foregone-margin) cash flow only; drops the unused `debt_repayment_per_year` argument and deletes `calculate_lost_cash_flow`
- Removes the remaining-debt floor (`max(remaining_debt, original_cosa)`) in `optimal_technology_name`; the legacy-debt schedule remains the single home for the persisting debt
- Updates unit tests to the foregone-margin values, converts the bare expressions in `test_stranding_asset_cost` into real assertions, and adds a loss-making-incumbent regression guard (COSA negative, rewarding exit)
- Corrects PAM docs (debt_accumulation_impact, calculate_costs, furnace_group_strategy) to attribute lock-in to the foregone margin and the legacy-debt schedule, not to debt charged inside COSA

## Why
Previously COSA double-counted debt: it was charged both inside the stranding cost and again in the legacy-debt schedule. This change makes COSA reflect the foregone operating margin only.