### PR TITLE
Make the package download cache follow STEELO_HOME, with an app-level override

### DIFF
--- a/src/django/demo_data_preparation.py
+++ b/src/django/demo_data_preparation.py
@@ -5,6 +5,8 @@ This is not a pytest test file - it's a demonstration script.
 """
 
 import os
+from pathlib import Path
+
 import django
 
 
@@ -52,6 +54,8 @@ def test_data_preparation():
     os.environ["STEELO_DEVELOPMENT"] = "true"
     os.environ["STEELO_OUTPUT_DIR"] = "/tmp/steelo_outputs"
     os.environ["STEELO_HOME"] = "/tmp/steelo_home"
+    # Reuse the shared download cache so the throwaway home doesn't refetch packages
+    os.environ["STEELO_DATA_CACHE"] = str(Path.home() / ".steelo" / "data_cache")
     os.environ["MPLBACKEND"] = "Agg"
 
     success, message = service.prepare_data(preparation)

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -519,6 +519,10 @@ function getPythonEnv(djangoBundlePath, pythonPathEnv) {
     const appDataPath = process.env.APPDATA || path.join(process.env.USERPROFILE, 'AppData', 'Roaming');
     env.STEELO_HOME = path.join(appDataPath, 'SteelModel', `v${appVersion}`);
     console.log('Setting version-specific STEELO_HOME for Windows:', env.STEELO_HOME);
+    // Keep the package download cache version-independent so a new app version
+    // reuses already-downloaded data packages (~170 MB) instead of refetching them.
+    env.STEELO_DATA_CACHE = path.join(process.env.USERPROFILE, '.steelo', 'data_cache');
+    console.log('Setting shared STEELO_DATA_CACHE for Windows:', env.STEELO_DATA_CACHE);
   }
   
   // Add DYLD_LIBRARY_PATH for macOS to find HDF5/NetCDF dylibs

--- a/src/steelo/data/manager.py
+++ b/src/steelo/data/manager.py
@@ -22,6 +22,21 @@ from .manifest import DataManifest, DataPackage
 logger = logging.getLogger(__name__)
 
 
+def default_cache_dir() -> Path:
+    """Resolve the default package download cache directory.
+
+    Returns:
+        $STEELO_DATA_CACHE if set (lets packaged apps share one download cache
+        across version-specific homes), else $STEELO_HOME/data_cache
+        (~/.steelo/data_cache when unset), so isolated simulation homes get
+        isolated download caches.
+    """
+    from ..config import get_steelo_home
+
+    env_override = os.getenv("STEELO_DATA_CACHE")
+    return Path(env_override) if env_override else get_steelo_home() / "data_cache"
+
+
 class DataManager:
     """Manages data downloads and caching for the Steel Model."""
 
@@ -35,19 +50,11 @@ class DataManager:
 
         Args:
             cache_dir: Directory for caching downloaded data. Defaults to
-                $STEELO_DATA_CACHE if set (lets packaged apps share one download
-                cache across version-specific homes), else $STEELO_HOME/data_cache
-                (~/.steelo/data_cache when unset), so isolated simulation homes
-                get isolated download caches.
+                default_cache_dir() — see its docstring for the resolution order.
             manifest_path: Path to data manifest file
             offline_mode: If True, only use cached data
         """
-        if cache_dir is None:
-            from ..config import get_steelo_home
-
-            env_override = os.getenv("STEELO_DATA_CACHE")
-            cache_dir = Path(env_override) if env_override else get_steelo_home() / "data_cache"
-        self.cache_dir = cache_dir
+        self.cache_dir = cache_dir if cache_dir is not None else default_cache_dir()
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
         default_manifest = Path(__file__).parent / "manifest.json"

--- a/src/steelo/data/manager.py
+++ b/src/steelo/data/manager.py
@@ -6,6 +6,7 @@ This module handles downloading, caching, and validation of data files.
 import hashlib
 import json
 import logging
+import os
 import shutil
 import zipfile
 from pathlib import Path
@@ -33,11 +34,20 @@ class DataManager:
         """Initialize data manager.
 
         Args:
-            cache_dir: Directory for caching downloaded data
+            cache_dir: Directory for caching downloaded data. Defaults to
+                $STEELO_DATA_CACHE if set (lets packaged apps share one download
+                cache across version-specific homes), else $STEELO_HOME/data_cache
+                (~/.steelo/data_cache when unset), so isolated simulation homes
+                get isolated download caches.
             manifest_path: Path to data manifest file
             offline_mode: If True, only use cached data
         """
-        self.cache_dir = cache_dir or Path.home() / ".steelo" / "data_cache"
+        if cache_dir is None:
+            from ..config import get_steelo_home
+
+            env_override = os.getenv("STEELO_DATA_CACHE")
+            cache_dir = Path(env_override) if env_override else get_steelo_home() / "data_cache"
+        self.cache_dir = cache_dir
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
         default_manifest = Path(__file__).parent / "manifest.json"

--- a/src/steelo/entrypoints/cache_cli.py
+++ b/src/steelo/entrypoints/cache_cli.py
@@ -8,6 +8,7 @@ from rich.table import Table
 
 from ..config import get_steelo_home
 from ..data.cache_manager import DataPreparationCache
+from ..data.manager import default_cache_dir
 
 
 def steelo_cache() -> str:
@@ -27,7 +28,9 @@ def steelo_cache() -> str:
     clear_parser.add_argument("--keep-recent", type=int, help="Keep N most recent cached preparations")
     clear_parser.add_argument("--cache-dir", type=str, help="Cache directory (default: $STEELO_HOME/preparation_cache)")
     clear_parser.add_argument(
-        "--data-cache-dir", type=str, help="Data cache directory (default: $HOME/.steelo/data_cache)"
+        "--data-cache-dir",
+        type=str,
+        help="Data cache directory (default: $STEELO_DATA_CACHE or $STEELO_HOME/data_cache)",
     )
 
     # List command
@@ -61,7 +64,7 @@ def steelo_cache() -> str:
 
     elif args.command == "clear":
         # Get data cache directory
-        data_cache_dir = Path(args.data_cache_dir) if args.data_cache_dir else get_steelo_home() / "data_cache"
+        data_cache_dir = Path(args.data_cache_dir) if args.data_cache_dir else default_cache_dir()
 
         # Get data directory (follow symlinks to find actual location)
         data_dir = Path("data")

--- a/src/steelo/entrypoints/cache_cli.py
+++ b/src/steelo/entrypoints/cache_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from rich.console import Console
 from rich.table import Table
 
+from ..config import get_steelo_home
 from ..data.cache_manager import DataPreparationCache
 
 
@@ -43,8 +44,7 @@ def steelo_cache() -> str:
     if args.cache_dir:
         cache_root = Path(args.cache_dir)
     else:
-        steelo_home = Path.home() / ".steelo"
-        cache_root = steelo_home / "preparation_cache"
+        cache_root = get_steelo_home() / "preparation_cache"
 
     cache_manager = DataPreparationCache(cache_root)
 
@@ -61,7 +61,7 @@ def steelo_cache() -> str:
 
     elif args.command == "clear":
         # Get data cache directory
-        data_cache_dir = Path(args.data_cache_dir) if args.data_cache_dir else Path.home() / ".steelo" / "data_cache"
+        data_cache_dir = Path(args.data_cache_dir) if args.data_cache_dir else get_steelo_home() / "data_cache"
 
         # Get data directory (follow symlinks to find actual location)
         data_dir = Path("data")

--- a/tests/unit/test_data_manager_cache_dir.py
+++ b/tests/unit/test_data_manager_cache_dir.py
@@ -1,0 +1,56 @@
+"""Tests for DataManager download-cache location resolution."""
+
+from pathlib import Path
+
+from steelo.data.manager import DataManager
+
+
+def test_cache_dir_defaults_to_steelo_home(monkeypatch, tmp_path):
+    """The download cache follows $STEELO_HOME so isolated homes do not share it.
+
+    Two simulations running in parallel with different STEELO_HOMEs must not
+    race on the same package download; the cache therefore lives inside the
+    active home rather than a hardcoded ~/.steelo path.
+    """
+    home = tmp_path / "isolated-home"
+    monkeypatch.setenv("STEELO_HOME", str(home))
+
+    manager = DataManager()
+
+    assert manager.cache_dir == home / "data_cache"
+    assert manager.cache_dir.is_dir()
+
+
+def test_data_cache_env_override_wins_over_home(monkeypatch, tmp_path):
+    """$STEELO_DATA_CACHE overrides the per-home default.
+
+    Packaged apps set version-specific STEELO_HOMEs but share one download cache
+    across versions via this override, so users never re-download packages.
+    """
+    monkeypatch.setenv("STEELO_HOME", str(tmp_path / "versioned-home"))
+    shared = tmp_path / "shared-cache"
+    monkeypatch.setenv("STEELO_DATA_CACHE", str(shared))
+
+    manager = DataManager()
+
+    assert manager.cache_dir == shared
+
+
+def test_cache_dir_falls_back_to_default_home(monkeypatch):
+    """Without STEELO_HOME set, the cache stays at ~/.steelo/data_cache."""
+    monkeypatch.delenv("STEELO_HOME", raising=False)
+    monkeypatch.delenv("STEELO_DATA_CACHE", raising=False)
+
+    manager = DataManager()
+
+    assert manager.cache_dir == Path.home() / ".steelo" / "data_cache"
+
+
+def test_explicit_cache_dir_wins(monkeypatch, tmp_path):
+    """An explicitly passed cache_dir overrides any STEELO_HOME setting."""
+    monkeypatch.setenv("STEELO_HOME", str(tmp_path / "ignored-home"))
+    explicit = tmp_path / "explicit-cache"
+
+    manager = DataManager(cache_dir=explicit)
+
+    assert manager.cache_dir == explicit


### PR DESCRIPTION
## Problem

`DataManager` hardcoded its package download cache to `~/.steelo/data_cache`, ignoring `STEELO_HOME`. Two parallel simulations with fresh homes raced on the same `core-data.tmp` download (checksum mismatch / vanished file, observed live). A naive per-home cache would however make the Windows standalone app re-download ~170 MB of packages on every release, because its Electron shell sets a version-specific `STEELO_HOME`.

## Solution

Download-cache resolution order in `DataManager` (shared `default_cache_dir()` resolver, also used by `steelo-cache clear`):

1. explicit `cache_dir` argument (unchanged)
2. `$STEELO_DATA_CACHE` env var — absolute override, set by the packaged app
3. `$STEELO_HOME/data_cache` — isolated homes get isolated caches
4. `~/.steelo/data_cache` when nothing is set (old behaviour, byte-identical)

The Electron Windows-standalone block sets `STEELO_DATA_CACHE=%USERPROFILE%\.steelo\data_cache` — the exact pre-change location — so existing installs keep their downloaded packages and new app versions re-download nothing. Preparation caches deliberately stay per-version inside the versioned `STEELO_HOME`.

## Validation

- 4 new unit tests cover the resolution order; full `pytest` + `mypy src/` green
- Behavioural spot checks: no env vars → legacy path; `STEELO_HOME` → per-home; override wins
- End-to-end throwaway-home simulation downloads packages into the isolated home
- macOS / dev-mode Electron never sets these env vars → behaviour unchanged; both Windows spawn points inherit the env via `getPythonEnv()`
- Outstanding: first-launch check on the next Windows build (upgrade install must report packages already cached)