### PR TITLE
Fix TM PAM connector energy cost booking: convert per-product costs once at the connector snapshot

### DIFF
--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -229,20 +229,24 @@ def calculate_cost_breakdown_by_feedstock(
     """
     Calculate detailed cost breakdown by feedstock type for a furnace group.
 
-    Uses actual BOM energy and distributes it proportionally across feedstocks based on their
-    energy intensity (from dynamic business cases) and usage share (demand_share_pct).
+    The material cost column comes from the booked BOM (the ledger); the energy carrier
+    columns and by-product credits are built bottom-up from the authored business case
+    (``energy_vopex_breakdown_by_input`` and ``dbc.outputs`` x prices), each weighted by the
+    pathway's product share. Because those legs are ledger-independent, the columns summing
+    to unit_vopex + unit_secondary_output_costs is a genuine cross-check: divergence signals
+    a booking bug or a stale (preserved) BOM rather than being true by construction.
 
-    Secondary output revenues (by-products with prices in ``output_costs``) are included as
-    negative values. Carriers in ``disposal_cost_outputs`` keep their raw price sign
-    (positive = disposal cost).
+    Carriers in ``disposal_cost_outputs`` keep their raw price sign (positive = disposal cost).
 
     Args:
-        bill_of_materials: Nested dictionary containing materials and energy data.
+        bill_of_materials: Nested dictionary containing materials data (energy is not read).
         chosen_reductant: Selected reductant type (e.g., 'coke', 'natural_gas') to filter
             business cases.
         dynamic_business_cases: List of primary feedstock options with energy requirements.
         energy_costs: Unused, kept for backward compatibility.
-        energy_vopex_breakdown_by_input: Unused, kept for backward compatibility.
+        energy_vopex_breakdown_by_input: Per-charge, per-carrier energy costs in USD per
+            tonne of product (FurnaceGroup.energy_vopex_breakdown_by_input) — the bottom-up
+            source for the energy columns.
         cost_breakdown_keys: Canonical list of normalised carrier/feedstock keys
             that should appear in every feedstock's breakdown. Missing keys are zero-padded.
             Derived from primary_feedstocks.json. When None, no zero-padding is applied.
@@ -259,44 +263,6 @@ def calculate_cost_breakdown_by_feedstock(
 
     if not bill_of_materials or not bill_of_materials.get("materials"):
         return breakdown
-
-    # Get BOM energy (same source as calculate_variable_opex)
-    bom_energy = bill_of_materials.get("energy", {})
-
-    # Calculate energy intensity per carrier for each feedstock from dynamic business case
-    # Structure: {feedstock: {carrier: amount}}
-    feedstock_carrier_intensities: dict[str, dict[str, float]] = {}
-
-    for dbc in dynamic_business_cases:
-        if dbc.reductant != chosen_reductant:
-            continue
-
-        dbc_lower = dbc.metallic_charge.lower()
-        if dbc_lower not in bill_of_materials["materials"]:
-            continue
-
-        carrier_amounts: dict[str, float] = {}
-
-        # Get energy requirements by carrier
-        for energy_key, amount in (dbc.energy_requirements or {}).items():
-            normalized_key = normalize_name(energy_key)
-            if normalized_key in ENERGY_FEEDSTOCK_KEYS:
-                carrier_amounts[normalized_key] = carrier_amounts.get(normalized_key, 0.0) + (
-                    _coerce_to_float(amount) or 0.0
-                )
-
-        # Add secondary feedstock by carrier (already in t/t after excel_reader conversion)
-        for secondary_key, amount in (dbc.secondary_feedstock or {}).items():
-            normalized_secondary = normalize_name(secondary_key)
-            if normalized_secondary in ENERGY_FEEDSTOCK_KEYS:
-                carrier_amounts[normalized_secondary] = carrier_amounts.get(normalized_secondary, 0.0) + amount
-
-        feedstock_carrier_intensities[dbc_lower] = carrier_amounts
-
-    logger.debug(
-        "feedstock_carrier_intensities: %s",
-        {k: sorted(v.keys()) for k, v in feedstock_carrier_intensities.items()},
-    )
 
     # Build cost breakdown for each feedstock
     for dbc in dynamic_business_cases:
@@ -316,48 +282,30 @@ def calculate_cost_breakdown_by_feedstock(
 
         demand_share = _coerce_to_float(material_entry.get("demand_share_pct", 1.0)) or 1.0
 
-        # Distribute BOM energy proportionally if available
-        if bom_energy and metallic_charge_lower in feedstock_carrier_intensities:
-            feedstock_carriers = feedstock_carrier_intensities[metallic_charge_lower]
+        # Energy vopex and by-product amounts are per tonne of product -> weight by the
+        # pathway's product share, not its input-tonne share.
+        req_qty = dbc.required_quantity_per_ton_of_product
+        if not req_qty:
+            raise ValueError(
+                f"Feedstock {dbc.metallic_charge} ({dbc.reductant}) has no "
+                "required_quantity_per_ton_of_product to derive its product share with"
+            )
+        product_share = demand_share / req_qty
 
-            # Distribute BOM energy carrier-by-carrier
-            for carrier, carrier_data in bom_energy.items():
-                if not isinstance(carrier_data, dict):
+        if energy_vopex_breakdown_by_input:
+            charge_breakdown = (
+                energy_vopex_breakdown_by_input.get(dbc.metallic_charge)
+                or energy_vopex_breakdown_by_input.get(metallic_charge_lower)
+                or {}
+            )
+            for carrier, cost_per_tonne_product in charge_breakdown.items():
+                cost_value = _coerce_to_float(cost_per_tonne_product) or 0.0
+                if cost_value == 0:
                     continue
-
-                carrier_unit_cost = _coerce_to_float(carrier_data.get("unit_cost")) or 0.0
-                if carrier_unit_cost == 0:
-                    continue
-
                 normalized_carrier = normalize_name(carrier)
-
-                # Check if this feedstock uses this carrier
-                feedstock_carrier_intensity = feedstock_carriers.get(normalized_carrier, 0.0)
-                if feedstock_carrier_intensity == 0:
-                    # This feedstock doesn't use this carrier, skip it
-                    continue
-
-                # Calculate weighted intensity for THIS CARRIER across all feedstocks that use it
-                total_weighted_intensity_for_carrier = 0.0
-                for fs_lower, fs_carriers in feedstock_carrier_intensities.items():
-                    if fs_lower not in bill_of_materials["materials"]:
-                        continue
-
-                    fs_carrier_intensity = fs_carriers.get(normalized_carrier, 0.0)
-                    if fs_carrier_intensity > 0:
-                        fs_demand_share = (
-                            _coerce_to_float(bill_of_materials["materials"][fs_lower].get("demand_share_pct", 1.0))
-                            or 1.0
-                        )
-                        total_weighted_intensity_for_carrier += fs_carrier_intensity * fs_demand_share
-
-                if total_weighted_intensity_for_carrier > 0:
-                    # This feedstock's share of THIS carrier's cost
-                    carrier_weight = (demand_share * feedstock_carrier_intensity) / total_weighted_intensity_for_carrier
-
-                    # Weighted energy cost for this feedstock and carrier
-                    weighted_cost = carrier_unit_cost * carrier_weight
-                    feed_breakdown[normalized_carrier] = feed_breakdown.get(normalized_carrier, 0.0) + weighted_cost
+                feed_breakdown[normalized_carrier] = (
+                    feed_breakdown.get(normalized_carrier, 0.0) + cost_value * product_share
+                )
 
         # Add output revenue/cost for by-products
         # Physical outputs (dbc.outputs): revenue via -abs(price), unless disposal cost
@@ -366,14 +314,6 @@ def calculate_cost_breakdown_by_feedstock(
             all_outputs = {**(dbc.outputs or {}), **(dbc.carbon_outputs or {})}
             primary_output_keys = set(dbc.get_primary_outputs().keys())
             physical_output_keys = set(normalize_name(k) for k in (dbc.outputs or {}).keys())
-            # By-product amounts are per tonne of product -> weight by product share, not input share.
-            req_qty = dbc.required_quantity_per_ton_of_product
-            if all_outputs and not req_qty:
-                raise ValueError(
-                    f"Feedstock {dbc.name} has outputs but no required_quantity_per_ton_of_product "
-                    "to derive its product share with"
-                )
-            product_share = demand_share / req_qty if req_qty else 0.0
             if all_outputs:
                 logger.debug(
                     "outputs for %s: all=%s primary(excluded)=%s",

--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -220,7 +220,6 @@ def calculate_cost_breakdown_by_feedstock(
     bill_of_materials: dict[str, dict[str, dict[str, float]]],
     chosen_reductant: str,
     dynamic_business_cases: list["PrimaryFeedstock"],
-    energy_costs: dict[str, float],
     energy_vopex_breakdown_by_input: dict[str, dict[str, float]] | None = None,
     cost_breakdown_keys: list[str] | None = None,
     output_costs: dict[str, float] | None = None,
@@ -243,7 +242,6 @@ def calculate_cost_breakdown_by_feedstock(
         chosen_reductant: Selected reductant type (e.g., 'coke', 'natural_gas') to filter
             business cases.
         dynamic_business_cases: List of primary feedstock options with energy requirements.
-        energy_costs: Unused, kept for backward compatibility.
         energy_vopex_breakdown_by_input: Per-charge, per-carrier energy costs in USD per
             tonne of product (FurnaceGroup.energy_vopex_breakdown_by_input) — the bottom-up
             source for the energy columns.

--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -366,6 +366,14 @@ def calculate_cost_breakdown_by_feedstock(
             all_outputs = {**(dbc.outputs or {}), **(dbc.carbon_outputs or {})}
             primary_output_keys = set(dbc.get_primary_outputs().keys())
             physical_output_keys = set(normalize_name(k) for k in (dbc.outputs or {}).keys())
+            # By-product amounts are per tonne of product -> weight by product share, not input share.
+            req_qty = dbc.required_quantity_per_ton_of_product
+            if all_outputs and not req_qty:
+                raise ValueError(
+                    f"Feedstock {dbc.name} has outputs but no required_quantity_per_ton_of_product "
+                    "to derive its product share with"
+                )
+            product_share = demand_share / req_qty if req_qty else 0.0
             if all_outputs:
                 logger.debug(
                     "outputs for %s: all=%s primary(excluded)=%s",
@@ -391,14 +399,14 @@ def calculate_cost_breakdown_by_feedstock(
                         effective_price = -abs(raw_price)  # revenue
                 else:
                     effective_price = raw_price  # carbon outputs keep sign
-                revenue = amount * effective_price * demand_share
+                revenue = amount * effective_price * product_share
                 logger.debug(
-                    "[COST BREAKDOWN] output '%s'%s: amount=%.4f x price=$%.4f x share=%.4f = $%.4f",
+                    "[COST BREAKDOWN] output '%s'%s: amount=%.4f x price=$%.4f x product_share=%.4f = $%.4f",
                     normalized_output,
                     " [disposal]" if disposal_cost_outputs and normalized_output in disposal_cost_outputs else "",
                     amount,
                     effective_price,
-                    demand_share,
+                    product_share,
                     revenue,
                 )
                 feed_breakdown[normalized_output] = feed_breakdown.get(normalized_output, 0.0) + revenue
@@ -1918,7 +1926,8 @@ def calculate_cost_adjustments_from_secondary_outputs(
     """
     Calculate per-unit cost adjustments from secondary outputs (by-products).
 
-    The adjustment is expressed in USD per tonne of product. Revenues from by-products will
+    The adjustment is expressed in USD per tonne of product, weighting each feedstock pathway
+    by its product share (demand / required_quantity). Revenues from by-products will
     return negative values (reducing production cost) while additional costs will return positive
     values.
 
@@ -1956,11 +1965,10 @@ def calculate_cost_adjustments_from_secondary_outputs(
         if material_volume <= 0:
             continue
 
-        product_volume = material_data.get("product_volume")
-        if (product_volume is None or product_volume <= 0) and getattr(dbc, "required_quantity_per_ton_of_product", 0):
-            required_qty = dbc.required_quantity_per_ton_of_product
-            if required_qty:
-                product_volume = material_volume / required_qty
+        # This pathway's own product contribution — the BOM's product_volume is the furnace
+        # group's TOTAL production, which would weight every pathway equally.
+        required_qty = getattr(dbc, "required_quantity_per_ton_of_product", None)
+        product_volume = material_volume / required_qty if required_qty else material_data.get("product_volume")
         if product_volume is None or product_volume <= 0:
             continue
 

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -2174,7 +2174,6 @@ class FurnaceGroup:
         return calculate_cost_breakdown_by_feedstock(
             bill_of_materials=self.bill_of_materials,
             dynamic_business_cases=self.technology.dynamic_business_case or [],
-            energy_costs=self.energy_costs,
             chosen_reductant=self.chosen_reductant,
             energy_vopex_breakdown_by_input=self.energy_vopex_breakdown_by_input,
             cost_breakdown_keys=self.cost_breakdown_keys,

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -9170,9 +9170,12 @@ class Environment:
                     f"expected dict, got {type(share_data).__name__}"
                 )
 
-            # (a) Check input_effectiveness
+            # (a) Check input_effectiveness. Energy-like commodities (e.g. traded bio_pci
+            # booked into materials by the TM write-back) are expected here — their cost
+            # comes through the energy reconstruction instead.
             if normalized_feedstock not in input_effectiveness:
-                logger.warning(
+                skip_log = logger.debug if normalized_feedstock in ENERGY_FEEDSTOCK_KEYS else logger.warning
+                skip_log(
                     "[AVG_BOM_DIAG] pf_match: tech=%s mc=%s skipped, not in input_effectiveness (available: %s)",
                     tech,
                     feedstock,
@@ -9260,6 +9263,13 @@ class Environment:
                 tech,
             )
         else:
+            # Renormalise surviving input shares — skipped entries (e.g. bio_pci) must not
+            # deflate the metallic-charge demands they were counted against.
+            total_input_share = sum(data["input_share_pct"] for data in surviving.values())
+            if total_input_share > 0:
+                for data in surviving.values():
+                    data["input_share_pct"] /= total_input_share
+
             # Compute output shares from input shares and effectiveness
             raw_output: dict[str, float] = {}
             for norm_mc, data in surviving.items():

--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -44,7 +44,9 @@ class TM_PAM_connector:
         Attributes Created:
             flat_feedstocks_dict: Flattened dict for O(1) feedstock lookup by name.
             feedstock_energy_requirements: Energy requirements per feedstock type.
-            processing_energy_cost: Energy costs (total + carrier breakdown) by furnace group and commodity.
+            processing_energy_cost: Energy costs (total + carrier breakdown) by furnace group and
+                commodity, in USD per tonne of metallic INPUT (converted from the FG's per-tonne-of-
+                product energy_vopex dicts using each charge's required_quantity_per_ton_of_product).
             chosen_reductant: Reductant choice for each furnace group.
             transport_costs: Dict mapping (from_iso, to_iso, commodity) to cost.
             iron_furnaces: List of furnace group IDs producing iron.
@@ -61,12 +63,34 @@ class TM_PAM_connector:
                 per_feed_energy: dict[str, dict[str, dict[str, float] | float]] = {}
                 feed_totals = getattr(fg, "energy_vopex_by_input", {}) or {}
                 feed_breakdowns = getattr(fg, "energy_vopex_breakdown_by_input", {}) or {}
+                req_by_charge = (
+                    {
+                        str(feedstock.metallic_charge).lower(): feedstock.required_quantity_per_ton_of_product
+                        for feedstock in fg.effective_primary_feedstocks
+                        if isinstance(feedstock.metallic_charge, str)
+                    }
+                    if feed_totals
+                    else {}
+                )
                 for commodity, total_cost in feed_totals.items():
-                    normalized_commodity = str(commodity).lower()
-                    breakdown = feed_breakdowns.get(commodity) or feed_breakdowns.get(str(commodity).lower()) or {}
-                    normalized_breakdown = {normalize_name(carrier): float(cost) for carrier, cost in breakdown.items()}
+                    if not isinstance(commodity, str):
+                        continue
+                    normalized_commodity = commodity.lower()
+                    # energy_vopex_* values are USD per tonne of product; edge volumes flow in
+                    # metallic-input tonnes, so convert here — once — to USD per tonne of input.
+                    req_qty = req_by_charge.get(normalized_commodity)
+                    if not req_qty:
+                        raise ValueError(
+                            f"Furnace group {fg.furnace_group_id} carries energy cost for metallic charge "
+                            f"'{commodity}' but has no effective primary feedstock row with a "
+                            "required_quantity_per_ton_of_product to convert it with"
+                        )
+                    breakdown = feed_breakdowns.get(commodity) or feed_breakdowns.get(normalized_commodity) or {}
+                    normalized_breakdown = {
+                        normalize_name(carrier): float(cost) / req_qty for carrier, cost in breakdown.items()
+                    }
                     per_feed_energy[normalized_commodity] = {
-                        "total": float(total_cost),
+                        "total": float(total_cost) / req_qty,
                         "carriers": normalized_breakdown,
                     }
                 self.processing_energy_cost[fg.furnace_group_id] = per_feed_energy
@@ -269,7 +293,8 @@ class TM_PAM_connector:
         Notes
         -----
         - Uses `self.chosen_reductant` to name reductant-specific processes.
-        - Uses `self.processing_energy_cost` to fetch energy costs per process.
+        - Uses `self.processing_energy_cost` to fetch energy costs per process (USD per
+          tonne of metallic input, matching the input-tonne edge volumes).
         - Uses `self.flat_feedstocks_dict` to lookup primary outputs and efficiencies.
         """
         logger = logging.getLogger(f"{__name__}.create_graph")
@@ -868,9 +893,9 @@ class TM_PAM_connector:
                     },
                     "energy": {
                         commodity_name: {
-                            "demand": float,       # Total energy demand
+                            "demand": float,       # Metallic-input tonnes the cost was booked on
                             "total_cost": float,   # Total energy cost (USD)
-                            "unit_cost": float     # Energy cost per unit (USD/unit)
+                            "unit_cost": float     # Energy cost per tonne of product (USD/t)
                         }
                     }
                 }

--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -7,6 +7,7 @@ from collections import deque
 from steelo.adapters.repositories.in_memory_repository import (
     PlantInMemoryRepository,
 )
+from steelo.domain.calculate_costs import ENERGY_FEEDSTOCK_KEYS
 from steelo.domain.models import PrimaryFeedstock, FurnaceGroup, TransportKPI
 from steelo.domain.trade_modelling.trade_lp_modelling import Allocations, ProcessType
 from steelo.domain.constants import LP_TOLERANCE
@@ -24,6 +25,23 @@ def _required_quantity_by_charge(fg) -> dict[str, float]:
         for feedstock in fg.effective_primary_feedstocks
         if isinstance(feedstock.metallic_charge, str)
     }
+
+
+def _energy_intensity_by_charge(fg) -> dict[str, dict[str, float]]:
+    """Per-charge carrier quantities per tonne of product (energy requirements plus
+    energy-like secondary feedstocks), keyed by normalised carrier name."""
+    intensities: dict[str, dict[str, float]] = {}
+    for feedstock in fg.effective_primary_feedstocks:
+        if not isinstance(feedstock.metallic_charge, str):
+            continue
+        carriers: dict[str, float] = {}
+        for source in (feedstock.energy_requirements or {}, feedstock.secondary_feedstock or {}):
+            for carrier, amount in source.items():
+                normalized = normalize_name(carrier)
+                if normalized in ENERGY_FEEDSTOCK_KEYS:
+                    carriers[normalized] = carriers.get(normalized, 0.0) + amount
+        intensities[feedstock.metallic_charge.lower()] = carriers
+    return intensities
 
 
 class TM_PAM_connector:
@@ -895,7 +913,7 @@ class TM_PAM_connector:
                     },
                     "energy": {
                         commodity_name: {
-                            "demand": float,       # Metallic-input tonnes the cost was booked on
+                            "demand": float,       # Carrier quantity (t or kWh, post-conversion units)
                             "total_cost": float,   # Total energy cost (USD)
                             "unit_cost": float     # Energy cost per tonne of product (USD/t)
                         }
@@ -1070,6 +1088,16 @@ class TM_PAM_connector:
                         fg.furnace_group_id,
                         booked_energy,
                         expected_energy,
+                    )
+
+                # Restate energy demand as carrier quantities (t / kWh, matching the price
+                # units) instead of the edge's metallic input tonnage.
+                intensity_by_charge = _energy_intensity_by_charge(fg)
+                for carrier, entry in collect["energy"].items():
+                    entry["demand"] = sum(
+                        material["demand"] / req * intensity_by_charge.get(charge, {}).get(carrier, 0.0)
+                        for charge, material in collect["materials"].items()
+                        if (req := req_by_charge.get(charge))
                     )
 
             util_rate = getattr(fg, "utilization_rate", None)

--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -1064,10 +1064,12 @@ class TM_PAM_connector:
                 )
                 booked_energy = sum(entry["total_cost"] for entry in collect["energy"].values())
                 if not math.isclose(booked_energy, expected_energy, rel_tol=1e-9, abs_tol=1e-6):
-                    raise ValueError(
-                        f"Energy booking mismatch for furnace group {fg.furnace_group_id}: "
-                        f"booked {booked_energy:.6f} USD vs {expected_energy:.6f} USD expected "
-                        "from per-product energy vopex x product tonnes"
+                    logger.error(
+                        "Energy booking mismatch for furnace group %s: booked %.6f USD vs %.6f USD "
+                        "expected from per-product energy vopex x product tonnes",
+                        fg.furnace_group_id,
+                        booked_energy,
+                        expected_energy,
                     )
 
             util_rate = getattr(fg, "utilization_rate", None)

--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import math
 from typing import Any
 import networkx as nx
 from collections import deque
@@ -14,6 +15,15 @@ from steelo.utilities.utils import normalize_name
 
 
 # logging.getLogger().setLevel(logging.WARNING)  # Commented out to avoid setting root logger
+
+
+def _required_quantity_by_charge(fg) -> dict[str, float]:
+    """Map each metallic charge of the FG's chosen-reductant feedstock rows to its req_qty."""
+    return {
+        str(feedstock.metallic_charge).lower(): feedstock.required_quantity_per_ton_of_product
+        for feedstock in fg.effective_primary_feedstocks
+        if isinstance(feedstock.metallic_charge, str)
+    }
 
 
 class TM_PAM_connector:
@@ -63,15 +73,7 @@ class TM_PAM_connector:
                 per_feed_energy: dict[str, dict[str, dict[str, float] | float]] = {}
                 feed_totals = getattr(fg, "energy_vopex_by_input", {}) or {}
                 feed_breakdowns = getattr(fg, "energy_vopex_breakdown_by_input", {}) or {}
-                req_by_charge = (
-                    {
-                        str(feedstock.metallic_charge).lower(): feedstock.required_quantity_per_ton_of_product
-                        for feedstock in fg.effective_primary_feedstocks
-                        if isinstance(feedstock.metallic_charge, str)
-                    }
-                    if feed_totals
-                    else {}
-                )
+                req_by_charge = _required_quantity_by_charge(fg) if feed_totals else {}
                 for commodity, total_cost in feed_totals.items():
                     if not isinstance(commodity, str):
                         continue
@@ -1044,6 +1046,29 @@ class TM_PAM_connector:
                         )
 
             logger.debug(f"[BOM] FG {fg.furnace_group_id}: Final BOM materials = {list(collect['materials'].keys())}")
+
+            # Two-leg check on freshly booked energy: the ledger total (built from edge costs
+            # x volumes) must equal the FG's own per-product energy vopex x product tonnes.
+            # Divergence means a unit or booking regression somewhere in the edge pipeline.
+            if collect["energy"] and collect["materials"]:
+                vopex_by_charge = {
+                    str(charge).lower(): float(value)
+                    for charge, value in (getattr(fg, "energy_vopex_by_input", {}) or {}).items()
+                    if isinstance(charge, str)
+                }
+                req_by_charge = _required_quantity_by_charge(fg)
+                expected_energy = sum(
+                    material["demand"] / req_by_charge[charge] * vopex_by_charge[charge]
+                    for charge, material in collect["materials"].items()
+                    if charge in vopex_by_charge
+                )
+                booked_energy = sum(entry["total_cost"] for entry in collect["energy"].values())
+                if not math.isclose(booked_energy, expected_energy, rel_tol=1e-9, abs_tol=1e-6):
+                    raise ValueError(
+                        f"Energy booking mismatch for furnace group {fg.furnace_group_id}: "
+                        f"booked {booked_energy:.6f} USD vs {expected_energy:.6f} USD expected "
+                        "from per-product energy vopex x product tonnes"
+                    )
 
             util_rate = getattr(fg, "utilization_rate", None)
             if util_rate is not None and util_rate <= 0:

--- a/tests/unit/test_calculate_costs.py
+++ b/tests/unit/test_calculate_costs.py
@@ -654,9 +654,6 @@ def test_cost_breakdown_nets_dual_carrier():
                 "product_volume": 1000.0,
             },
         },
-        "energy": {
-            "bf_gas": {"unit_cost": 10.0, "demand": 100.0},
-        },
     }
     # bf_gas has POSITIVE price (cost to buy); output should still be revenue via -abs()
     input_costs = {"bf_gas": 5.0}
@@ -666,10 +663,11 @@ def test_cost_breakdown_nets_dual_carrier():
         chosen_reductant="coke",
         dynamic_business_cases=[dbc],
         energy_costs={},
+        energy_vopex_breakdown_by_input={"io_low": {"bf_gas": 10.0}},
         output_costs=input_costs,
     )
 
-    # Energy input: bf_gas unit_cost = 10.0 (full allocation, single feedstock)
+    # Energy input: per-product vopex 10.0 x product share 1.0
     # Output revenue: 0.2 * -abs(5.0) * 1.0 = -1.0 (physical output → always revenue)
     # Net: 10.0 + (-1.0) = 9.0
     assert result["io_low"]["bf_gas"] == pytest.approx(9.0)

--- a/tests/unit/test_calculate_costs.py
+++ b/tests/unit/test_calculate_costs.py
@@ -583,6 +583,7 @@ class _BreakdownDBC:
         energy_requirements: dict | None = None,
         secondary_feedstock: dict | None = None,
         primary_output_keys: set | None = None,
+        required_quantity_per_ton_of_product: float = 1.0,
     ):
         self.metallic_charge = metallic_charge
         self.reductant = reductant
@@ -592,6 +593,7 @@ class _BreakdownDBC:
         self.energy_requirements = energy_requirements or {}
         self.secondary_feedstock = secondary_feedstock or {}
         self._primary_output_keys = primary_output_keys or set()
+        self.required_quantity_per_ton_of_product = required_quantity_per_ton_of_product
 
     def get_primary_outputs(self, primary_products=None):
         """Return dict of primary outputs (keys used for filtering)."""
@@ -1035,3 +1037,104 @@ def test_breakdown_disposal_cost_none_preserves_legacy():
 
     # No disposal flag: -abs(15) * 0.3 * 1.0 = -4.5 (revenue)
     assert result["io_low"]["steelmaking_slag"] == pytest.approx(-4.5)
+
+
+def test_cost_breakdown_credits_weighted_by_product_share():
+    """Multi-pathway by-product credits use product shares, not input-tonne shares."""
+    dbcs = [
+        _BreakdownDBC(
+            metallic_charge="io_low",
+            reductant="coke",
+            outputs={"ironmaking_slag": 0.3},
+            required_quantity_per_ton_of_product=1.6,
+        ),
+        _BreakdownDBC(
+            metallic_charge="io_mid",
+            reductant="coke",
+            outputs={"ironmaking_slag": 0.2},
+            required_quantity_per_ton_of_product=1.5,
+        ),
+    ]
+    bom = {
+        "materials": {
+            "io_low": {
+                "demand": 160.0,
+                "demand_share_pct": 0.8,
+                "unit_material_cost": 100.0,
+                "product_volume": 200.0,
+            },
+            "io_mid": {
+                "demand": 150.0,
+                "demand_share_pct": 0.75,
+                "unit_material_cost": 90.0,
+                "product_volume": 200.0,
+            },
+        },
+        "energy": {},
+    }
+
+    result = calculate_cost_breakdown_by_feedstock(
+        bill_of_materials=bom,
+        chosen_reductant="coke",
+        dynamic_business_cases=dbcs,
+        energy_costs={},
+        output_costs={"ironmaking_slag": -10.0},
+    )
+
+    # product shares: io_low 0.8/1.6 = 0.5, io_mid 0.75/1.5 = 0.5
+    assert result["io_low"]["ironmaking_slag"] == pytest.approx(0.3 * -10.0 * 0.5)
+    assert result["io_mid"]["ironmaking_slag"] == pytest.approx(0.2 * -10.0 * 0.5)
+
+
+def test_secondary_output_scalar_matches_breakdown_credits():
+    """The unit_secondary_output_costs scalar equals the summed breakdown credits."""
+    dbcs = [
+        _BreakdownDBC(
+            metallic_charge="io_low",
+            reductant="coke",
+            outputs={"ironmaking_slag": 0.3},
+            required_quantity_per_ton_of_product=1.6,
+        ),
+        _BreakdownDBC(
+            metallic_charge="io_mid",
+            reductant="coke",
+            outputs={"ironmaking_slag": 0.2},
+            required_quantity_per_ton_of_product=1.5,
+        ),
+    ]
+    bom = {
+        "materials": {
+            "io_low": {
+                "demand": 160.0,
+                "demand_share_pct": 0.8,
+                "unit_material_cost": 100.0,
+                "product_volume": 200.0,
+            },
+            "io_mid": {
+                "demand": 150.0,
+                "demand_share_pct": 0.75,
+                "unit_material_cost": 90.0,
+                "product_volume": 200.0,
+            },
+        },
+        "energy": {},
+    }
+    output_costs = {"ironmaking_slag": -10.0}
+
+    breakdown = calculate_cost_breakdown_by_feedstock(
+        bill_of_materials=bom,
+        chosen_reductant="coke",
+        dynamic_business_cases=dbcs,
+        energy_costs={},
+        output_costs=output_costs,
+    )
+    scalar = calculate_cost_adjustments_from_secondary_outputs(
+        bill_of_materials=bom,
+        dynamic_business_cases=dbcs,
+        output_costs=output_costs,
+    )
+
+    credits = breakdown["io_low"]["ironmaking_slag"] + breakdown["io_mid"]["ironmaking_slag"]
+    # (100 t x -10 x 0.3 + 100 t x -10 x 0.2) / 200 t = -2.5 USD/t product
+    assert scalar == pytest.approx(-2.5)
+    assert credits == pytest.approx(scalar)

--- a/tests/unit/test_calculate_costs.py
+++ b/tests/unit/test_calculate_costs.py
@@ -628,7 +628,6 @@ def test_cost_breakdown_includes_output_revenue():
         bill_of_materials=bom,
         chosen_reductant="coke",
         dynamic_business_cases=[dbc],
-        energy_costs={},
         output_costs=input_costs,
     )
 
@@ -662,7 +661,6 @@ def test_cost_breakdown_nets_dual_carrier():
         bill_of_materials=bom,
         chosen_reductant="coke",
         dynamic_business_cases=[dbc],
-        energy_costs={},
         energy_vopex_breakdown_by_input={"io_low": {"bf_gas": 10.0}},
         output_costs=input_costs,
     )
@@ -699,7 +697,6 @@ def test_cost_breakdown_excludes_primary_products():
         bill_of_materials=bom,
         chosen_reductant="",
         dynamic_business_cases=[dbc],
-        energy_costs={},
         output_costs=input_costs,
     )
 
@@ -734,7 +731,6 @@ def test_cost_breakdown_skips_outputs_without_price():
         bill_of_materials=bom,
         chosen_reductant="coke",
         dynamic_business_cases=[dbc],
-        energy_costs={},
         output_costs=input_costs,
         cost_breakdown_keys=cost_breakdown_keys,
     )
@@ -776,7 +772,6 @@ def test_cost_breakdown_co2_stored_revenue():
         bill_of_materials=bom,
         chosen_reductant="coke",
         dynamic_business_cases=[dbc],
-        energy_costs={},
         output_costs=input_costs,
     )
 
@@ -995,7 +990,6 @@ def test_breakdown_disposal_cost_output():
     result = calculate_cost_breakdown_by_feedstock(
         bill_of_materials=bom,
         dynamic_business_cases=[dbc],
-        energy_costs={},
         chosen_reductant="coke",
         output_costs=output_costs,
         disposal_cost_outputs=frozenset({"steelmaking_slag"}),
@@ -1028,7 +1022,6 @@ def test_breakdown_disposal_cost_none_preserves_legacy():
     result = calculate_cost_breakdown_by_feedstock(
         bill_of_materials=bom,
         dynamic_business_cases=[dbc],
-        energy_costs={},
         chosen_reductant="coke",
         output_costs=output_costs,
     )
@@ -1075,7 +1068,6 @@ def test_cost_breakdown_credits_weighted_by_product_share():
         bill_of_materials=bom,
         chosen_reductant="coke",
         dynamic_business_cases=dbcs,
-        energy_costs={},
         output_costs={"ironmaking_slag": -10.0},
     )
 
@@ -1123,7 +1115,6 @@ def test_secondary_output_scalar_matches_breakdown_credits():
         bill_of_materials=bom,
         chosen_reductant="coke",
         dynamic_business_cases=dbcs,
-        energy_costs={},
         output_costs=output_costs,
     )
     scalar = calculate_cost_adjustments_from_secondary_outputs(

--- a/tests/unit/test_carbon_cost_calculations.py
+++ b/tests/unit/test_carbon_cost_calculations.py
@@ -522,7 +522,6 @@ def test_cost_breakdown_energy_columns_come_from_vopex_breakdown():
         bill_of_materials=bill_of_materials,
         chosen_reductant="",
         dynamic_business_cases=[dynamic_business_case],
-        energy_costs={},
         energy_vopex_breakdown_by_input={"dri_high": {"coking_coal": 6.48}},
     )
 
@@ -553,7 +552,6 @@ def test_cost_breakdown_normalizes_vopex_breakdown_carrier_keys():
         bill_of_materials=bill_of_materials,
         chosen_reductant="coke",
         dynamic_business_cases=[dynamic_business_case],
-        energy_costs={},
         energy_vopex_breakdown_by_input={
             "sinter": {"bio_pci": 20.0, "Burnt Dolomite": 2.0, "Burnt lime": 1.0},
         },
@@ -592,7 +590,6 @@ def test_cost_breakdown_ignores_metallic_secondary_feedstocks_for_energy():
         bill_of_materials=bill_of_materials,
         chosen_reductant="hydrogen",
         dynamic_business_cases=[dynamic_business_case],
-        energy_costs={"dri_mid": 9999.0},  # Would explode if interpreted as energy
     )
 
     feed_breakdown = breakdown["dri_mid"]

--- a/tests/unit/test_carbon_cost_calculations.py
+++ b/tests/unit/test_carbon_cost_calculations.py
@@ -817,3 +817,59 @@ class TestCarbonCostRefactoredIntegration:
         }
 
         assert cost_breakdown["carbon_cost_per_unit"] == pytest.approx(1.27912885)
+
+
+def test_get_bom_from_avg_boms_renormalises_after_bio_pci_skip():
+    """A traded bio_pci entry in avg_boms must not deflate the ore demands.
+
+    The TM write-back books every allocated commodity into materials, so charcoal
+    fleets carry bio_pci there and generate_average_boms aggregates it; the
+    reconstruction skips it (not a metallic charge) and must renormalise the
+    surviving ore shares. The biomass cost belongs on the energy side, once.
+    """
+
+    def build_env(avg_bom):
+        env = Environment.__new__(Environment)
+        env.config = Mock()
+        env.config.primary_products = ["hot_metal"]
+        pfs = []
+        for mc, req in [("io_low", 1.6), ("io_mid", 1.5)]:
+            pf = PrimaryFeedstock(metallic_charge=mc, reductant="bio_pci", technology="BF_CHARCOAL")
+            pf.required_quantity_per_ton_of_product = req
+            pf.secondary_feedstock = {}
+            pf.energy_requirements = {"bio_pci": 0.475, "electricity": 100.0}
+            pf.outputs = {"hot_metal": Volumes(1.0)}
+            pfs.append(pf)
+        env.dynamic_feedstocks = {"BF_CHARCOAL": pfs, "bf_charcoal": pfs}
+        env.avg_boms = {"BF_CHARCOAL": avg_bom}
+        env.avg_utilization = {"BF_CHARCOAL": {"utilization_rate": 0.7}}
+        env.energy_costs = {"bio_pci": 660.0, "electricity": 0.09}
+        env.primary_products = ["hot_metal"]
+        return env
+
+    leaky = {
+        "io_low": {"input_share_pct": 0.4, "unit_cost": 100.0},
+        "io_mid": {"input_share_pct": 0.4, "unit_cost": 90.0},
+        "bio_pci": {"input_share_pct": 0.2, "unit_cost": 660.0},
+    }
+    clean = {
+        "io_low": {"input_share_pct": 0.5, "unit_cost": 100.0},
+        "io_mid": {"input_share_pct": 0.5, "unit_cost": 90.0},
+    }
+
+    energy_costs = {"bio_pci": 660.0, "electricity": 0.09}
+    bom_leaky, _, _ = build_env(leaky).get_bom_from_avg_boms(
+        energy_costs=energy_costs, tech="BF_CHARCOAL", capacity=1000.0, most_common_reductant="bio_pci"
+    )
+    bom_clean, _, _ = build_env(clean).get_bom_from_avg_boms(
+        energy_costs=energy_costs, tech="BF_CHARCOAL", capacity=1000.0, most_common_reductant="bio_pci"
+    )
+
+    assert "bio_pci" not in bom_leaky["materials"]
+    for mc in ("io_low", "io_mid"):
+        assert bom_leaky["materials"][mc]["demand"] == pytest.approx(bom_clean["materials"][mc]["demand"])
+    # 0.5 share x 1000 t capacity x 1.6 t/t
+    assert bom_leaky["materials"]["io_low"]["demand"] == pytest.approx(800.0)
+    # Biomass cost appears exactly once, via the energy reconstruction
+    assert bom_leaky["energy"]["bio_pci"]["demand"] == pytest.approx(bom_clean["energy"]["bio_pci"]["demand"])
+    assert bom_leaky["energy"]["bio_pci"]["unit_cost"] == pytest.approx(660.0)

--- a/tests/unit/test_carbon_cost_calculations.py
+++ b/tests/unit/test_carbon_cost_calculations.py
@@ -495,21 +495,19 @@ class TestCarbonCostCompleteFlow:
         assert carbon_cost_in_breakdown != 1.0  # Would be wrong (double division)
 
 
-def test_cost_breakdown_converts_coking_coal_secondary_feedstock_to_tonnes():
-    """Ensure secondary-feedstock coking coal in t/t (converted at read time) is costed correctly."""
+def test_cost_breakdown_energy_columns_come_from_vopex_breakdown():
+    """Energy columns are the pathway's per-product vopex breakdown x its product share.
+
+    The kg->t secondary-feedstock conversion this test previously exercised happens
+    upstream (generate_energy_vopex_by_reductant); this function consumes the result.
+    """
     bill_of_materials = {
         "materials": {
             "dri_high": {
-                "demand": 1000.0,
+                "demand": 1100.0,
+                "demand_share_pct": 1.1,
                 "total_cost": 1_000_000.0,
                 "unit_cost": 1000.0,
-                "product_volume": 1000.0,
-            }
-        },
-        "energy": {
-            "coking_coal": {
-                "demand": 30.863112425484626 * 0.001 * 1000.0,  # kg/t * 0.001 (kg->t) * 1000t total
-                "unit_cost": 210.0,
                 "product_volume": 1000.0,
             }
         },
@@ -518,97 +516,56 @@ def test_cost_breakdown_converts_coking_coal_secondary_feedstock_to_tonnes():
     dynamic_business_case = Mock()
     dynamic_business_case.metallic_charge = "dri_high"
     dynamic_business_case.reductant = ""
-    dynamic_business_case.energy_requirements = {}
-    dynamic_business_case.secondary_feedstock = {"coking_coal": 0.030863112425484626}  # t/t (converted at read time)
     dynamic_business_case.required_quantity_per_ton_of_product = 1.1
 
     breakdown = calculate_cost_breakdown_by_feedstock(
         bill_of_materials=bill_of_materials,
         chosen_reductant="",
         dynamic_business_cases=[dynamic_business_case],
-        energy_costs={"coking_coal": 210.0},  # USD/t after Excel normalization
+        energy_costs={},
+        energy_vopex_breakdown_by_input={"dri_high": {"coking_coal": 6.48}},
     )
 
-    coking_coal_cost = breakdown["dri_high"]["coking_coal"]
-    # The function returns the weighted unit cost without multiplying by required_quantity_per_ton_of_product
-    # Expected: unit_cost (210.0) when there's only one feedstock using this carrier
-    assert coking_coal_cost == pytest.approx(210.0, rel=1e-3)
+    # product share = demand_share_pct / req_qty = 1.1 / 1.1 = 1.0
+    assert breakdown["dri_high"]["coking_coal"] == pytest.approx(6.48)
 
 
-def test_cost_breakdown_handles_space_and_hyphenated_energy_price_keys():
-    """Energy prices stored with spaces/hyphens must still map to normalized feedstock keys."""
+def test_cost_breakdown_normalizes_vopex_breakdown_carrier_keys():
+    """Carrier keys with spaces/case in the vopex breakdown map to normalized column names."""
     bill_of_materials = {
         "materials": {
             "sinter": {
-                "demand": 1000.0,
+                "demand": 550.0,
+                "demand_share_pct": 0.55,
                 "total_cost": 100_000.0,
                 "unit_cost": 100.0,
                 "product_volume": 1000.0,
             }
-        },
-        "energy": {
-            "bio_pci": {
-                "demand": 2.0 * 1000.0,
-                "unit_cost": 10.0,
-                "product_volume": 1000.0,
-            },
-            "natural_gas": {
-                "demand": 3.0 * 1000.0,
-                "unit_cost": 5.0,
-                "product_volume": 1000.0,
-            },
-            "burnt_dolomite": {
-                "demand": 1.0 * 1000.0,
-                "unit_cost": 2.0,
-                "product_volume": 1000.0,
-            },
-            "burnt_lime": {
-                "demand": 0.5 * 1000.0,
-                "unit_cost": 1.0,
-                "product_volume": 1000.0,
-            },
-            "olivine": {
-                "demand": 0.25 * 1000.0,
-                "unit_cost": 3.0,
-                "product_volume": 1000.0,
-            },
         },
     }
 
     dynamic_business_case = Mock()
     dynamic_business_case.metallic_charge = "sinter"
     dynamic_business_case.reductant = "coke"
-    dynamic_business_case.energy_requirements = {"bio_pci": 2.0, "natural_gas": 3.0}
-    dynamic_business_case.secondary_feedstock = {
-        "Burnt Dolomite": 1.0,
-        "Burnt lime": 0.5,
-        "Olivine": 0.25,
-    }
     dynamic_business_case.required_quantity_per_ton_of_product = 1.1
-
-    energy_prices = {
-        "bio_pci": 10.0,
-        "natural_gas": 5.0,
-        "burnt dolomite": 2.0,
-        "burnt lime": 1.0,
-        "olivine": 3.0,
-    }
 
     breakdown = calculate_cost_breakdown_by_feedstock(
         bill_of_materials=bill_of_materials,
         chosen_reductant="coke",
         dynamic_business_cases=[dynamic_business_case],
-        energy_costs=energy_prices,
+        energy_costs={},
+        energy_vopex_breakdown_by_input={
+            "sinter": {"bio_pci": 20.0, "Burnt Dolomite": 2.0, "Burnt lime": 1.0},
+        },
     )
 
     feed_breakdown = breakdown["sinter"]
 
-    # The function returns weighted unit costs without multiplying by required_quantity_per_ton_of_product
-    assert feed_breakdown["bio_pci"] == pytest.approx(10.0)  # unit_cost when only one feedstock
-    assert feed_breakdown["natural_gas"] == pytest.approx(5.0)  # unit_cost
-    assert feed_breakdown["burnt_dolomite"] == pytest.approx(2.0)  # unit_cost
-    assert feed_breakdown["burnt_lime"] == pytest.approx(1.0)  # unit_cost
-    assert feed_breakdown["olivine"] == pytest.approx(3.0)  # unit_cost
+    # product share = 0.55 / 1.1 = 0.5
+    assert feed_breakdown["bio_pci"] == pytest.approx(10.0)
+    assert feed_breakdown["burnt_dolomite"] == pytest.approx(1.0)
+    assert feed_breakdown["burnt_lime"] == pytest.approx(0.5)
+    assert "Burnt Dolomite" not in feed_breakdown
 
 
 def test_cost_breakdown_ignores_metallic_secondary_feedstocks_for_energy():

--- a/tests/unit/test_tm_pam_connector_energy_breakdown.py
+++ b/tests/unit/test_tm_pam_connector_energy_breakdown.py
@@ -91,6 +91,8 @@ def test_update_bill_of_materials_uses_energy_carriers():
 
     connector = TM_PAM_connector(dynamic_feedstocks_classes={}, plants=repo, transport_kpis=None)
 
+    furnace_group.production = 10.0
+
     connector.G = nx.MultiDiGraph()
     connector.G.add_node(
         "supplier_node",
@@ -102,18 +104,21 @@ def test_update_bill_of_materials_uses_energy_carriers():
     connector.G.add_node(
         furnace_group.furnace_group_id,
         process="eaf_hbi_low",
-        allocations={"hbi_low": {"Volume": 10.0, "Cost": 1000.0}},
+        allocations={"hbi_low": {"Volume": 12.0, "Cost": 1000.0}},
         export={},
         unit_cost={},
         product_cost={},
     )
+    # 12 t of input at req_qty 1.2 -> 10 t of product; edge costs come from the
+    # connector's own converted (per-input-tonne) snapshot, as create_graph stamps them.
+    snapshot = connector.processing_energy_cost[furnace_group.furnace_group_id]["hbi_low"]
     connector.G.add_edge(
         "supplier_node",
         furnace_group.furnace_group_id,
         key="hbi_low",
-        volume=10.0,
-        processing_energy_cost=120.0,
-        processing_energy_breakdown={"electricity": 70.0, "hydrogen": 50.0},
+        volume=12.0,
+        processing_energy_cost=snapshot["total"],
+        processing_energy_breakdown=snapshot["carriers"],
         commodity="hbi_low",
     )
 
@@ -122,8 +127,8 @@ def test_update_bill_of_materials_uses_energy_carriers():
     energy_block = furnace_group.bill_of_materials["energy"]
 
     assert set(energy_block.keys()) == {"electricity", "hydrogen"}
-    assert energy_block["electricity"]["unit_cost"] == 70.0
-    assert energy_block["hydrogen"]["unit_cost"] == 50.0
+    assert energy_block["electricity"]["unit_cost"] == pytest.approx(70.0)
+    assert energy_block["hydrogen"]["unit_cost"] == pytest.approx(50.0)
     assert energy_block["electricity"]["total_cost"] == pytest.approx(700.0)
     assert energy_block["hydrogen"]["total_cost"] == pytest.approx(500.0)
 

--- a/tests/unit/test_tm_pam_connector_energy_breakdown.py
+++ b/tests/unit/test_tm_pam_connector_energy_breakdown.py
@@ -31,7 +31,12 @@ class _StubFurnaceGroup:
         self.chosen_reductant = "hydrogen"
         self.bill_of_materials = {}
         self.effective_primary_feedstocks = [
-            SimpleNamespace(metallic_charge="hbi_low", required_quantity_per_ton_of_product=1.2),
+            SimpleNamespace(
+                metallic_charge="hbi_low",
+                required_quantity_per_ton_of_product=1.2,
+                energy_requirements={"electricity": 500.0, "hydrogen": 20.0},
+                secondary_feedstock={},
+            ),
         ]
 
 

--- a/tests/unit/test_tm_pam_connector_energy_breakdown.py
+++ b/tests/unit/test_tm_pam_connector_energy_breakdown.py
@@ -30,6 +30,58 @@ class _StubFurnaceGroup:
         self.energy_vopex_by_carrier = {"electricity": 70.0, "hydrogen": 50.0}
         self.chosen_reductant = "hydrogen"
         self.bill_of_materials = {}
+        self.effective_primary_feedstocks = [
+            SimpleNamespace(metallic_charge="hbi_low", required_quantity_per_ton_of_product=1.2),
+        ]
+
+
+def test_snapshot_converts_energy_costs_to_per_input_tonne():
+    """The connector snapshot divides per-product energy costs by each charge's req_qty."""
+    furnace_group = _StubFurnaceGroup()
+    plant = _StubPlant("plant", [furnace_group])
+    repo = _StubRepo([plant])
+
+    connector = TM_PAM_connector(dynamic_feedstocks_classes={}, plants=repo, transport_kpis=None)
+
+    entry = connector.processing_energy_cost["plant_fg1"]["hbi_low"]
+    assert entry["total"] == pytest.approx(120.0 / 1.2)
+    assert entry["carriers"]["electricity"] == pytest.approx(70.0 / 1.2)
+    assert entry["carriers"]["hydrogen"] == pytest.approx(50.0 / 1.2)
+
+
+def test_snapshot_divides_each_charge_by_its_own_req_qty():
+    """Multi-charge furnace groups convert per charge, not with a blended factor."""
+    furnace_group = _StubFurnaceGroup()
+    furnace_group.energy_vopex_by_input = {"io_low": 96.0, "io_mid": 90.0}
+    furnace_group.energy_vopex_breakdown_by_input = {
+        "io_low": {"coking_coal": 96.0},
+        "io_mid": {"coking_coal": 90.0},
+    }
+    furnace_group.effective_primary_feedstocks = [
+        SimpleNamespace(metallic_charge="io_low", required_quantity_per_ton_of_product=1.6),
+        SimpleNamespace(metallic_charge="io_mid", required_quantity_per_ton_of_product=1.5),
+    ]
+    plant = _StubPlant("plant", [furnace_group])
+    repo = _StubRepo([plant])
+
+    connector = TM_PAM_connector(dynamic_feedstocks_classes={}, plants=repo, transport_kpis=None)
+
+    per_feed = connector.processing_energy_cost["plant_fg1"]
+    assert per_feed["io_low"]["total"] == pytest.approx(60.0)
+    assert per_feed["io_mid"]["total"] == pytest.approx(60.0)
+    assert per_feed["io_low"]["carriers"]["coking_coal"] == pytest.approx(60.0)
+    assert per_feed["io_mid"]["carriers"]["coking_coal"] == pytest.approx(60.0)
+
+
+def test_snapshot_raises_when_charge_has_no_feedstock_row():
+    """A charge carrying energy cost without a req_qty row must fail loudly."""
+    furnace_group = _StubFurnaceGroup()
+    furnace_group.effective_primary_feedstocks = []
+    plant = _StubPlant("plant", [furnace_group])
+    repo = _StubRepo([plant])
+
+    with pytest.raises(ValueError, match="hbi_low"):
+        TM_PAM_connector(dynamic_feedstocks_classes={}, plants=repo, transport_kpis=None)
 
 
 def test_update_bill_of_materials_uses_energy_carriers():

--- a/tests/unit/test_tm_pam_connector_energy_units.py
+++ b/tests/unit/test_tm_pam_connector_energy_units.py
@@ -115,3 +115,51 @@ def test_booked_energy_equals_per_product_cost_times_product_tonnes():
     # Downstream: the BF's outgoing hot-metal unit cost embeds converted energy:
     # (materials 14,000 + energy 18,600) / 200 t = 163 USD/t.
     assert connector.G.nodes["plant_bf1"]["unit_cost"]["hot_metal"] == pytest.approx(163.0)
+
+
+def test_energy_booking_validator_detects_unit_regression():
+    """Reintroducing an undivided (per-product) edge cost must fail the two-leg check."""
+    furnace_group = _make_bf_furnace_group()
+    plant = SimpleNamespace(plant_id="plant", furnace_groups=[furnace_group])
+    connector = TM_PAM_connector(
+        dynamic_feedstocks_classes={},
+        plants=_StubRepo([plant]),
+        transport_kpis=None,
+    )
+
+    sup_low = tlp.ProcessCenter(
+        name="sup_low",
+        process=tlp.Process(name="io_low_supply", type=tlp.ProcessType.SUPPLY, bill_of_materials=[]),
+        capacity=1000.0,
+        location=_location("AUS"),
+        production_cost=50.0,
+    )
+    bf_pc = tlp.ProcessCenter(
+        name="plant_bf1",
+        process=tlp.Process(name="BF", type=tlp.ProcessType.PRODUCTION, bill_of_materials=[]),
+        capacity=500.0,
+        location=_location("DEU"),
+        production_cost=0.0,
+    )
+    sink_pc = tlp.ProcessCenter(
+        name="deu_demand",
+        process=tlp.Process(name="demand", type=tlp.ProcessType.DEMAND, bill_of_materials=[]),
+        capacity=1000.0,
+        location=_location("DEU"),
+    )
+
+    allocations = tlp.Allocations(
+        allocations={
+            (sup_low, bf_pc, tlp.Commodity(name="io_low")): 160.0,
+            (bf_pc, sink_pc, tlp.Commodity(name="hot_metal")): 100.0,
+        },
+    )
+
+    connector.create_graph(allocations)
+    for _, _, key, data in connector.G.edges(keys=True, data=True):
+        if key == "io_low":
+            data["processing_energy_breakdown"] = {"coking_coal": 96.0}  # per-product, undivided
+    connector.propage_cost_forward_by_layers_and_normalize()
+
+    with pytest.raises(ValueError, match="plant_bf1"):
+        connector.update_bill_of_materials([furnace_group])

--- a/tests/unit/test_tm_pam_connector_energy_units.py
+++ b/tests/unit/test_tm_pam_connector_energy_units.py
@@ -1,0 +1,117 @@
+"""End-to-end unit check for the TM->PAM energy-cost conversion.
+
+Two suppliers feed a two-charge blast furnace that exports hot metal to a demand
+sink. Energy costs are authored per tonne of product; edge volumes flow in input
+tonnes. The connector must convert once at the snapshot so that booked BOM energy
+equals per-product cost x product tonnes, and the downstream node's material cost
+embeds the converted (not inflated) energy.
+"""
+
+import pytest
+from types import SimpleNamespace
+
+import steelo.domain.trade_modelling.trade_lp_modelling as tlp
+from steelo.domain.trade_modelling.TM_PAM_connector import TM_PAM_connector
+
+
+class _StubRepo:
+    def __init__(self, plants):
+        self._plants = plants
+
+    def list(self):
+        return self._plants
+
+
+def _location(iso3):
+    return SimpleNamespace(iso3=iso3, country=iso3, lat=0.0, lon=0.0)
+
+
+def _make_bf_furnace_group():
+    return SimpleNamespace(
+        furnace_group_id="plant_bf1",
+        technology=SimpleNamespace(name="BF", product="iron"),
+        status="operating",
+        chosen_reductant="coke+pci",
+        energy_vopex_by_input={"io_low": 96.0, "io_mid": 90.0},
+        energy_vopex_breakdown_by_input={
+            "io_low": {"coking_coal": 96.0},
+            "io_mid": {"coking_coal": 90.0},
+        },
+        effective_primary_feedstocks=[
+            SimpleNamespace(metallic_charge="io_low", required_quantity_per_ton_of_product=1.6),
+            SimpleNamespace(metallic_charge="io_mid", required_quantity_per_ton_of_product=1.5),
+        ],
+        bill_of_materials={},
+        production=200.0,
+    )
+
+
+def test_booked_energy_equals_per_product_cost_times_product_tonnes():
+    """160 t io_low (req 1.6) + 150 t io_mid (req 1.5) -> 200 t hot metal.
+
+    Correct booking: 96 x 100 + 90 x 100 = 18,600 USD, not per-product cost x
+    input tonnes (96 x 160 + 90 x 150 = 28,860 USD).
+    """
+    furnace_group = _make_bf_furnace_group()
+    plant = SimpleNamespace(plant_id="plant", furnace_groups=[furnace_group])
+    connector = TM_PAM_connector(
+        dynamic_feedstocks_classes={},
+        plants=_StubRepo([plant]),
+        transport_kpis=None,
+    )
+
+    sup_low = tlp.ProcessCenter(
+        name="sup_low",
+        process=tlp.Process(name="io_low_supply", type=tlp.ProcessType.SUPPLY, bill_of_materials=[]),
+        capacity=1000.0,
+        location=_location("AUS"),
+        production_cost=50.0,
+    )
+    sup_mid = tlp.ProcessCenter(
+        name="sup_mid",
+        process=tlp.Process(name="io_mid_supply", type=tlp.ProcessType.SUPPLY, bill_of_materials=[]),
+        capacity=1000.0,
+        location=_location("BRA"),
+        production_cost=40.0,
+    )
+    bf_pc = tlp.ProcessCenter(
+        name="plant_bf1",
+        process=tlp.Process(name="BF", type=tlp.ProcessType.PRODUCTION, bill_of_materials=[]),
+        capacity=500.0,
+        location=_location("DEU"),
+        production_cost=0.0,
+    )
+    sink_pc = tlp.ProcessCenter(
+        name="deu_demand",
+        process=tlp.Process(name="demand", type=tlp.ProcessType.DEMAND, bill_of_materials=[]),
+        capacity=1000.0,
+        location=_location("DEU"),
+    )
+
+    allocations = tlp.Allocations(
+        allocations={
+            (sup_low, bf_pc, tlp.Commodity(name="io_low")): 160.0,
+            (sup_mid, bf_pc, tlp.Commodity(name="io_mid")): 150.0,
+            (bf_pc, sink_pc, tlp.Commodity(name="hot_metal")): 200.0,
+        },
+    )
+
+    connector.create_graph(allocations)
+    connector.propage_cost_forward_by_layers_and_normalize()
+    connector.update_bill_of_materials([furnace_group])
+
+    bom = furnace_group.bill_of_materials
+
+    energy = bom["energy"]["coking_coal"]
+    assert energy["total_cost"] == pytest.approx(18_600.0)
+    assert energy["demand"] == pytest.approx(310.0)
+    assert energy["unit_cost"] == pytest.approx(93.0)
+
+    materials = bom["materials"]
+    assert materials["io_low"]["demand"] == pytest.approx(160.0)
+    assert materials["io_low"]["total_cost"] == pytest.approx(50.0 * 160.0 + 60.0 * 160.0)
+    assert materials["io_mid"]["total_cost"] == pytest.approx(40.0 * 150.0 + 60.0 * 150.0)
+
+    # Downstream: the BF's outgoing hot-metal unit cost embeds converted energy:
+    # (materials 14,000 + energy 18,600) / 200 t = 163 USD/t.
+    assert connector.G.nodes["plant_bf1"]["unit_cost"]["hot_metal"] == pytest.approx(163.0)

--- a/tests/unit/test_tm_pam_connector_energy_units.py
+++ b/tests/unit/test_tm_pam_connector_energy_units.py
@@ -7,6 +7,8 @@ equals per-product cost x product tonnes, and the downstream node's material cos
 embeds the converted (not inflated) energy.
 """
 
+import logging
+
 import pytest
 from types import SimpleNamespace
 
@@ -117,8 +119,8 @@ def test_booked_energy_equals_per_product_cost_times_product_tonnes():
     assert connector.G.nodes["plant_bf1"]["unit_cost"]["hot_metal"] == pytest.approx(163.0)
 
 
-def test_energy_booking_validator_detects_unit_regression():
-    """Reintroducing an undivided (per-product) edge cost must fail the two-leg check."""
+def test_energy_booking_validator_detects_unit_regression(caplog):
+    """Reintroducing an undivided (per-product) edge cost must trip the two-leg check."""
     furnace_group = _make_bf_furnace_group()
     plant = SimpleNamespace(plant_id="plant", furnace_groups=[furnace_group])
     connector = TM_PAM_connector(
@@ -161,5 +163,9 @@ def test_energy_booking_validator_detects_unit_regression():
             data["processing_energy_breakdown"] = {"coking_coal": 96.0}  # per-product, undivided
     connector.propage_cost_forward_by_layers_and_normalize()
 
-    with pytest.raises(ValueError, match="plant_bf1"):
+    with caplog.at_level(logging.ERROR):
         connector.update_bill_of_materials([furnace_group])
+
+    assert any(
+        "Energy booking mismatch" in record.message and "plant_bf1" in record.getMessage() for record in caplog.records
+    )

--- a/tests/unit/test_tm_pam_connector_energy_units.py
+++ b/tests/unit/test_tm_pam_connector_energy_units.py
@@ -40,8 +40,18 @@ def _make_bf_furnace_group():
             "io_mid": {"coking_coal": 90.0},
         },
         effective_primary_feedstocks=[
-            SimpleNamespace(metallic_charge="io_low", required_quantity_per_ton_of_product=1.6),
-            SimpleNamespace(metallic_charge="io_mid", required_quantity_per_ton_of_product=1.5),
+            SimpleNamespace(
+                metallic_charge="io_low",
+                required_quantity_per_ton_of_product=1.6,
+                energy_requirements={"coking_coal": 0.48},
+                secondary_feedstock={},
+            ),
+            SimpleNamespace(
+                metallic_charge="io_mid",
+                required_quantity_per_ton_of_product=1.5,
+                energy_requirements={"coking_coal": 0.45},
+                secondary_feedstock={},
+            ),
         ],
         bill_of_materials={},
         production=200.0,
@@ -106,7 +116,8 @@ def test_booked_energy_equals_per_product_cost_times_product_tonnes():
 
     energy = bom["energy"]["coking_coal"]
     assert energy["total_cost"] == pytest.approx(18_600.0)
-    assert energy["demand"] == pytest.approx(310.0)
+    # Carrier quantity: 100 t product x 0.48 t/t + 100 t x 0.45 t/t
+    assert energy["demand"] == pytest.approx(93.0)
     assert energy["unit_cost"] == pytest.approx(93.0)
 
     materials = bom["materials"]
@@ -119,7 +130,7 @@ def test_booked_energy_equals_per_product_cost_times_product_tonnes():
     assert connector.G.nodes["plant_bf1"]["unit_cost"]["hot_metal"] == pytest.approx(163.0)
 
 
-def test_energy_booking_validator_detects_unit_regression(caplog):
+def test_energy_booking_validator_detects_unit_regression():
     """Reintroducing an undivided (per-product) edge cost must trip the two-leg check."""
     furnace_group = _make_bf_furnace_group()
     plant = SimpleNamespace(plant_id="plant", furnace_groups=[furnace_group])
@@ -163,9 +174,18 @@ def test_energy_booking_validator_detects_unit_regression(caplog):
             data["processing_energy_breakdown"] = {"coking_coal": 96.0}  # per-product, undivided
     connector.propage_cost_forward_by_layers_and_normalize()
 
-    with caplog.at_level(logging.ERROR):
+    # Capture on the function's own logger — immune to other tests' logging reconfiguration.
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.emit = records.append  # type: ignore[method-assign]
+    target = logging.getLogger("steelo.domain.trade_modelling.TM_PAM_connector.update_bill_of_materials")
+    target.addHandler(handler)
+    target.disabled = False
+    try:
         connector.update_bill_of_materials([furnace_group])
+    finally:
+        target.removeHandler(handler)
 
     assert any(
-        "Energy booking mismatch" in record.message and "plant_bf1" in record.getMessage() for record in caplog.records
+        "Energy booking mismatch" in record.getMessage() and "plant_bf1" in record.getMessage() for record in records
     )


### PR DESCRIPTION
## Problem

`FurnaceGroup.energy_vopex_by_input` is authored in USD per tonne of **product**, but trade-graph edge volumes flow in tonnes of metallic **input**. The trade LP divides correctly; the TM→PAM write-back never did — booked BOM energy was inflated by the charge-blended `required_quantity_per_ton_of_product` (BF +67 USD/t product fleet-mean, DRI +30, cascading into BOF/EAF via propagated material costs). Present since the initial import. Two adjacent weighting bugs compounded it: by-product credits weighted pathways by input share instead of product share, and the post-processed energy columns inherited the same misweighting.

## Fix (8 commits, in booking order)

- **Convert once, at the connector snapshot**: each charge's energy total and per-carrier breakdown divided by its own `required_quantity_per_ton_of_product`; fails loudly if the feedstock row is missing.
- **Product-share weighting** for by-product credits in the cost breakdown and the `unit_secondary_output_costs` scalar (`demand_share / req`, exact because both BOM producers store `demand_share_pct` in input-tonnes-per-product-tonne).
- **Two-leg booking validator**: booked edge energy must equal Σ demand/req × per-product vopex (error log, tolerance one cent), so any future unit regression surfaces immediately.
- **Bottom-up CSV energy columns** from `energy_vopex_breakdown_by_input` × product share — post-processed additivity (Σ breakdown = unit_vopex + unit_secondary_output_costs) becomes a genuine two-source cross-check instead of true-by-construction.
- **BOM energy demand restated as carrier quantities** (t / kWh, matching price units and the avg-BOM convention) — also fixes the new-plants subsidy path that recomputes `total_cost = price × demand`.
- **Avg-BOM input shares renormalised** after energy-like commodity skips (e.g. bio_pci no longer deflates the metallic-charge demands it was counted against).

## Validation

- 2027 baseline-vs-fix pair (archived, `experiments/2026-08_tm-energy-units/`): booked BF energy 201→134 USD/t = the authored blend; DRI 115→84; emissions unchanged; additivity exact to 1e-13 fleet-wide; zero validator trips.
- 2050 runs: deltas reproduce at horizon scale (2025 unit_vopex means BF −67.5, BOF −54.7, DRI −29.9, EAF −43.7 vs develop); validator silent across 26 years.
