### PR TITLE
Fix TM graph booking: parallel-edge double-booking, traversal order, corrected-BOM consistency

### DIFF
--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -278,7 +278,9 @@ def calculate_cost_breakdown_by_feedstock(
         material_unit_cost = _coerce_to_float(material_entry.get("unit_material_cost")) or 0.0
         feed_breakdown["material cost (incl. transport and tariffs)"] = material_unit_cost
 
-        demand_share = _coerce_to_float(material_entry.get("demand_share_pct", 1.0)) or 1.0
+        demand_share = _coerce_to_float(material_entry.get("demand_share_pct"))
+        if demand_share is None:
+            demand_share = 1.0
 
         # Energy vopex and by-product amounts are per tonne of product -> weight by the
         # pathway's product share, not its input-tonne share.
@@ -405,7 +407,9 @@ def calculate_carbon_breakdown_by_feedstock(
             continue
 
         material_entry = bill_of_materials["materials"][metallic_charge_lower]
-        demand_share = _coerce_to_float(material_entry.get("demand_share_pct", 1.0)) or 1.0
+        demand_share = _coerce_to_float(material_entry.get("demand_share_pct"))
+        if demand_share is None:
+            demand_share = 1.0
 
         feed_carbon: dict[str, float] = {}
 
@@ -1906,9 +1910,12 @@ def calculate_cost_adjustments_from_secondary_outputs(
         # This pathway's own product contribution — the BOM's product_volume is the furnace
         # group's TOTAL production, which would weight every pathway equally.
         required_qty = getattr(dbc, "required_quantity_per_ton_of_product", None)
-        product_volume = material_volume / required_qty if required_qty else material_data.get("product_volume")
-        if product_volume is None or product_volume <= 0:
-            continue
+        if not required_qty:
+            raise ValueError(
+                f"Feedstock {dbc.metallic_charge} ({dbc.reductant}) has no "
+                "required_quantity_per_ton_of_product to derive its product volume with"
+            )
+        product_volume = material_volume / required_qty
 
         total_product_volume += product_volume
 

--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -952,25 +952,30 @@ class TM_PAM_connector:
             _ = {"materials": [], "energy": []}
             product_volume = 0.0
             if self.G is not None:
-                in_edges = list(self.G.in_edges(fg.furnace_group_id))
+                # Iterate edge-wise: keyless in_edges repeats the (u, v) pair once per parallel
+                # edge and get_edge_data(u, v) returns ALL parallel edges, double-booking every
+                # commodity arriving from a multi-commodity source (e.g. a DRI plant shipping
+                # dri_mid and hbi_mid to the same BOF).
+                in_edges = list(self.G.in_edges(fg.furnace_group_id, data=True))
                 logger.debug(f"[BOM] FG {fg.furnace_group_id}: Found {len(in_edges)} incoming edges")
-                for edges in in_edges:
-                    edge_data = self.G.get_edge_data(*edges)
-                    for commodity, attr_dict in edge_data.items():
-                        # costs = self.G.nodes[edges[0]]["unit_cost"]
-                        # unit_costs = costs[commodity] if isinstance(costs, dict) and commodity in costs else costs
-                        processing_energy_cost = attr_dict.get("processing_energy_cost", 0.0)
-                        energy_breakdown = attr_dict.get("processing_energy_breakdown") or {}
+                for _source, _target, attr_dict in in_edges:
+                    processing_energy_cost = attr_dict.get("processing_energy_cost", 0.0)
+                    energy_breakdown = attr_dict.get("processing_energy_breakdown") or {}
 
-                        if energy_breakdown:
-                            for carrier, carrier_unit_cost in energy_breakdown.items():
-                                _["energy"].append(
-                                    {carrier: {"demand": attr_dict["volume"], "unit_cost": carrier_unit_cost}}
-                                )
-                        elif processing_energy_cost:
+                    if energy_breakdown:
+                        for carrier, carrier_unit_cost in energy_breakdown.items():
                             _["energy"].append(
-                                {commodity: {"demand": attr_dict["volume"], "unit_cost": processing_energy_cost}}
+                                {carrier: {"demand": attr_dict["volume"], "unit_cost": carrier_unit_cost}}
                             )
+                    elif processing_energy_cost:
+                        _["energy"].append(
+                            {
+                                attr_dict["commodity"]: {
+                                    "demand": attr_dict["volume"],
+                                    "unit_cost": processing_energy_cost,
+                                }
+                            }
+                        )
             else:
                 logger.debug(f"[BOM] FG {fg.furnace_group_id}: Graph is None, no edges to process")
 

--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -3,7 +3,6 @@ import logging
 import math
 from typing import Any
 import networkx as nx
-from collections import deque
 from steelo.adapters.repositories.in_memory_repository import (
     PlantInMemoryRepository,
 )
@@ -309,20 +308,14 @@ class TM_PAM_connector:
         Example:
             If 100 tons steel shipped with 0.95 efficiency → allocation = 100/0.95 = 105.3 tons input.
         """
-        G = self.G.copy()
-        for edge in G.edges(keys=True, data=True):
-            from_node, to_node, commodity, data = edge
+        for _from_node, _to_node, _commodity, data in self.G.edges(keys=True, data=True):
             if volume_attr in data:
                 volume = data[volume_attr]
                 effectiveness = data.get(effectiveness_attr, 1)
                 if effectiveness is None:
                     effectiveness = 1
                 # Calculate the allocation based on the volume and effectiveness
-                allocation_value = volume / effectiveness if effectiveness > 0 else 0
-                if commodity_attr in data:
-                    commodity = data[commodity_attr]
-                G[from_node][to_node][commodity][allocation_attr] = allocation_value
-        self.G = G.copy()
+                data[allocation_attr] = volume / effectiveness if effectiveness > 0 else 0
 
     def create_graph(self, solved_trade_allocations):
         """
@@ -515,33 +508,25 @@ class TM_PAM_connector:
 
         Side Effects
         ------------
-        - Reads from and then replaces `self.G` with a new MultiDiGraph containing:
-            1. Per-commodity cumulative costs in `node[source_attr]` (a dict).
-            2. Per-commodity unit costs in `node[unit_cost_attr]`.
-        - Prints the number of edges processed (for debugging).
-        - Prints each node's computed unit cost (for debugging).
+        Mutates `self.G` in place:
+            1. Per-commodity input costs accumulated in `node[allocation_attr]`.
+            2. Per-commodity export volumes in `node[export_attr]`.
+            3. Per-commodity unit costs in `node[unit_cost_attr]`.
 
         Notes
         -----
-        - Assumes `self.G` is a DAG (no cycles), so BFS/topological layers make sense.
+        - Requires `self.G` to be a DAG; `nx.topological_sort` raises on cycles.
         - Skips any sink node (no outgoing edges) in propagation phase.
         - Leaves zero-volume edges effectively ignored in normalization.
         """
         logger = logging.getLogger(f"{__name__}.propage_cost_forward_by_layers_and_normalize")
-        # Make a copy so we don't mutate the original in the middle of traversal
-        G = self.G.copy()
-
-        # Identify “roots” = nodes with zero in-degree
-        roots = [n for n in G.nodes if G.in_degree(n) == 0]
-
-        # BFS queue seeded with roots; track visited to avoid repeats
-        q = deque(roots)
-        seen = set(roots)
+        G = self.G
         edge_count = 0
 
-        # 1) Propagate costs forward layer by layer
-        while q:
-            u = q.popleft()
+        # Topological order guarantees a node is processed only after ALL of its suppliers
+        # have pushed costs into it — BFS discovery order does not, and made downstream
+        # costs depend on the allocation dict's insertion order on multi-tier chains.
+        for u in nx.topological_sort(G):
             node_cost = G.nodes[u].get(source_attr, {})  # may be dict by commodity
             unit_cost = {}
 
@@ -550,7 +535,7 @@ class TM_PAM_connector:
                 if export_attr not in G.nodes[u]:
                     G.nodes[u][export_attr] = {}
                 # Accumulate export volumes by commodity
-                for src, v, comm, edata in self.G.out_edges(u, keys=True, data=True):
+                for src, v, comm, edata in G.out_edges(u, keys=True, data=True):
                     G.nodes[u][export_attr][comm] = G.nodes[u][export_attr].get(comm, 0) + edata.get(volume_attr, 0)
             # If G[u] is also a to-node
             # For each outgoing edge (u → v) carrying commodity `comm`
@@ -654,11 +639,6 @@ class TM_PAM_connector:
                             ],
                         )
 
-                # Initialize the target node's cost dict if needed
-                if source_attr not in G.nodes[v] or not isinstance(G.nodes[v][source_attr], dict):
-                    G.nodes[v][source_attr] = {}
-                    G.nodes[v][allocation_attr] = {}
-
                 # Accumulate cost and volume
                 # Store both total cost and material cost (excluding current step's energy)
                 # MaterialCost includes upstream material + ALL upstream costs
@@ -669,31 +649,8 @@ class TM_PAM_connector:
                 prev["MaterialCost"] += material_tariff_transportation_cost  # Excludes current step's energy only
                 prev["Volume"] += volume
                 G.nodes[v][allocation_attr][comm] = prev
-                G.nodes[v][source_attr][comm] = prev["Cost"]
-
-                # For multi-output processes (e.g., BF producing both hot_metal and pig_iron),
-                # allocate the total input cost proportionally across all output commodities
-                # based on their respective volumes, ensuring equal per-unit costs
-                output_edges = list(G.out_edges(v, keys=True, data=True))
-                if output_edges:
-                    # Calculate total output volume across all commodities
-                    total_output_volume = sum(edge_data.get(volume_attr, 0.0) for _, _, _, edge_data in output_edges)
-
-                    if total_output_volume > 0:
-                        # Allocate cost proportionally to each output commodity
-                        for _, _, out_comm, edge_data in output_edges:
-                            out_volume = edge_data.get(volume_attr, 0.0)
-                            # Cost for this output = (total input cost) × (this output volume / total output volume)
-                            allocated_cost = prev["Cost"] * (out_volume / total_output_volume)
-                            G.nodes[v][source_attr][out_comm] = allocated_cost
-
-                # Enqueue v if not yet visited
-                if v not in seen:
-                    seen.add(v)
-                    q.append(v)
 
             G.nodes[u][unit_cost_attr].update(unit_cost)
-            # print(f"Node {u} unit costs: {unit_cost}")
 
         logger.info(f"Processed {edge_count} edges")
 

--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -1428,6 +1428,9 @@ class TM_PAM_connector:
         4. Keeping the constrained commodity's BOM demand unchanged; scaling all other
            metallic BOM entries down so ``T_new`` is satisfied.
         5. Scaling non-metallic BOM entries with production.
+        6. Refreshing ``demand_share_pct`` and rebuilding the BOM energy entries from the
+           corrected material demands (``demand / req x intensity`` and ``x vopex``), since
+           the metallic mix changes non-uniformly.
 
         For each FG the most-binding violation (smallest ``actual_share / required_share``)
         is used.
@@ -1575,25 +1578,54 @@ class TM_PAM_connector:
                 comm_lower = comm.lower()
                 if comm_lower in constrained_equiv:
                     # Constrained commodity: demand fixed, but unit_cost rises (less output)
-                    pass
+                    scale = 1.0
                 elif comm_lower in METALLIC_COMMODITIES:
                     # Other metallics: reduce to maintain valid share
-                    old_demand = float(info.get("demand", 0.0))
-                    info["demand"] = old_demand * scale_other
-                    if "total_cost" in info:
-                        info["total_cost"] = float(info["total_cost"]) * scale_other
+                    scale = scale_other
                 else:
                     # Non-metallic inputs (iron ore, flux, gases): scale with production
-                    old_demand = float(info.get("demand", 0.0))
-                    info["demand"] = old_demand * scale_production
-                    if "total_cost" in info:
-                        info["total_cost"] = float(info["total_cost"]) * scale_production
+                    scale = scale_production
 
-                # Recompute unit_cost against new production
-                if new_production > 0 and "total_cost" in info:
-                    info["unit_cost"] = float(info["total_cost"]) / new_production
+                info["demand"] = float(info.get("demand", 0.0)) * scale
+                for total_key, unit_key in (
+                    ("total_cost", "unit_cost"),
+                    ("total_material_cost", "unit_material_cost"),
+                ):
+                    if total_key in info:
+                        info[total_key] = float(info[total_key]) * scale
+                        if new_production > 0:
+                            info[unit_key] = info[total_key] / new_production
 
                 info["product_volume"] = new_production
+
+            # The metallic mix changed non-uniformly, so the share weights and the
+            # per-pathway energy legs must be recomputed from the corrected demands —
+            # a single scale factor would misstate both.
+            _ensure_material_shares(materials)
+
+            energy = bom.get("energy", {})
+            if energy:
+                req_by_charge = _required_quantity_by_charge(fg)
+                intensity_by_charge = _energy_intensity_by_charge(fg)
+                vopex_by_charge = {
+                    str(charge).lower(): {normalize_name(c): float(v) for c, v in (carriers or {}).items()}
+                    for charge, carriers in (getattr(fg, "energy_vopex_breakdown_by_input", {}) or {}).items()
+                    if isinstance(charge, str)
+                }
+                for carrier, entry in energy.items():
+                    carrier_demand = 0.0
+                    carrier_cost = 0.0
+                    for charge, info in materials.items():
+                        req = req_by_charge.get(charge.lower())
+                        if not req:
+                            continue
+                        product_tonnes = float(info.get("demand", 0.0)) / req
+                        carrier_demand += product_tonnes * intensity_by_charge.get(charge.lower(), {}).get(carrier, 0.0)
+                        carrier_cost += product_tonnes * vopex_by_charge.get(charge.lower(), {}).get(carrier, 0.0)
+                    entry["demand"] = carrier_demand
+                    entry["total_cost"] = carrier_cost
+                    entry["unit_cost"] = carrier_cost / new_production if new_production > 0 else 0.0
+                    entry["product_volume"] = new_production
 
             corrected += 1
 

--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -19,12 +19,23 @@ from steelo.utilities.utils import normalize_name
 
 
 def _required_quantity_by_charge(fg) -> dict[str, float]:
-    """Map each metallic charge of the FG's chosen-reductant feedstock rows to its req_qty."""
-    return {
-        str(feedstock.metallic_charge).lower(): feedstock.required_quantity_per_ton_of_product
-        for feedstock in fg.effective_primary_feedstocks
-        if isinstance(feedstock.metallic_charge, str)
-    }
+    """Map each metallic charge of the FG's chosen-reductant feedstock rows to its req_qty.
+
+    Raises if two rows for the same charge disagree — the snapshot conversion would
+    otherwise silently use whichever row happened to come last."""
+    req_by_charge: dict[str, float] = {}
+    for feedstock in fg.effective_primary_feedstocks:
+        if not isinstance(feedstock.metallic_charge, str):
+            continue
+        charge = feedstock.metallic_charge.lower()
+        req_qty = feedstock.required_quantity_per_ton_of_product
+        if charge in req_by_charge and req_by_charge[charge] != req_qty:
+            raise ValueError(
+                f"Furnace group {fg.furnace_group_id} has conflicting required_quantity_per_ton_of_product "
+                f"values for metallic charge '{charge}': {req_by_charge[charge]} vs {req_qty}"
+            )
+        req_by_charge[charge] = req_qty
+    return req_by_charge
 
 
 def _energy_intensity_by_charge(fg) -> dict[str, dict[str, float]]:
@@ -42,6 +53,31 @@ def _energy_intensity_by_charge(fg) -> dict[str, dict[str, float]]:
                     carriers[normalized] = carriers.get(normalized, 0.0) + amount
         intensities[feedstock.metallic_charge.lower()] = carriers
     return intensities
+
+
+def _ensure_material_shares(materials: dict[str, dict[str, float]]) -> None:
+    """Stamp each material entry with demand_share_pct = demand / product volume (input
+    tonnes per tonne of product), the weight the cost-breakdown product-share maths needs."""
+    if not materials:
+        return
+    product_volume = None
+    for values in materials.values():
+        pv = values.get("product_volume")
+        if isinstance(pv, (int, float)) and pv > 0:
+            product_volume = float(pv)
+            break
+    if product_volume is None or product_volume <= 0:
+        total_output = sum(float(v.get("product_volume") or 0.0) for v in materials.values())
+        if total_output > 0:
+            product_volume = total_output
+        else:
+            demand_sum = sum(float(v.get("demand") or 0.0) for v in materials.values())
+            product_volume = demand_sum if demand_sum > 0 else None
+    if not product_volume or product_volume <= 0:
+        return
+    for values in materials.values():
+        demand = float(values.get("demand") or 0.0)
+        values["demand_share_pct"] = demand / product_volume
 
 
 class TM_PAM_connector:
@@ -109,6 +145,11 @@ class TM_PAM_connector:
                     normalized_breakdown = {
                         normalize_name(carrier): float(cost) / req_qty for carrier, cost in breakdown.items()
                     }
+                    if float(total_cost) and not normalized_breakdown:
+                        raise ValueError(
+                            f"Furnace group {fg.furnace_group_id} has energy cost for metallic charge "
+                            f"'{commodity}' but no per-carrier breakdown to book it by"
+                        )
                     per_feed_energy[normalized_commodity] = {
                         "total": float(total_cost) / req_qty,
                         "carriers": normalized_breakdown,
@@ -959,23 +1000,10 @@ class TM_PAM_connector:
                 in_edges = list(self.G.in_edges(fg.furnace_group_id, data=True))
                 logger.debug(f"[BOM] FG {fg.furnace_group_id}: Found {len(in_edges)} incoming edges")
                 for _source, _target, attr_dict in in_edges:
-                    processing_energy_cost = attr_dict.get("processing_energy_cost", 0.0)
+                    # The __init__ snapshot guarantees a per-carrier breakdown wherever energy cost exists.
                     energy_breakdown = attr_dict.get("processing_energy_breakdown") or {}
-
-                    if energy_breakdown:
-                        for carrier, carrier_unit_cost in energy_breakdown.items():
-                            _["energy"].append(
-                                {carrier: {"demand": attr_dict["volume"], "unit_cost": carrier_unit_cost}}
-                            )
-                    elif processing_energy_cost:
-                        _["energy"].append(
-                            {
-                                attr_dict["commodity"]: {
-                                    "demand": attr_dict["volume"],
-                                    "unit_cost": processing_energy_cost,
-                                }
-                            }
-                        )
+                    for carrier, carrier_unit_cost in energy_breakdown.items():
+                        _["energy"].append({carrier: {"demand": attr_dict["volume"], "unit_cost": carrier_unit_cost}})
             else:
                 logger.debug(f"[BOM] FG {fg.furnace_group_id}: Graph is None, no edges to process")
 
@@ -1081,14 +1109,14 @@ class TM_PAM_connector:
                 }
                 req_by_charge = _required_quantity_by_charge(fg)
                 expected_energy = sum(
-                    material["demand"] / req_by_charge[charge] * vopex_by_charge[charge]
+                    material["demand"] / req * vopex_by_charge[charge]
                     for charge, material in collect["materials"].items()
-                    if charge in vopex_by_charge
+                    if charge in vopex_by_charge and (req := req_by_charge.get(charge))
                 )
                 booked_energy = sum(entry["total_cost"] for entry in collect["energy"].values())
-                if not math.isclose(booked_energy, expected_energy, rel_tol=1e-9, abs_tol=1e-6):
+                if not math.isclose(booked_energy, expected_energy, rel_tol=0.0, abs_tol=0.01):
                     logger.error(
-                        "Energy booking mismatch for furnace group %s: booked %.6f USD vs %.6f USD "
+                        "Energy booking mismatch for furnace group %s: booked %.2f USD vs %.2f USD "
                         "expected from per-product energy vopex x product tonnes",
                         fg.furnace_group_id,
                         booked_energy,
@@ -1107,6 +1135,7 @@ class TM_PAM_connector:
 
             util_rate = getattr(fg, "utilization_rate", None)
             if util_rate is not None and util_rate <= 0:
+                _ensure_material_shares(collect["materials"])
                 fg.bill_of_materials = collect
             else:
                 # make sure BOM exists when we have allocations, otherwise use existing BOM
@@ -1133,28 +1162,6 @@ class TM_PAM_connector:
                     # Fall through to initialize or keep the merged_bom structure
 
                 merged_bom: dict[str, dict[str, dict[str, float]]] = existing_bom or {"materials": {}, "energy": {}}
-
-                def _ensure_material_shares(materials: dict[str, dict[str, float]]) -> None:
-                    if not materials:
-                        return
-                    product_volume = None
-                    for values in materials.values():
-                        pv = values.get("product_volume")
-                        if isinstance(pv, (int, float)) and pv > 0:
-                            product_volume = float(pv)
-                            break
-                    if product_volume is None or product_volume <= 0:
-                        total_output = sum(float(v.get("product_volume") or 0.0) for v in materials.values())
-                        if total_output > 0:
-                            product_volume = total_output
-                        else:
-                            demand_sum = sum(float(v.get("demand") or 0.0) for v in materials.values())
-                            product_volume = demand_sum if demand_sum > 0 else None
-                    if not product_volume or product_volume <= 0:
-                        return
-                    for commodity, values in materials.items():
-                        demand = float(values.get("demand") or 0.0)
-                        values["demand_share_pct"] = demand / product_volume
 
                 if collect["materials"]:
                     merged_bom["materials"] = collect["materials"]

--- a/tests/unit/test_calculate_costs.py
+++ b/tests/unit/test_calculate_costs.py
@@ -105,6 +105,36 @@ def test_cost_adjustments_ignore_secondary_feedstocks_and_use_product_volume():
     assert pytest.approx(adjustment, 1e-9) == -10.0
 
 
+def test_cost_adjustments_raise_without_required_quantity():
+    """A matched pathway without required_quantity_per_ton_of_product cannot derive its
+    product contribution and must fail loudly instead of falling back to total production."""
+
+    class DummyDBC:
+        def __init__(self):
+            self.metallic_charge = "io_low"
+            self.outputs = {"slag": 1.0}
+            self.carbon_outputs: dict[str, float] = {}
+            self.reductant = "coke"
+            self.required_quantity_per_ton_of_product = 0.0
+
+    bill_of_materials = {
+        "materials": {
+            "io_low": {
+                "demand": 1611.0,
+                "total_cost": 0.0,
+                "product_volume": 1000.0,
+            }
+        },
+    }
+
+    with pytest.raises(ValueError, match="io_low.*required_quantity_per_ton_of_product"):
+        calculate_cost_adjustments_from_secondary_outputs(
+            bill_of_materials=bill_of_materials,
+            dynamic_business_cases=[DummyDBC()],
+            output_costs={"slag": -10.0},
+        )
+
+
 def test_empty_materials_demand_cost():
     # Test with empty materials_demand_cost - should return only energy unit cost
     # Note: Function now expects product_volume and total_cost for energy costs

--- a/tests/unit/test_tm_pam_connector_energy_units.py
+++ b/tests/unit/test_tm_pam_connector_energy_units.py
@@ -191,6 +191,42 @@ def test_energy_booking_validator_detects_unit_regression():
     )
 
 
+def test_snapshot_raises_on_missing_carrier_breakdown():
+    """A charge with an energy total but no per-carrier breakdown cannot be booked by carrier."""
+    furnace_group = _make_bf_furnace_group()
+    furnace_group.energy_vopex_breakdown_by_input = {"io_low": {"coking_coal": 96.0}}  # io_mid missing
+
+    plant = SimpleNamespace(plant_id="plant", furnace_groups=[furnace_group])
+    with pytest.raises(ValueError, match="io_mid.*no per-carrier breakdown"):
+        TM_PAM_connector(
+            dynamic_feedstocks_classes={},
+            plants=_StubRepo([plant]),
+            transport_kpis=None,
+        )
+
+
+def test_snapshot_raises_on_conflicting_required_quantities():
+    """Two feedstock rows for the same charge with different req_qty must fail loudly, not
+    silently convert with whichever row came last."""
+    furnace_group = _make_bf_furnace_group()
+    furnace_group.effective_primary_feedstocks.append(
+        SimpleNamespace(
+            metallic_charge="io_low",
+            required_quantity_per_ton_of_product=1.4,
+            energy_requirements={"coking_coal": 0.48},
+            secondary_feedstock={},
+        ),
+    )
+
+    plant = SimpleNamespace(plant_id="plant", furnace_groups=[furnace_group])
+    with pytest.raises(ValueError, match="conflicting required_quantity_per_ton_of_product.*io_low"):
+        TM_PAM_connector(
+            dynamic_feedstocks_classes={},
+            plants=_StubRepo([plant]),
+            transport_kpis=None,
+        )
+
+
 def test_multi_commodity_source_energy_not_double_booked():
     """Two commodities from ONE source node must each book their energy exactly once."""
     furnace_group = _make_bf_furnace_group()

--- a/tests/unit/test_tm_pam_connector_energy_units.py
+++ b/tests/unit/test_tm_pam_connector_energy_units.py
@@ -317,3 +317,109 @@ def test_cost_propagation_is_allocation_order_independent():
 
         # (scrap 500 t x 300 + ore 1600 t x 100) / 1000 t steel = 310 USD/t
         assert connector.G.nodes["bof1"]["unit_cost"]["steel"] == pytest.approx(310.0)
+
+
+def test_utilization_correction_refreshes_shares_and_energy():
+    """After a min-share correction the BOM must stay internally consistent.
+
+    hot_metal fixed at 400 t against a 70 % minimum -> production 1000 -> 571.43 t,
+    scrap 600 -> 171.43 t. demand_share_pct must land exactly on 0.7 / 0.3 and the
+    energy entries must equal demand/req x intensity (quantities) and x vopex (costs)
+    for the corrected mix, not a stale or uniformly scaled copy.
+    """
+    furnace_group = SimpleNamespace(
+        furnace_group_id="plant_bof1",
+        technology=SimpleNamespace(name="BOF", product="steel"),
+        capacity=1000.0,
+        allocated_volumes=1000.0,
+        utilization_rate=1.0,
+        chosen_reductant="none",
+        energy_vopex_breakdown_by_input={
+            "hot_metal": {"electricity": 10.0},
+            "scrap": {"electricity": 20.0},
+        },
+        effective_primary_feedstocks=[
+            SimpleNamespace(
+                metallic_charge="hot_metal",
+                required_quantity_per_ton_of_product=1.0,
+                energy_requirements={"electricity": 0.5},
+                secondary_feedstock={},
+            ),
+            SimpleNamespace(
+                metallic_charge="scrap",
+                required_quantity_per_ton_of_product=1.0,
+                energy_requirements={"electricity": 0.8},
+                secondary_feedstock={},
+            ),
+        ],
+        bill_of_materials={
+            "materials": {
+                "hot_metal": {
+                    "demand": 400.0,
+                    "total_cost": 40_000.0,
+                    "total_material_cost": 40_000.0,
+                    "unit_cost": 40.0,
+                    "unit_material_cost": 40.0,
+                    "product_volume": 1000.0,
+                    "demand_share_pct": 0.4,
+                },
+                "scrap": {
+                    "demand": 600.0,
+                    "total_cost": 30_000.0,
+                    "total_material_cost": 30_000.0,
+                    "unit_cost": 30.0,
+                    "unit_material_cost": 30.0,
+                    "product_volume": 1000.0,
+                    "demand_share_pct": 0.6,
+                },
+            },
+            "energy": {
+                "electricity": {
+                    "demand": 680.0,
+                    "total_cost": 16_000.0,
+                    "unit_cost": 16.0,
+                    "product_volume": 1000.0,
+                }
+            },
+        },
+    )
+    furnace_group.set_allocated_volumes = lambda v: setattr(furnace_group, "allocated_volumes", v)
+
+    connector = TM_PAM_connector(
+        dynamic_feedstocks_classes={},
+        plants=_StubRepo([]),
+        transport_kpis=None,
+    )
+    corrected = connector.correct_utilization_for_supply_constraints(
+        furnace_groups=[furnace_group],
+        bom_issues=[
+            {
+                "fg_id": "plant_bof1",
+                "check": "min_share",
+                "commodity": "hot_metal",
+                "actual_share": 0.4,
+                "required_share": 0.7,
+            }
+        ],
+    )
+    assert corrected == 1
+
+    new_production = 400.0 / 0.7
+    assert furnace_group.allocated_volumes == pytest.approx(new_production)
+
+    materials = furnace_group.bill_of_materials["materials"]
+    assert materials["hot_metal"]["demand"] == pytest.approx(400.0)
+    assert materials["scrap"]["demand"] == pytest.approx(new_production - 400.0)
+    assert materials["hot_metal"]["demand_share_pct"] == pytest.approx(0.7)
+    assert materials["scrap"]["demand_share_pct"] == pytest.approx(0.3)
+    assert materials["scrap"]["total_material_cost"] == pytest.approx(30_000.0 * (new_production - 400.0) / 600.0)
+    assert materials["scrap"]["unit_material_cost"] == pytest.approx(
+        materials["scrap"]["total_material_cost"] / new_production
+    )
+
+    energy = furnace_group.bill_of_materials["energy"]["electricity"]
+    scrap_product_tonnes = new_production - 400.0
+    assert energy["demand"] == pytest.approx(400.0 * 0.5 + scrap_product_tonnes * 0.8)
+    assert energy["total_cost"] == pytest.approx(400.0 * 10.0 + scrap_product_tonnes * 20.0)
+    assert energy["unit_cost"] == pytest.approx(energy["total_cost"] / new_production)
+    assert energy["product_volume"] == pytest.approx(new_production)

--- a/tests/unit/test_tm_pam_connector_energy_units.py
+++ b/tests/unit/test_tm_pam_connector_energy_units.py
@@ -189,3 +189,51 @@ def test_energy_booking_validator_detects_unit_regression():
     assert any(
         "Energy booking mismatch" in record.getMessage() and "plant_bf1" in record.getMessage() for record in records
     )
+
+
+def test_multi_commodity_source_energy_not_double_booked():
+    """Two commodities from ONE source node must each book their energy exactly once."""
+    furnace_group = _make_bf_furnace_group()
+    plant = SimpleNamespace(plant_id="plant", furnace_groups=[furnace_group])
+    connector = TM_PAM_connector(
+        dynamic_feedstocks_classes={},
+        plants=_StubRepo([plant]),
+        transport_kpis=None,
+    )
+
+    dual_supplier = tlp.ProcessCenter(
+        name="sup_dual",
+        process=tlp.Process(name="dual_supply", type=tlp.ProcessType.SUPPLY, bill_of_materials=[]),
+        capacity=1000.0,
+        location=_location("AUS"),
+        production_cost=50.0,
+    )
+    bf_pc = tlp.ProcessCenter(
+        name="plant_bf1",
+        process=tlp.Process(name="BF", type=tlp.ProcessType.PRODUCTION, bill_of_materials=[]),
+        capacity=500.0,
+        location=_location("DEU"),
+        production_cost=0.0,
+    )
+    sink_pc = tlp.ProcessCenter(
+        name="deu_demand",
+        process=tlp.Process(name="demand", type=tlp.ProcessType.DEMAND, bill_of_materials=[]),
+        capacity=1000.0,
+        location=_location("DEU"),
+    )
+
+    # Both charges arrive from the SAME source node -> two parallel edges sup_dual -> plant_bf1.
+    allocations = tlp.Allocations(
+        allocations={
+            (dual_supplier, bf_pc, tlp.Commodity(name="io_low")): 160.0,
+            (dual_supplier, bf_pc, tlp.Commodity(name="io_mid")): 150.0,
+            (bf_pc, sink_pc, tlp.Commodity(name="hot_metal")): 200.0,
+        },
+    )
+
+    connector.create_graph(allocations)
+    connector.propage_cost_forward_by_layers_and_normalize()
+    connector.update_bill_of_materials([furnace_group])
+
+    energy = furnace_group.bill_of_materials["energy"]["coking_coal"]
+    assert energy["total_cost"] == pytest.approx(18_600.0)  # 96 x 100 + 90 x 100, once each

--- a/tests/unit/test_tm_pam_connector_energy_units.py
+++ b/tests/unit/test_tm_pam_connector_energy_units.py
@@ -273,3 +273,47 @@ def test_multi_commodity_source_energy_not_double_booked():
 
     energy = furnace_group.bill_of_materials["energy"]["coking_coal"]
     assert energy["total_cost"] == pytest.approx(18_600.0)  # 96 x 100 + 90 x 100, once each
+
+
+def test_cost_propagation_is_allocation_order_independent():
+    """A node's outgoing cost must include ALL upstream legs regardless of allocation order.
+
+    Diamond topology: scrap root -> BOF, ore root -> BF -> BOF, BOF -> demand. BFS
+    discovery order processed the BOF before the BF whenever the scrap edge came first
+    in the allocations dict, dropping the entire hot-metal leg from the BOF's unit cost
+    (150 instead of 310 USD/t). Topological ordering must give 310 either way.
+    """
+
+    def _pc(name, process_type, cost=None):
+        return tlp.ProcessCenter(
+            name=name,
+            process=tlp.Process(name=name, type=process_type, bill_of_materials=[]),
+            capacity=1000.0,
+            location=_location("DEU"),
+            production_cost=cost,
+        )
+
+    scrap_sup = _pc("scrap_sup", tlp.ProcessType.SUPPLY, 300.0)
+    ore_sup = _pc("ore_sup", tlp.ProcessType.SUPPLY, 100.0)
+    bf_pc = _pc("bf1", tlp.ProcessType.PRODUCTION, 0.0)
+    bof_pc = _pc("bof1", tlp.ProcessType.PRODUCTION, 0.0)
+    demand_pc = _pc("dem", tlp.ProcessType.DEMAND)
+
+    edges = [
+        ((scrap_sup, bof_pc, tlp.Commodity(name="scrap")), 500.0),
+        ((ore_sup, bf_pc, tlp.Commodity(name="io_low")), 1600.0),
+        ((bf_pc, bof_pc, tlp.Commodity(name="hot_metal")), 500.0),
+        ((bof_pc, demand_pc, tlp.Commodity(name="steel")), 1000.0),
+    ]
+
+    for order in (edges, [edges[1], edges[0], *edges[2:]]):
+        connector = TM_PAM_connector(
+            dynamic_feedstocks_classes={},
+            plants=_StubRepo([]),
+            transport_kpis=None,
+        )
+        connector.create_graph(tlp.Allocations(allocations=dict(order)))
+        connector.propage_cost_forward_by_layers_and_normalize()
+
+        # (scrap 500 t x 300 + ore 1600 t x 100) / 1000 t steel = 310 USD/t
+        assert connector.G.nodes["bof1"]["unit_cost"]["steel"] == pytest.approx(310.0)

--- a/tests/unit/test_tm_pam_connector_supplier_costs.py
+++ b/tests/unit/test_tm_pam_connector_supplier_costs.py
@@ -345,9 +345,9 @@ def test_cost_propagation_handles_output_alias():
     connector.propage_cost_forward_by_layers_and_normalize()
 
     furnace_node = connector.G.nodes[furnace_pc.name]
-    assert "pig_iron" in furnace_node["product_cost"], "Expected pig iron cost stored on furnace node"
-    assert furnace_node["product_cost"]["pig_iron"] == pytest.approx(8_000.0)
     assert furnace_node["allocations"]["pig_iron"]["Cost"] == pytest.approx(8_000.0)
+    # The alias must survive into the outgoing steel price: 8,000 / 100 t + own 20 USD/t.
+    assert furnace_node["unit_cost"]["steel"] == pytest.approx(100.0)
 
 
 def test_scrap_supplier_with_country_based_id():


### PR DESCRIPTION
Stacked on #119. Three graph-layer bugs in the same family — silent, order/topology-dependent, and invisible to CSV-level checks — plus the guard rails that keep them out.

## Bug 1 — parallel-edge double-booking (caught by #119's new validator within a day)

NetworkX's keyless `in_edges` repeats a node pair once per parallel edge, *and* `get_edge_data` returns all parallel edges each time. A DRI plant shipping two commodities to one BOF:

```
before:  2 parallel edges x both edges read each time = every commodity booked twice  (+22 % energy on the affected BOF)
after:   iterate in_edges(data=True) = each edge booked exactly once
```

Present since the initial import; every other edge-iteration site audited clean.

## Bug 2 — traversal-order-dependent costs

Cost propagation used BFS discovery order, so a node could be priced before all its suppliers had pushed costs into it. On a BOF fed by scrap (direct) and hot metal (via a BF), the steel cost depended on dict insertion order:

```
scrap edge first:  BOF priced before the BF pushes -> 150 $/t   (hot-metal leg missing entirely)
ore edge first:                                       310 $/t   (correct)
```

Latent today (chains are two tiers deep; the corrupted attribute was unread), one new processing tier away from going live. Fixed with a topological sort — order-independent by construction; regression test asserts both orders give 310. The propagation also now mutates the graph explicitly instead of relying on shallow-copy aliasing.

## Bug 3 — corrected BOMs left internally inconsistent

The min-share utilisation correction (clustered runs only) rescaled material demands but not the shares, energy entries, or material-cost fields — producing impossible states in real output (`total_material_cost > total_cost`, energy costed on the pre-correction product volume). Shares are now refreshed and energy rebuilt from the corrected mix; a single scale factor cannot work because the metallic mix changes non-uniformly.

## Fail-loud guards

Missing unit-conversion divisors, missing per-carrier breakdowns, and conflicting duplicate feedstock rows now raise at trade-module construction instead of producing silently wrong bookings; an authored zero demand share is respected instead of coerced to full weight; the booking validator degrades gracefully (error log, cent tolerance) instead of crashing.

## Impact & validation

Economically inert in default (unclustered) runs — a 2050 before/after pair shows median deltas of zero and no fleet drift. The double-booking and correction fixes matter for multi-commodity flows and clustered runs. A full clustered 2050 run at this head completed clean: 2,805 corrections exercised, zero booking mismatches, zero errors, corrected BOMs verified internally consistent through 2050 (archive: `experiments/2026-08_tm-graph-fixes/`). Full unit suite + mypy green against main.