### PR TITLE
PAM bug fixes: cost-of-debt subsidy scaling, debt amortisation slice, OPEX subsidy window and province input-cost fallback

### DIFF
--- a/src/steelo/adapters/dataprocessing/excel_reader.py
+++ b/src/steelo/adapters/dataprocessing/excel_reader.py
@@ -2015,7 +2015,8 @@ def _normalize_cost_item(cost_item: str | None, row_index: int) -> str | None:
         return "opex"
     elif normalized in ("capex",):
         return "capex"
-    elif normalized in ("cost of debt", "debt"):
+    # Underscore/hyphen spellings would otherwise fall through and be read as an energy carrier
+    elif normalized in ("cost of debt", "cost_of_debt", "cost-of-debt", "debt"):
         return "cost of debt"
     # Known aliases
     elif normalized == "h2":
@@ -2199,7 +2200,7 @@ def read_subsidies(
         # - Other absolute subsidies: keep as-is (e.g., USD/t output)
         if subsidy_type == "relative":
             subsidy_amount = float(subsidy_amount) / 100
-        elif cost_item == "cost_of_debt":
+        elif cost_item == "cost of debt":
             # Absolute cost of debt subsidy is given as percentage point reduction
             subsidy_amount = float(subsidy_amount) / 100
         else:

--- a/src/steelo/adapters/dataprocessing/excel_reader.py
+++ b/src/steelo/adapters/dataprocessing/excel_reader.py
@@ -114,6 +114,15 @@ def read_regional_input_prices_from_master_excel(
         input_costs_sheet (str): Name of the sheet containing input costs.
     Returns:
         list[InputCosts]: A list of InputCosts objects containing the regional input prices.
+
+    Notes:
+        Sub-national rows (ISO-3 code like "CHN:CN-HE") may author only a subset of
+        commodities; the gaps are filled from the parent country's row so a province
+        never silently prices an unauthored commodity at zero.
+
+    Raises:
+        ValueError: If any commodity remains unpriced after the country fallback —
+            a silent 0.0 would zero that carrier's cost downstream.
     """
 
     # 1) Load raw data
@@ -124,9 +133,11 @@ def read_regional_input_prices_from_master_excel(
 
     # 2) Build input_cost_dict = { year: { ISO3: { commodity: cost_in_raw_units, … } } }
     input_costs_df.columns.name = "Year"
+    # min_count=1 keeps unauthored (geo, commodity) pairs as NaN through the pivot so the
+    # sub-national fallback below can tell "not authored" apart from an authored 0.0
     input_cost_stacked = (
         input_costs_df.groupby(["ISO-3 code", "Commodity"])
-        .sum(numeric_only=True)
+        .sum(numeric_only=True, min_count=1)
         .unstack(level=1)
         .stack(level="Year")
         .reset_index()
@@ -169,7 +180,7 @@ def read_regional_input_prices_from_master_excel(
 
     grouped: dict[str, dict[str, dict[str, float]]] = (
         input_cost_stacked.groupby(["year", "iso-3 code"])
-        .sum(numeric_only=True)
+        .sum(numeric_only=True, min_count=1)
         .apply(lambda row: row.to_dict(), axis=1)
         .unstack(level="year")
         .to_dict()
@@ -180,6 +191,25 @@ def read_regional_input_prices_from_master_excel(
     input_cost_dict: dict[int, dict[str, dict[str, float]]] = {
         int(year): country_data for year, country_data in grouped.items()
     }
+
+    # 4b) Sub-national rows author only some commodities (e.g. province electricity);
+    # fill the gaps from the parent country so unauthored commodities are never
+    # priced at zero. A gap that survives the fallback (missing at country level
+    # too) would silently price that commodity at 0.0 downstream, so fail loudly.
+    for year_key, by_geo in input_cost_dict.items():
+        for geo_key, costs in by_geo.items():
+            iso3, _, code = geo_key.partition(":")
+            if code:
+                parent = by_geo.get(iso3) or {}
+                for commodity, value in costs.items():
+                    if pd.isna(value):
+                        costs[commodity] = parent.get(commodity, float("nan"))
+            unpriced = sorted(commodity for commodity, value in costs.items() if pd.isna(value))
+            if unpriced:
+                raise ValueError(
+                    f"Input costs: {geo_key} has no authored value in {year_key} "
+                    f"(and no country fallback) for: {unpriced}"
+                )
 
     # 5) Build a List[InputCosts], sorted by year then geo_key. The "ISO-3 code" column holds
     # either a country (CHN) or a sub-national geo_key (CHN:CN-HE); split into iso3 + geo_unit.

--- a/src/steelo/data/cache_manager.py
+++ b/src/steelo/data/cache_manager.py
@@ -51,7 +51,7 @@ class CacheMetadata:
 class DataPreparationCache:
     """Manages cached data preparations based on content hashing."""
 
-    CACHE_VERSION = "1.4"  # Bump to invalidate all caches (per-technology cost_of_capital.json format)
+    CACHE_VERSION = "1.5"  # Bump to invalidate all caches (sub-national input-cost rows fall back to country values)
 
     def __init__(self, cache_root: Optional[Path] = None):
         """Initialize cache manager.

--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -787,7 +787,8 @@ def calculate_debt_repayment(
 
     Returns:
         list[float]: List of yearly repayment amounts (principal + interest) for the remaining lifetime.
-            Returns list of zeros if there is no debt (equity_share = 1.0).
+            Returns list of zeros if there is no debt (equity_share = 1.0), and an empty list once the
+            loan is fully repaid (lifetime_remaining <= 0).
 
     Note:
         - The repayment method uses constant principal payments with declining interest (not constant annuity payments).
@@ -798,6 +799,9 @@ def calculate_debt_repayment(
     if lifetime_remaining is None:
         lifetime_remaining = lifetime
 
+    if lifetime_remaining <= 0:
+        return []
+
     # Calculate total debt (investment minus equity portion)
     debt = total_investment * (1 - equity_share)
 
@@ -805,8 +809,8 @@ def calculate_debt_repayment(
     if debt == 0:
         total_repayment_list = [0.0] * lifetime
     else:
-        # Create schedule with constant principal repayments
-        capital_repayment_list = [debt / lifetime] * lifetime_remaining
+        # Amortise over the full lifetime so the tail slice reflects the debt already repaid
+        capital_repayment_list = [debt / lifetime] * lifetime
         total_repayment_list = []
 
         # Calculate total repayment (principal + interest) for each year

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -2415,7 +2415,7 @@ class FurnaceGroup:
         applied_opex_subsidies = collect_active_subsidies_over_period(
             tech_opex_subsidies.get(self.technology.name, []),
             start_year=Year(current_year),
-            end_year=Year(current_year + self.lifetime.end),
+            end_year=self.lifetime.end,
         )
 
         # Calculate unit OPEX with subsidies (without carbon costs yet)

--- a/tests/unit/test_calculate_costs.py
+++ b/tests/unit/test_calculate_costs.py
@@ -1,5 +1,6 @@
 import pytest
 
+from steelo.domain import calculate_costs
 from steelo.domain.calculate_costs import (
     calculate_cost_breakdown_by_feedstock,
     calculate_debt_repayment,
@@ -209,11 +210,106 @@ def test_calculate_debt_repayment_lifetime_remaining():
     lifetime_remaining = 5
     cost_of_debt = 0.05
 
+    # Tail of the full 10-year schedule: principal of 80/year on debt of 800, plus interest on the
+    # average balance of each of the last five years.
+    expected_repayments = [98.0, 94.0, 90.0, 86.0, 82.0]
+
     result = calculate_debt_repayment(total_investment, equity_share, lifetime, cost_of_debt, lifetime_remaining)
 
     # Assertions
     assert len(result) == lifetime_remaining, "Result should have 'lifetime_remaining' number of repayments."
     assert all(isinstance(x, (int, float)) for x in result), "All repayments should be numbers."
+    assert result == pytest.approx(expected_repayments), f"Expected {expected_repayments}, but got {result}"
+
+
+def test_calculate_debt_repayment_returns_tail_of_full_schedule():
+    """Test that a part-way-through loan is charged interest on the debt still outstanding.
+
+    The returned schedule must be the last `lifetime_remaining` years of the full schedule, not a
+    fresh amortisation restarted from the initial debt balance.
+    """
+    # Arrange
+    total_investment = 1000
+    equity_share = 0.2
+    lifetime = 10
+    lifetime_remaining = 5
+    cost_of_debt = 0.05
+
+    # Act
+    full_schedule = calculate_costs.calculate_debt_repayment(
+        total_investment,
+        equity_share,
+        lifetime,
+        cost_of_debt,
+    )
+    result = calculate_costs.calculate_debt_repayment(
+        total_investment,
+        equity_share,
+        lifetime,
+        cost_of_debt,
+        lifetime_remaining,
+    )
+
+    # Assert
+    assert result == pytest.approx(full_schedule[-lifetime_remaining:])
+    assert result[0] < full_schedule[0], "Later years carry less outstanding debt, so less interest."
+
+
+def test_calculate_debt_repayment_agrees_with_current_year_repayment():
+    """Test that the first year of the remaining schedule matches calculate_current_debt_repayment.
+
+    Both functions amortise the same loan, so for a plant six years into a ten-year loan they must
+    agree on that year's payment.
+    """
+    # Arrange
+    total_investment = 1000
+    equity_share = 0.2
+    lifetime = 10
+    cost_of_debt = 0.05
+    years_elapsed = 6
+    lifetime_remaining = lifetime - years_elapsed + 1
+
+    # Act
+    schedule = calculate_costs.calculate_debt_repayment(
+        total_investment,
+        equity_share,
+        lifetime,
+        cost_of_debt,
+        lifetime_remaining,
+    )
+    current_year_repayment = calculate_costs.calculate_current_debt_repayment(
+        total_investment=total_investment,
+        lifetime_expired=False,
+        lifetime_years=lifetime,
+        years_elapsed=years_elapsed,
+        cost_of_debt=cost_of_debt,
+        equity_share=equity_share,
+    )
+
+    # Assert
+    assert schedule[0] == pytest.approx(current_year_repayment)
+
+
+@pytest.mark.parametrize("lifetime_remaining", [0, -3])
+@pytest.mark.parametrize("equity_share", [0.2, 1.0])
+def test_calculate_debt_repayment_no_remaining_lifetime(equity_share, lifetime_remaining):
+    """Test that a fully repaid loan yields no further repayments, with or without debt."""
+    # Arrange
+    total_investment = 1000
+    lifetime = 10
+    cost_of_debt = 0.05
+
+    # Act
+    result = calculate_costs.calculate_debt_repayment(
+        total_investment,
+        equity_share,
+        lifetime,
+        cost_of_debt,
+        lifetime_remaining,
+    )
+
+    # Assert
+    assert result == []
 
 
 @pytest.fixture

--- a/tests/unit/test_calculate_opex_subsidies.py
+++ b/tests/unit/test_calculate_opex_subsidies.py
@@ -1,8 +1,11 @@
 """Tests for calculate_opex_with_subsidies and calculate_opex_list_with_subsidies functions."""
 
+from unittest.mock import patch
+
 import pytest
+from steelo import devdata
 from steelo.domain import calculate_costs
-from steelo.domain.models import Subsidy, Year
+from steelo.domain.models import PointInTime, Subsidy, TimeFrame, Year
 
 
 def test_calculate_opex_with_subsidies_no_subsidies():
@@ -345,3 +348,66 @@ def test_calculate_opex_list_with_subsidies_full_period():
     assert len(result) == 5
     for i, (actual, exp) in enumerate(zip(result, expected)):
         assert actual == pytest.approx(exp), f"Year {i}: expected {exp}, got {actual}"
+
+
+def test_furnace_group_opex_subsidy_window_ends_at_lifetime_end():
+    """Test that the current technology's OPEX subsidies are collected over the furnace group's lifetime.
+
+    The collection window must end at the furnace group's absolute end year. Adding that year to the
+    current year yields a window thousands of years long, in which expired subsidies stay active.
+    """
+    # Arrange
+    furnace_group = devdata.get_furnace_group(
+        fg_id="fg_opex_window",
+        tech_name="EAF",
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2015), end=Year(2035)),
+            plant_lifetime=20,
+        ),
+    )
+    expired_subsidy = Subsidy(
+        scenario_name="expired_after_lifetime",
+        iso3="USA",
+        technology_name="EAF",
+        cost_item="opex",
+        subsidy_type="absolute",
+        subsidy_amount=40.0,
+        start_year=Year(2040),
+        end_year=Year(2050),
+    )
+    collected_windows = []
+    collected_subsidies = []
+    real_collect = calculate_costs.collect_active_subsidies_over_period
+
+    def spy(subsidies, start_year, end_year):
+        collected_windows.append((start_year, end_year))
+        collected = real_collect(subsidies, start_year=start_year, end_year=end_year)
+        collected_subsidies.append(collected)
+        return collected
+
+    # Act - no allowed transitions, so the method returns straight after collecting OPEX subsidies
+    with patch("steelo.domain.models.collect_active_subsidies_over_period", side_effect=spy):
+        furnace_group.optimal_technology_name(
+            market_price_series={"steel": [600.0] * 30, "iron": [400.0] * 30},
+            cost_of_debt_by_tech={"EAF": 0.04},
+            cost_of_equity_by_tech={"EAF": 0.08},
+            get_bom_from_avg_boms=lambda *args: (None, 0.0, ""),
+            capex_dict={"EAF": 400.0},
+            capex_renovation_share={"EAF": 0.7},
+            technology_fopex_dict={"eaf": 50.0},
+            dynamic_business_cases={"EAF": []},
+            chosen_emissions_boundary_for_carbon_costs="scope_1",
+            technology_emission_factors=[],
+            tech_to_product={"EAF": "steel"},
+            plant_lifetime=20,
+            construction_time=2,
+            current_year=Year(2025),
+            risk_free_rate=0.02,
+            allowed_furnace_transitions={},
+            tech_opex_subsidies={"EAF": [expired_subsidy]},
+        )
+
+    # Assert
+    assert collected_windows == [(Year(2025), Year(2035))]
+    assert collected_subsidies == [[]], "A subsidy starting after the end year must not be collected."

--- a/tests/unit/test_input_costs_province_fallback.py
+++ b/tests/unit/test_input_costs_province_fallback.py
@@ -1,0 +1,67 @@
+"""Sub-national Input-costs rows fall back to the parent country per commodity."""
+
+import pandas as pd
+import pytest
+
+from steelo.adapters.dataprocessing.excel_reader import read_regional_input_prices_from_master_excel
+from steelo.domain.constants import PERMWh_TO_PERkWh
+
+
+def write_master(tmp_path, rows):
+    """Write an Input costs sheet with the given rows and return its path."""
+    path = tmp_path / "master.xlsx"
+    pd.DataFrame(rows).to_excel(path, sheet_name="Input costs", index=False)
+    return path
+
+
+def by_key(result):
+    return {(entry.iso3, entry.geo_unit, int(entry.year)): entry.costs for entry in result}
+
+
+@pytest.fixture
+def master_with_province_rows(tmp_path):
+    """Fully authored country rows plus a province row authoring only Electricity."""
+    return write_master(
+        tmp_path,
+        [
+            {"ISO-3 code": "CHN", "Commodity": "Electricity", "Unit": "USD/MWh", 2025: 60.0, 2026: 61.0},
+            {"ISO-3 code": "CHN", "Commodity": "Coal", "Unit": "USD/t", 2025: 100.0, 2026: 101.0},
+            {"ISO-3 code": "CHN:CN-AH", "Commodity": "Electricity", "Unit": "USD/MWh", 2025: 48.5, 2026: 49.0},
+        ],
+    )
+
+
+def test_province_inherits_unauthored_commodities_from_country(master_with_province_rows):
+    """A province row keeps its authored electricity but takes coal from the country row."""
+    costs = by_key(read_regional_input_prices_from_master_excel(master_with_province_rows))
+
+    province_2025 = costs[("CHN", "CN-AH", 2025)]
+    assert province_2025["electricity"] == pytest.approx(48.5 * PERMWh_TO_PERkWh)
+    assert province_2025["coal"] == pytest.approx(100.0)
+
+    province_2026 = costs[("CHN", "CN-AH", 2026)]
+    assert province_2026["electricity"] == pytest.approx(49.0 * PERMWh_TO_PERkWh)
+    assert province_2026["coal"] == pytest.approx(101.0)
+
+
+def test_country_rows_unchanged_by_fallback(master_with_province_rows):
+    """Country rows keep their authored values."""
+    costs = by_key(read_regional_input_prices_from_master_excel(master_with_province_rows))
+
+    chn_2025 = costs[("CHN", None, 2025)]
+    assert chn_2025["electricity"] == pytest.approx(60.0 * PERMWh_TO_PERkWh)
+    assert chn_2025["coal"] == pytest.approx(100.0)
+
+
+def test_country_level_gap_raises(tmp_path):
+    """A commodity unpriced even after the country fallback fails loudly, never a silent 0.0."""
+    master = write_master(
+        tmp_path,
+        [
+            {"ISO-3 code": "CHN", "Commodity": "Electricity", "Unit": "USD/MWh", 2025: 60.0},
+            {"ISO-3 code": "CHN", "Commodity": "Coal", "Unit": "USD/t", 2025: 100.0},
+            {"ISO-3 code": "IND", "Commodity": "Electricity", "Unit": "USD/MWh", 2025: 70.0},
+        ],
+    )
+    with pytest.raises(ValueError, match=r"IND has no authored value in 2025 .* \['coal'\]"):
+        read_regional_input_prices_from_master_excel(master)

--- a/tests/unit/test_read_subsidies.py
+++ b/tests/unit/test_read_subsidies.py
@@ -256,6 +256,23 @@ def test_normalize_cost_item_debt_shorthand():
     assert result == "cost of debt"
 
 
+@pytest.mark.parametrize(
+    "cost_item",
+    [
+        "cost_of_debt",
+        "cost-of-debt",
+        "Cost_Of_Debt",
+    ],
+)
+def test_normalize_cost_item_underscore_and_hyphen_spellings(cost_item):
+    """Test that underscore/hyphen spellings normalise to 'cost of debt' rather than an energy carrier."""
+    # Act
+    result = _normalize_cost_item(cost_item, row_index=0)
+
+    # Assert
+    assert result == "cost of debt"
+
+
 def test_normalize_cost_item_hydrogen():
     """Test that hydrogen is normalized."""
     # Arrange
@@ -693,6 +710,48 @@ def test_read_subsidies_relative_percentage_conversion():
     # Assert - 10% -> 0.1
     assert len(result) == 1
     assert result[0].subsidy_amount == pytest.approx(0.1)
+
+
+@pytest.mark.parametrize(
+    "cost_item",
+    [
+        "Cost of debt",
+        "COST OF DEBT",
+        "debt",
+        "cost_of_debt",
+    ],
+)
+def test_read_subsidies_absolute_cost_of_debt_converted_to_decimal(cost_item):
+    """Test that absolute cost of debt subsidies are converted from percentage points to a decimal.
+
+    The Subsidies sheet documents this column as "cost of debt: absolute % reduction
+    (e.g. 5 -> reduction of 5% points)", while cost_of_debt is held as a decimal downstream.
+    """
+    # Arrange
+    subsidies_df = _make_subsidies_df(
+        [
+            {
+                "Scenario name": "Absolute Debt",
+                "Location": "DEU",
+                "Technology": "DRI",
+                "Cost item": cost_item,
+                "Subsidy type": "absolute",
+                "Subsidy amount": 5,
+                "Start year": 2025,
+                "End year": 2050,
+            }
+        ]
+    )
+
+    # Act
+    with patch("steelo.adapters.dataprocessing.excel_reader.pd.read_excel") as mock_read:
+        mock_read.side_effect = [subsidies_df, _make_country_df(), _make_techno_df()]
+        result = read_subsidies(Path("dummy.xlsx"))
+
+    # Assert - 5 percentage points -> 0.05
+    assert len(result) == 1
+    assert result[0].cost_item == "cost of debt"
+    assert result[0].subsidy_amount == pytest.approx(0.05)
 
 
 def test_read_subsidies_absolute_opex_no_conversion():


### PR DESCRIPTION
## PAM bug fixes

**Cost-of-debt subsidy scaling** (`read_subsidies`): the unit-conversion branch compared the underscored `cost_of_debt` while `_normalize_cost_item` returns the spaced form, so absolute cost-of-debt subsidies skipped the `/100` and were stored 100x too large (a "3 %-point" subsidy slammed the effective rate to the risk-free floor). Underscore/hyphen spellings are now also accepted as aliases instead of falling through and registering as phantom energy carriers. Latent in shipped workbooks (only the `Example` row, dated 2100, uses cost of debt), but live for any real authored row.

**Debt amortisation slice** (`calculate_debt_repayment`): `[debt / lifetime] * lifetime_remaining` made the trailing `[-lifetime_remaining:]` slice a no-op, so part-way-through furnace groups were charged the *first* N years of the schedule (highest interest) instead of the last N — overstating debt burden in every NPV and strategy decision. Amortisation now runs over the full lifetime and the tail slice works; `lifetime_remaining <= 0` returns `[]` for both the debt and zero-debt paths (previously the zero-debt path returned a full-length schedule via a `[-0:]` slicing quirk). The first year of the remaining schedule now agrees with `calculate_current_debt_repayment`.

**OPEX subsidy window** (`FurnaceGroup.optimal_technology_name` STAGE 2): `end_year=Year(current_year + self.lifetime.end)` added an absolute year to the current year, producing a ~2,000-year collection window. Numerically neutral (downstream `calculate_opex_list_with_subsidies` re-filters per year) but wasted a ~2,000-iteration loop per furnace group per year and over-reported applied subsidies in debug logs. Window now ends at `self.lifetime.end`.

**Province input-cost fallback** (`read_regional_input_prices_from_master_excel`): sub-national rows authoring only a subset of commodities now fall back to the parent country's values instead of silently pricing unauthored commodities at 0.0; a gap that survives the fallback raises. `CACHE_VERSION` bumped to 1.5.
