### PR TITLE
Resolve expired furnace-group lifetimes to renovate or close instead of no action

### DIFF
--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -3771,6 +3771,12 @@ class Plant:
         11. Apply probabilistic adoption decision (if enabled)
         12. Return appropriate command (ChangeFurnaceGroupTechnology, RenovateFurnaceGroup, CloseFurnaceGroup, or None)
 
+        An expired lifetime always resolves to an action: any no-action exit (all NPVs
+        non-positive, blocked/unaffordable/rejected switch) falls back to renovating the
+        incumbent when it is value-creating and affordable, otherwise the group closes.
+        ``lifetime.expired`` is true only in the renovation-boundary year, so returning
+        None would roll the group into a fresh cycle without paying renovation capex.
+
         Args:
             furnace_group_id: Unique identifier for the furnace group
             plant_group: PlantGroup that owns this plant. Its ``balance`` is the treasury
@@ -3943,11 +3949,88 @@ class Plant:
         logger.debug(f"[FG STRATEGY] CAPEX by tech ($/t): {npv_capex_dict}")
         logger.debug(f"[FG STRATEGY] COSA: {cosa_msg}")
 
+        def renovate_or_close_expired() -> commands.Command:
+            """Resolve an expired lifetime when no switch happens: renovate or close.
+
+            The incumbent is renovated when its NPV is positive and the group can fund
+            the equity portion; otherwise the furnace group closes. The incumbent being
+            absent from ``tech_npv_dict`` means renovation is no longer an allowed
+            transition (phased out or CO2-gated), so the group closes too.
+            """
+            incumbent = furnace_group.technology.name
+            incumbent_npv = tech_npv_dict.get(incumbent)
+            if incumbent_npv is None or not math.isfinite(incumbent_npv) or incumbent_npv <= 0:
+                logger.info(
+                    f"[FG STRATEGY] DECISION - CLOSE FG plant_id={self.plant_id} "
+                    f"plant_group_id={plant_group.plant_group_id} "
+                    f"(lifetime expired, incumbent {incumbent} NPV not positive: {incumbent_npv})"
+                )
+                return commands.CloseFurnaceGroup(
+                    plant_id=self.plant_id, furnace_group_id=furnace_group.furnace_group_id
+                )
+
+            renovation_capex_per_tonne = npv_capex_dict.get(incumbent)
+            if renovation_capex_per_tonne is None:
+                raise ValueError(f"CAPEX (renovation) for technology {incumbent} not found in NPV CAPEX dict")
+            renovation_share = capex_renovation_share.get(incumbent)
+            if renovation_share is None:
+                raise ValueError(f"CAPEX renovation share for technology {incumbent} not found")
+            full_capex_per_tonne = renovation_capex_per_tonne / renovation_share
+            incumbent_capex_no_subsidy = region_capex.get(incumbent)
+            if incumbent_capex_no_subsidy is None:
+                raise ValueError(f"CAPEX without subsidies for technology {incumbent} not found in region CAPEX dict")
+
+            incumbent_capex_subs = filter_subsidies_for_year(tech_capex_subsidies.get(incumbent, []), current_year)
+            incumbent_debt_subs = filter_subsidies_for_year(tech_debt_subsidies.get(incumbent, []), current_year)
+            incumbent_cost_of_debt = calculate_debt_with_subsidies(
+                cost_of_debt=cost_of_debt,
+                debt_subsidies=incumbent_debt_subs,
+                risk_free_rate=risk_free_rate,
+            )
+
+            renovate_cost = renovation_capex_per_tonne * furnace_group.capacity * furnace_group.equity_share
+            logger.info(
+                f"[FG STRATEGY] plant_id={self.plant_id} plant_group_id={plant_group.plant_group_id} "
+                f"renovate_cost=${renovate_cost:,.2f} balance=${plant_group.balance:,.2f} "
+                f"headroom=${plant_group.balance - renovate_cost:,.2f}"
+            )
+            if renovate_cost > plant_group.balance:
+                logger.info(
+                    f"[FG STRATEGY] DECISION - CLOSE FG plant_id={self.plant_id} "
+                    f"plant_group_id={plant_group.plant_group_id} gate_pass=False "
+                    f"(cannot afford renovation: ${renovate_cost:,.2f} > "
+                    f"group balance ${plant_group.balance:,.2f})"
+                )
+                return commands.CloseFurnaceGroup(
+                    plant_id=self.plant_id, furnace_group_id=furnace_group.furnace_group_id
+                )
+
+            # Debit the group treasury via the single-site capex mutation
+            plant_group.deduct_equity(renovate_cost, reason="renovation")
+            logger.info(
+                f"[FG STRATEGY] DECISION - RENOVATE {incumbent} plant_id={self.plant_id} "
+                f"plant_group_id={plant_group.plant_group_id} gate_pass=True "
+                f"(cost: ${renovate_cost:,.2f}, new group balance: ${plant_group.balance:,.2f})"
+            )
+            return commands.RenovateFurnaceGroup(
+                plant_id=self.plant_id,
+                furnace_group_id=furnace_group.furnace_group_id,
+                capex=full_capex_per_tonne,
+                capex_no_subsidy=incumbent_capex_no_subsidy,
+                cost_of_debt=incumbent_cost_of_debt,
+                cost_of_debt_no_subsidy=cost_of_debt,
+                capex_subsidies=incumbent_capex_subs,
+                debt_subsidies=incumbent_debt_subs,
+            )
+
         # ===== STAGE 5: Check if any technology option is profitable =====
         best_npv = max(tech_npv_dict.values(), default=0)
         logger.debug(f"[FG STRATEGY] Best NPV across all options: ${best_npv:,.2f}")
 
         if best_npv <= 0:
+            if furnace_group.lifetime.expired:
+                logger.debug("[FG STRATEGY] All NPVs negative or zero at end of lifetime")
+                return renovate_or_close_expired()
             logger.debug("[FG STRATEGY] DECISION - No action (all NPVs negative or zero)")
             return None
 
@@ -3974,6 +4057,8 @@ class Plant:
 
             if not valid_techs:
                 logger.warning(f"[FG STRATEGY] No valid NPV values found for plant {self.plant_id}")
+                if furnace_group.lifetime.expired:
+                    return renovate_or_close_expired()
                 return None
 
             # Weighted random selection based on NPV (negative NPVs get zero weight)
@@ -3982,6 +4067,8 @@ class Plant:
             logger.debug(f"[FG STRATEGY] Selection weights: {formatted_dict}")
 
             if sum(weights) < 0.0001:
+                if furnace_group.lifetime.expired:
+                    return renovate_or_close_expired()
                 return None
 
             best_tech = random.choices(population=list(valid_techs.keys()), weights=weights, k=1)[0]
@@ -4048,63 +4135,7 @@ class Plant:
 
             if furnace_group.lifetime.expired:
                 logger.debug("[FG STRATEGY] Furnace group lifetime expired, evaluating renovation")
-
-                # Get subsidized renovation CAPEX per tonne
-                capex_per_tonne_opt = npv_capex_dict.get(best_tech)
-                if capex_per_tonne_opt is None:
-                    raise ValueError(f"CAPEX (renovation) for technology {best_tech} not found in NPV CAPEX dict")
-                capex_per_tonne: float = capex_per_tonne_opt
-
-                # Convert back to full greenfield CAPEX (needed for command)
-                renovation_share = capex_renovation_share.get(best_tech)
-                if renovation_share is None:
-                    raise ValueError(f"CAPEX renovation share for technology {best_tech} not found")
-                full_capex_per_tonne = capex_per_tonne / renovation_share
-
-                # Calculate actual renovation cost (equity portion only)
-                renovate_cost = capex_per_tonne * furnace_group.capacity * furnace_group.equity_share
-
-                logger.debug("[FG STRATEGY] Renovation cost calculation:")
-                logger.debug(f"[FG STRATEGY]   - Subsidized CAPEX: ${capex_per_tonne:,.2f}/t")
-                logger.debug(f"[FG STRATEGY]   - Capacity: {furnace_group.capacity * T_TO_KT:,.0f} kt")
-                logger.debug(f"[FG STRATEGY]   - Equity share: {furnace_group.equity_share:.1%}")
-                logger.debug(f"[FG STRATEGY]   - Total cost: ${renovate_cost:,.2f}")
-                logger.info(
-                    f"[FG STRATEGY] plant_id={self.plant_id} plant_group_id={plant_group.plant_group_id} "
-                    f"renovate_cost=${renovate_cost:,.2f} balance=${plant_group.balance:,.2f} "
-                    f"headroom=${plant_group.balance - renovate_cost:,.2f}"
-                )
-
-                # Check affordability against group treasury
-                if renovate_cost > plant_group.balance:
-                    logger.info(
-                        f"[FG STRATEGY] DECISION - CLOSE FG plant_id={self.plant_id} "
-                        f"plant_group_id={plant_group.plant_group_id} gate_pass=False "
-                        f"(cannot afford renovation: ${renovate_cost:,.2f} > "
-                        f"group balance ${plant_group.balance:,.2f})"
-                    )
-                    return commands.CloseFurnaceGroup(
-                        plant_id=self.plant_id, furnace_group_id=furnace_group.furnace_group_id
-                    )
-
-                # Debit the group treasury via the single-site capex mutation
-                plant_group.deduct_equity(renovate_cost, reason="renovation")
-                logger.info(
-                    f"[FG STRATEGY] DECISION - RENOVATE {best_tech} plant_id={self.plant_id} "
-                    f"plant_group_id={plant_group.plant_group_id} gate_pass=True "
-                    f"(cost: ${renovate_cost:,.2f}, new group balance: ${plant_group.balance:,.2f})"
-                )
-
-                return commands.RenovateFurnaceGroup(
-                    plant_id=self.plant_id,
-                    furnace_group_id=furnace_group.furnace_group_id,
-                    capex=full_capex_per_tonne,
-                    capex_no_subsidy=original_capex_per_tonne,
-                    cost_of_debt=cost_of_debt_with_subsidies,
-                    cost_of_debt_no_subsidy=cost_of_debt,
-                    capex_subsidies=capex_subs,
-                    debt_subsidies=debt_subs,
-                )
+                return renovate_or_close_expired()
             else:
                 logger.debug(
                     f"[FG STRATEGY] DECISION - No action "
@@ -4119,7 +4150,7 @@ class Plant:
         capex_per_tonne_opt = npv_capex_dict.get(best_tech)
         if capex_per_tonne_opt is None:
             raise ValueError(f"CAPEX (greenfield) for technology {best_tech} not found in NPV CAPEX dict")
-        capex_per_tonne: float = capex_per_tonne_opt  # type: ignore [no-redef]
+        capex_per_tonne: float = capex_per_tonne_opt
 
         # Calculate switching cost (equity portion only)
         switch_cost = capex_per_tonne * furnace_group.capacity * furnace_group.equity_share
@@ -4138,10 +4169,13 @@ class Plant:
         # Check affordability against group treasury
         if switch_cost > plant_group.balance:
             logger.debug(
-                f"[FG STRATEGY] DECISION - No action plant_id={self.plant_id} "
+                f"[FG STRATEGY] Cannot afford switch plant_id={self.plant_id} "
                 f"plant_group_id={plant_group.plant_group_id} gate_pass=False "
-                f"(cannot afford switch: ${switch_cost:,.2f} > group balance ${plant_group.balance:,.2f})"
+                f"(${switch_cost:,.2f} > group balance ${plant_group.balance:,.2f})"
             )
+            if furnace_group.lifetime.expired:
+                return renovate_or_close_expired()
+            logger.debug("[FG STRATEGY] DECISION - No action (switch unaffordable)")
             return None
 
         # ===== STAGE 10: Probabilistic adoption decision =====
@@ -4203,6 +4237,8 @@ class Plant:
                         f"{expansion_and_switch_capacity * T_TO_KT:,.0f} kt + {furnace_group.capacity * T_TO_KT:,.0f} kt > "
                         f"{expansion_limit * T_TO_KT:,.0f} kt"
                     )
+                    if furnace_group.lifetime.expired:
+                        return renovate_or_close_expired()
                     return None
 
             # ===== STAGE 12: Execute technology switch =====
@@ -4269,6 +4305,9 @@ class Plant:
                 if fg_is_ccs_or_ccu
                 else f"probabilistic rejection ({random_draw:.2%} >= {accept_prob:.2%})"
             )
+            if furnace_group.lifetime.expired:
+                logger.debug(f"[FG STRATEGY] Switch not taken ({rejection_reason}), lifetime expired")
+                return renovate_or_close_expired()
             logger.debug(f"[FG STRATEGY] DECISION - No action ({rejection_reason})")
             return None
 

--- a/tests/integration/test_furnace_strategy_expired_lifetime.py
+++ b/tests/integration/test_furnace_strategy_expired_lifetime.py
@@ -1,0 +1,172 @@
+"""Tests that an expired furnace-group lifetime always resolves to renovate, switch, or close.
+
+``lifetime.expired`` is true only in the renovation-boundary year, so a no-action
+outcome would roll the furnace group into a fresh cycle without paying renovation
+capex. These tests pin the fallback behaviour of every no-action exit in
+Plant.evaluate_furnace_group_strategy for expired furnace groups.
+"""
+
+from unittest.mock import MagicMock
+
+from steelo.devdata import get_furnace_group, get_plant
+from steelo.domain import PointInTime, TimeFrame, Volumes, Year
+from steelo.domain.commands import CloseFurnaceGroup, RenovateFurnaceGroup
+from steelo.domain.models import PlantGroup
+
+REGION_CAPEX = {"EAF": 400.0, "DRI": 600.0}
+RENOVATION_SHARE = {"EAF": 0.7, "DRI": 0.7}
+ALLOWED_TECHS = {Year(year): ["EAF", "DRI"] for year in range(2020, 2031)}
+TRANSITIONS = {"EAF": ["EAF", "DRI"]}
+
+# With capacity=100 and the devdata default equity_share=0.2:
+# renovate_cost (EAF) = 400 × 100 × 0.2 = 8,000
+# switch_cost (DRI) = 600 × 100 × 0.2 = 12,000
+RENOVATE_COST = 8_000.0
+SWITCH_COST = 12_000.0
+
+
+def make_plant_and_group(*, expired: bool, balance: float):
+    """Build an EAF plant plus owning group; start year controls lifetime expiry in 2025."""
+    fg = get_furnace_group(
+        fg_id="fg_expired_test",
+        utilization_rate=0.7,
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2005) if expired else Year(2015), end=Year(2045)),
+            plant_lifetime=20,
+        ),
+        capacity=100,
+        tech_name="EAF",
+    )
+    plant = get_plant(furnace_groups=[fg], plant_id="plant_expired_test")
+    plant.location.iso3 = "USA"
+    plant.technology_unit_fopex = {"EAF": 50.0, "DRI": 70.0}
+    plant.carbon_cost_series = [0.0] * 22
+    plant_group = PlantGroup(plant_group_id="gem_expired_test", plants=[plant])
+    plant_group.balance = balance
+    return plant, plant_group
+
+
+def mock_npvs(mocker, furnace_group, tech_npv_dict):
+    """Patch optimal_technology_name to return fixed NPVs with REGION_CAPEX-priced capex."""
+    bom = {
+        "materials": {"scrap": {"unit_cost": 200.0, "demand": 1.0}},
+        "energy": {"electricity": {"unit_cost": 80.0, "demand": 0.5}},
+    }
+    mocker.patch.object(
+        furnace_group,
+        "optimal_technology_name",
+        return_value=(
+            tech_npv_dict,
+            {tech: REGION_CAPEX[tech] for tech in tech_npv_dict},
+            10_000.0,
+            {tech: bom for tech in tech_npv_dict},
+        ),
+    )
+
+
+def evaluate(plant, plant_group, *, probabilistic_agents: bool = False):
+    """Call evaluate_furnace_group_strategy with a minimal fixed argument set."""
+    furnace_group = plant.furnace_groups[0]
+    return plant.evaluate_furnace_group_strategy(
+        furnace_group_id=furnace_group.furnace_group_id,
+        plant_group=plant_group,
+        market_price_series={"steel": [600.0] * 22, "iron": [400.0] * 22},
+        region_capex=REGION_CAPEX,
+        capex_renovation_share=RENOVATION_SHARE,
+        cost_of_debt=0.04,
+        cost_of_equity=0.08,
+        get_bom_from_avg_boms=MagicMock(),
+        probabilistic_agents=probabilistic_agents,
+        dynamic_business_cases={"EAF": [], "DRI": []},
+        chosen_emissions_boundary_for_carbon_costs="scope_1",
+        technology_emission_factors=[],
+        tech_to_product={"EAF": "steel", "DRI": "iron"},
+        plant_lifetime=20,
+        construction_time=2,
+        current_year=Year(2025),
+        allowed_techs=ALLOWED_TECHS,
+        risk_free_rate=0.02,
+        allowed_furnace_transitions=TRANSITIONS,
+        capacity_limit_steel=Volumes(10_000),
+        capacity_limit_iron=Volumes(10_000),
+        installed_capacity_in_year=lambda product: Volumes(1_000),
+        new_plant_capacity_in_year=lambda product: Volumes(0),
+    )
+
+
+def test_expired_fg_with_all_negative_npvs_closes(mocker):
+    """All options value-destroying at the renovation boundary: the group closes.
+
+    Previously Stage 5 returned None, letting the group roll into a fresh
+    lifetime cycle without renovating or closing.
+    """
+    plant, plant_group = make_plant_and_group(expired=True, balance=1_000_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": -1_000.0, "DRI": -5_000.0})
+
+    command = evaluate(plant, plant_group)
+
+    assert isinstance(command, CloseFurnaceGroup)
+    assert command.furnace_group_id == "fg_expired_test"
+
+
+def test_mid_life_fg_with_all_negative_npvs_takes_no_action(mocker):
+    """Mid-life groups with all-negative NPVs keep operating on sunk capital (unchanged)."""
+    plant, plant_group = make_plant_and_group(expired=False, balance=1_000_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": -1_000.0, "DRI": -5_000.0})
+
+    command = evaluate(plant, plant_group)
+
+    assert command is None
+
+
+def test_expired_fg_renovates_when_switch_unaffordable(mocker):
+    """A blocked switch at the boundary falls back to renovating the viable incumbent."""
+    plant, plant_group = make_plant_and_group(expired=True, balance=10_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": 500.0, "DRI": 1_000_000.0})
+    mocker.patch("steelo.domain.models.random.choices", return_value=["DRI"])
+
+    command = evaluate(plant, plant_group)
+
+    assert isinstance(command, RenovateFurnaceGroup)
+    assert command.capex_no_subsidy == REGION_CAPEX["EAF"]
+    assert plant_group.balance == 10_000.0 - RENOVATE_COST
+
+
+def test_expired_fg_closes_when_neither_switch_nor_renovation_affordable(mocker):
+    """No affordable action at the boundary: the group closes without debiting the treasury."""
+    plant, plant_group = make_plant_and_group(expired=True, balance=5_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": 500.0, "DRI": 1_000_000.0})
+    mocker.patch("steelo.domain.models.random.choices", return_value=["DRI"])
+
+    command = evaluate(plant, plant_group)
+
+    assert isinstance(command, CloseFurnaceGroup)
+    assert plant_group.balance == 5_000.0
+
+
+def test_expired_fg_with_optimal_incumbent_renovates(mocker):
+    """Stage 8 regression: an optimal incumbent at the boundary renovates as before."""
+    plant, plant_group = make_plant_and_group(expired=True, balance=1_000_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": 1_000_000.0, "DRI": 500.0})
+
+    command = evaluate(plant, plant_group)
+
+    assert isinstance(command, RenovateFurnaceGroup)
+    assert command.capex == REGION_CAPEX["EAF"] / RENOVATION_SHARE["EAF"]
+    assert command.capex_no_subsidy == REGION_CAPEX["EAF"]
+    assert plant_group.balance == 1_000_000.0 - RENOVATE_COST
+
+
+def test_expired_fg_renovates_after_probabilistic_rejection(mocker):
+    """A probabilistically rejected switch at the boundary falls back to renovation."""
+    plant, plant_group = make_plant_and_group(expired=True, balance=1_000_000.0)
+    # accept_prob = exp(-switch_cost / NPV) = exp(-12) — the mocked draw of 0.5 rejects it
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": 500.0, "DRI": 1_000.0})
+    mocker.patch("steelo.domain.models.random.choices", return_value=["DRI"])
+    mocker.patch("steelo.domain.models.random.random", return_value=0.5)
+
+    command = evaluate(plant, plant_group, probabilistic_agents=True)
+
+    assert isinstance(command, RenovateFurnaceGroup)
+    assert plant_group.balance == 1_000_000.0 - RENOVATE_COST


### PR DESCRIPTION
An expired lifetime now always resolves to an action. A new `renovate_or_close_expired()` fallback is invoked from every no-action exit when `lifetime.expired`:

- Renovate the incumbent when its NPV is positive and the plant-group treasury can fund the equity portion (identical logic and logging to the former Stage-8 branch, which now delegates to the same helper).
- Otherwise close — including when the incumbent is absent from the NPV dict (phased out or CO2-gated) or its NPV is non-positive.

Mid-life behaviour is unchanged: FGs with negative NPVs keep operating on sunk capital.