### PR TITLE
Remove bogus mocker dependency blocking uv sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "pycountry",
     "scipy",
     "pydantic",
-    "mocker",
     "matplotlib",
     "sentry-sdk",
     "osmnx",


### PR DESCRIPTION
pyproject.toml declared a direct dependency on the PyPI package "mocker", unrelated to pytest-mock (already correctly listed under dependency-groups.dev) which actually provides the mocker fixture used throughout the test suite. Nothing in the codebase imports mocker directly. Its sdist fails to extract under recent uv versions (unsupported compression method), hard-blocking `uv sync` on a fresh clone.

After removing it `uv sync` ran through and a short test run also worked. https://pypi.org/project/mocker/ seems deprecated.