### PR TITLE
Bootstrap groundwork for year-wise reductant scoring

### DIFF
--- a/src/steelo/bootstrap.py
+++ b/src/steelo/bootstrap.py
@@ -342,6 +342,7 @@ def bootstrap_simulation(
         env.carbon_costs = {iso3: _normalise_cost_series(series) for iso3, series in env.carbon_costs.items()}
         env.initiate_input_costs(input_costs_list=repository_json.input_costs.list())
         env.initiate_dynamic_feedstocks(feedstocks=repository_json.primary_feedstocks.list())
+        env.validate_reductant_material_invariance()
         env.initiate_techno_economic_details(capex_list=repository_json.capex.list())
         env.initiate_capex_subsidies(subsidies=repository_json.subsidies.list())
         env.initiate_opex_subsidies(subsidies=repository_json.subsidies.list())

--- a/src/steelo/bootstrap.py
+++ b/src/steelo/bootstrap.py
@@ -376,6 +376,7 @@ def bootstrap_simulation(
         )
         env.initiate_hydrogen_efficiency(repository_json.hydrogen_efficiency.list())
         env.initiate_hydrogen_capex_opex(repository_json.hydrogen_capex_opex.list())
+        env.initiate_capped_hydrogen_costs_by_year()
         env.initiate_technology_emission_factors(repository_json.technology_emission_factors.list())
 
         # Load secondary feedstock constraints from biomass availability data

--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, TypedDict, Any
+from typing import TYPE_CHECKING, NamedTuple, TypedDict, Any
 import math
 
 from steelo.utilities.utils import normalize_name
@@ -13,7 +13,7 @@ from steelo.domain.calculate_emissions import (
 # Constants moved to domain.constants for clean architecture
 if TYPE_CHECKING:
     from steelo.domain.models import PrimaryFeedstock, Subsidy, CountryMappingService, TechnologyEmissionFactors
-from collections import Counter
+from collections import Counter, defaultdict
 from steelo.domain.constants import MWH_TO_KWH, Year
 
 # Normalized keys that represent genuine energy carriers. Any secondary-feedstock entry whose normalized
@@ -1911,6 +1911,148 @@ def calculate_secondary_output_adjustment_per_tonne(
         if output in output_costs:
             adjustment += output_costs[output] * quantity
     return adjustment
+
+
+class ReductantScores(NamedTuple):
+    """Per-(metallic charge, reductant) scoring results for one technology's business cases."""
+
+    energy_vopex_by_input: dict[str, dict[str, float]]
+    energy_breakdown_by_input: dict[str, dict[str, dict[str, float]]]
+    score_by_input: dict[str, dict[str, float]]
+    material_profile_by_input: dict[str, dict[str, tuple]]
+
+
+def build_direct_ghg_lookup(
+    technology_emission_factors: list["TechnologyEmissionFactors"],
+    chosen_emissions_boundary: str,
+) -> dict[tuple[str, str, str], float]:
+    """
+    Direct GHG factors keyed by (technology, reductant, metallic charge) for one boundary.
+
+    Args:
+        technology_emission_factors: The full EF table.
+        chosen_emissions_boundary: Boundary whose rows populate the lookup.
+
+    Returns:
+        Lookup dict using the same matching rules as calculate_emissions: technology
+        lowercased, reductant normalised, metallic charge raw.
+    """
+    return {
+        (factor.technology.lower(), normalize_name(factor.reductant), factor.metallic_charge): factor.direct_ghg_factor
+        for factor in technology_emission_factors
+        if factor.boundary == chosen_emissions_boundary
+    }
+
+
+def score_reductants_for_business_cases(
+    dynamic_business_case: list["PrimaryFeedstock"],
+    energy_costs: dict[str, float],
+    output_energy_costs: dict[str, float],
+    carbon_price: float,
+    ef_by_key: dict[tuple[str, str, str], float] | None,
+    disposal_cost_outputs: frozenset[str] | None,
+) -> ReductantScores:
+    """
+    Score every (metallic charge, reductant) of a technology's business cases.
+
+    The score is energy VOPEX per tonne plus — when ``ef_by_key`` is provided —
+    ``carbon_price`` x direct GHG factor and the secondary-output adjustment
+    (by-product revenue / disposal and carbon storage costs). With ``ef_by_key``
+    None the score equals pure energy VOPEX (legacy energy-only choice).
+
+    Args:
+        dynamic_business_case: PrimaryFeedstock rows of one technology.
+        energy_costs: Input energy prices per carrier.
+        output_energy_costs: Output-side prices for the secondary-output adjustment.
+        carbon_price: Carbon price weighting the direct GHG factor (USD/tCO2e).
+        ef_by_key: Direct GHG lookup from build_direct_ghg_lookup, or None for
+            energy-only scoring. Missing keys raise KeyError (hard lookup) so a data
+            gap cannot silently score carbon as zero.
+        disposal_cost_outputs: Output names booked as disposal costs, not revenue.
+
+    Returns:
+        ReductantScores with energy VOPEX, its per-carrier breakdown, the total
+        score, and the material profile (for drift detection) per (charge, reductant).
+    """
+    energy_vopex_by_input: dict[str, dict[str, float]] = {}
+    energy_breakdown_by_input: dict[str, dict[str, dict[str, float]]] = {}
+    extra_score_by_input: dict[str, dict[str, float]] = {}
+    material_profile_by_input: dict[str, dict[str, tuple]] = {}
+
+    for dbc in dynamic_business_case:
+        metallic_input = dbc.metallic_charge
+        raw_energy_req = dbc.energy_requirements or {}
+        raw_secondary = dbc.secondary_feedstock or {}
+
+        combined_requirements: dict[str, float] = {}
+        for energy_type, volume in raw_energy_req.items():
+            normalized_energy = normalize_name(energy_type)
+            if normalized_energy not in ENERGY_FEEDSTOCK_KEYS:
+                continue
+            combined_requirements[normalized_energy] = combined_requirements.get(normalized_energy, 0.0) + volume
+
+        non_energy_secondary: dict[str, float] = {}
+        for secondary_type, volume in raw_secondary.items():
+            normalized_secondary = normalize_name(secondary_type)
+            if normalized_secondary not in ENERGY_FEEDSTOCK_KEYS:
+                non_energy_secondary[normalized_secondary] = volume
+                continue
+            combined_requirements[normalized_secondary] = combined_requirements.get(normalized_secondary, 0.0) + volume
+
+        # Material profile per reductant, only for the data-drift warning at the caller
+        material_profile_by_input.setdefault(metallic_input, {})[dbc.reductant] = (
+            dbc.required_quantity_per_ton_of_product,
+            tuple(sorted(non_energy_secondary.items())),
+        )
+
+        if not combined_requirements:
+            continue
+
+        if metallic_input not in energy_vopex_by_input:
+            energy_vopex_by_input[metallic_input] = {}
+        if dbc.reductant not in energy_vopex_by_input[metallic_input]:
+            energy_vopex_by_input[metallic_input][dbc.reductant] = 0.0
+        energy_breakdown_by_input.setdefault(metallic_input, {}).setdefault(dbc.reductant, defaultdict(float))
+
+        for energy_type, volume in combined_requirements.items():
+            normalized_energy = normalize_name(energy_type)
+            price = energy_costs.get(normalized_energy, energy_costs.get(energy_type, 0.0))
+            cost_value = volume * price
+            energy_vopex_by_input[metallic_input][dbc.reductant] += cost_value
+            energy_breakdown_by_input[metallic_input][dbc.reductant][normalized_energy] += cost_value
+
+        if ef_by_key is not None:
+            # Hard lookup: a missing EF row would silently bias the pick towards dirty
+            # reductants if defaulted to 0, so fail loudly instead
+            direct_ghg_factor = ef_by_key[(dbc.technology.lower(), normalize_name(dbc.reductant), dbc.metallic_charge)]
+            secondary_adjustment = calculate_secondary_output_adjustment_per_tonne(
+                dbc,
+                output_energy_costs,
+                disposal_cost_outputs,
+            )
+            extra = carbon_price * direct_ghg_factor + secondary_adjustment
+            extra_score_by_input.setdefault(metallic_input, {})[dbc.reductant] = (
+                extra_score_by_input.get(metallic_input, {}).get(dbc.reductant, 0.0) + extra
+            )
+
+    if ef_by_key is not None:
+        # extra_score_by_input is populated in lockstep with energy_vopex_by_input above
+        score_by_input = {
+            metallic_input: {
+                reductant: energy_cost + extra_score_by_input[metallic_input][reductant]
+                for reductant, energy_cost in reductant_costs.items()
+            }
+            for metallic_input, reductant_costs in energy_vopex_by_input.items()
+        }
+    else:
+        score_by_input = energy_vopex_by_input
+
+    return ReductantScores(
+        energy_vopex_by_input=energy_vopex_by_input,
+        energy_breakdown_by_input=energy_breakdown_by_input,
+        score_by_input=score_by_input,
+        material_profile_by_input=material_profile_by_input,
+    )
 
 
 def calculate_cost_adjustments_from_secondary_outputs(

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -7496,10 +7496,110 @@ class Environment:
     ) -> None:
         """
         Initialize the technology emission factors for the environment.
+
         Args:
             technology_emission_factors (list[TechnologyEmissionFactors]): A list of TechnologyEmissionFactors objects to be added to the environment.
+
+        Notes:
+            When dynamic feedstocks are already loaded, coverage is validated: every
+            (technology, reductant, metallic charge) business-case key needs an EF row in
+            the configured boundary and in every boundary present in the table. The
+            reductant score does a hard EF lookup, so a gap would crash mid-run — or
+            silently price carbon as zero in the legacy lenient paths — fail at load
+            time instead.
         """
         self.technology_emission_factors = technology_emission_factors
+
+        required_keys = {
+            (dbc.technology.lower(), normalize_name(dbc.reductant), dbc.metallic_charge)
+            for feedstocks in self.dynamic_feedstocks.values()
+            for dbc in feedstocks
+        }
+        if not required_keys:
+            return
+        if not technology_emission_factors:
+            raise ValueError(
+                "No technology emission factors loaded but dynamic business cases exist — "
+                "carbon-aware reductant scoring would fail on every lookup. Check the "
+                "'Technology emission factors' sheet / technology_emission_factors.json."
+            )
+        boundaries = {factor.boundary for factor in technology_emission_factors}
+        chosen_boundary = self.config.chosen_emissions_boundary_for_carbon_costs
+        if chosen_boundary not in boundaries:
+            raise ValueError(
+                f"Configured emissions boundary '{chosen_boundary}' has no rows in the "
+                f"technology emission factors (available: {sorted(boundaries)})."
+            )
+        for boundary in sorted(boundaries):
+            ef_keys = {
+                (factor.technology.lower(), normalize_name(factor.reductant), factor.metallic_charge)
+                for factor in technology_emission_factors
+                if factor.boundary == boundary
+            }
+            missing = required_keys - ef_keys
+            if missing:
+                sample = ", ".join(str(key) for key in sorted(missing)[:5])
+                raise ValueError(
+                    f"Technology emission factors incomplete for boundary '{boundary}': "
+                    f"{len(missing)} business-case key(s) missing (e.g. {sample})."
+                )
+
+    def validate_reductant_material_invariance(self) -> None:
+        """
+        Warn when a technology's material side differs across reductants.
+
+        The reductant score (annual re-pick and investment NPVs) carries no material
+        term: materials and utilisation are assumed reductant-invariant, which holds
+        in all current masters. Two kinds of authoring drift would silently break
+        that factorisation: a metallic charge present for only a subset of a
+        technology's reductants, and required quantities / non-energy secondary
+        feedstocks that differ per reductant.
+
+        Returns:
+            None. Logs one warning per affected (technology, metallic charge).
+        """
+        logger = logging.getLogger(f"{__name__}.Environment.validate_reductant_material_invariance")
+        checked: set[str] = set()
+        for tech_name, feedstocks in self.dynamic_feedstocks.items():
+            canonical = tech_name.lower()
+            if canonical in checked:
+                continue
+            checked.add(canonical)
+            profiles: dict[str, dict[str, tuple]] = {}
+            reductants: set[str] = set()
+            for dbc in feedstocks:
+                non_energy_secondary = tuple(
+                    sorted(
+                        (normalize_name(name), volume)
+                        for name, volume in (dbc.secondary_feedstock or {}).items()
+                        if normalize_name(name) not in ENERGY_FEEDSTOCK_KEYS
+                    )
+                )
+                profiles.setdefault(dbc.metallic_charge, {})[dbc.reductant] = (
+                    dbc.required_quantity_per_ton_of_product,
+                    non_energy_secondary,
+                )
+                reductants.add(dbc.reductant)
+            for metallic_charge, by_reductant in profiles.items():
+                if set(by_reductant) != reductants:
+                    logger.warning(
+                        "[REDUCTANT DATA] %s: metallic charge '%s' is authored only for reductant(s) %s "
+                        "(missing: %s) — the reductant score assumes identical charge coverage across "
+                        "reductants. Check the master's Bill of Materials authoring.",
+                        tech_name,
+                        metallic_charge,
+                        ", ".join(sorted(by_reductant)),
+                        ", ".join(sorted(reductants - set(by_reductant))),
+                    )
+                if len(set(by_reductant.values())) > 1:
+                    logger.warning(
+                        "[REDUCTANT DATA] %s: material requirements for charge '%s' differ across "
+                        "reductants (%s) — the reductant score carries no material term, so this "
+                        "difference is ignored. Check the master's Bill of Materials authoring.",
+                        tech_name,
+                        metallic_charge,
+                        ", ".join(sorted(by_reductant)),
+                    )
 
     def initiate_fopex(self, fopex_list: list[FOPEX]) -> None:
         """

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -7403,6 +7403,8 @@ class Environment:
         self.technology_emission_factors: list[TechnologyEmissionFactors] = []
         # Initialize input costs as empty dict, keyed by geo_key (iso3 or iso3:code)
         self.input_costs: dict[str, dict[Year, dict[str, float]]] = {}
+        # Precomputed capped-LCOH series (year -> geo_key -> USD/kg), filled at bootstrap
+        self.capped_hydrogen_costs_by_year: dict[Year, dict[str, float]] = {}
         # Initialize cost curves as empty dicts
         self.cost_curve: dict[str, list[dict[str, float]]] = {"steel": [], "iron": []}
         self.future_cost_curve: dict[str, list[dict[str, float]]] = {"steel": [], "iron": []}
@@ -8158,16 +8160,20 @@ class Environment:
                         input_costs["hydrogen"] = fg.energy_costs["hydrogen"]
                     fg.set_energy_costs(**input_costs)
 
-    def calculate_capped_hydrogen_costs_per_country(self) -> dict[str, float]:
+    def calculate_capped_hydrogen_costs_per_country(self, year: Year | None = None) -> dict[str, float]:
         """
         Calculate country-level hydrogen prices with regional ceilings and trade adjustments.
 
         Steps:
-            1. Extract electricity prices for all countries in the current simulation year and calculate Levelized Cost of Hydrogen
+            1. Extract electricity prices for all countries in the given year and calculate Levelized Cost of Hydrogen
             (LCOH) for each country using electricity prices, CAPEX, and OPEX.
             2. Determine regional hydrogen price ceilings based on percentile thresholds
             3. Apply price caps considering regional ceilings, interregional trade options, and pipeline transport costs. Pipeline
             transport costs are added when importing hydrogen from trading partners.
+
+        Args:
+            year: Year to price; defaults to the current simulation year. Every input is
+                exogenous, so any covered year can be computed at any time.
 
         Returns:
             capped_hydrogen_prices (dict[str, float]): Dictionary mapping ISO3 country codes to capped hydrogen prices in USD/kg.
@@ -8197,21 +8203,22 @@ class Environment:
         if not hasattr(self.config, "geo_config"):
             raise ValueError("GeoConfig is required for hydrogen price calculation")
         geo_config = self.config.geo_config
+        target_year = self.year if year is None else year
 
         # Step 1: LCOH per geo_key (country rows + any authored sub-national rows)
         electricity_by_geo_key = {}
         for geo_key, year_costs in self.input_costs.items():
             if geo_key is None:
                 continue
-            if self.year in year_costs:
-                if "electricity" not in year_costs[self.year]:
-                    raise ValueError(f"Electricity price not found for {geo_key} in year {self.year}")
-                electricity_by_geo_key[geo_key] = year_costs[self.year]["electricity"]
+            if target_year in year_costs:
+                if "electricity" not in year_costs[target_year]:
+                    raise ValueError(f"Electricity price not found for {geo_key} in year {target_year}")
+                electricity_by_geo_key[geo_key] = year_costs[target_year]["electricity"]
         lcoh_by_geo_key = calculate_lcoh_from_electricity_country_level(
             electricity_by_country=electricity_by_geo_key,
             hydrogen_efficiency=self.hydrogen_efficiency,
             hydrogen_capex_opex=self.hydrogen_capex_opex,
-            year=self.year,
+            year=target_year,
         )
 
         # Step 2: ceilings from country-level LCOH only; a province inherits its country's ceiling
@@ -8238,6 +8245,53 @@ class Environment:
 
         logger.info(f"Calculated capped hydrogen prices for {len(capped_hydrogen_prices)} countries")
         return capped_hydrogen_prices
+
+    def initiate_capped_hydrogen_costs_by_year(self) -> None:
+        """
+        Precompute the capped-LCOH series for the full data horizon.
+
+        Every input to the capped hydrogen price is exogenous (Excel trajectories,
+        static geo config), so the whole series is knowable at bootstrap. Covers
+        config.start_year through the last year present in input_costs.
+
+        Returns:
+            None. Fills self.capped_hydrogen_costs_by_year.
+
+        Notes:
+            Requires input_costs, hydrogen_efficiency, hydrogen_capex_opex and
+            country_mappings to be initiated first; raises if input costs are empty.
+        """
+        if self.config is None:
+            raise ValueError("SimulationConfig is required to precompute hydrogen prices")
+        data_years = {y for year_costs in self.input_costs.values() for y in year_costs}
+        if not data_years:
+            raise ValueError("Input costs must be initiated before precomputing hydrogen prices")
+        self.capped_hydrogen_costs_by_year = {
+            Year(y): self.calculate_capped_hydrogen_costs_per_country(year=Year(y))
+            for y in range(int(self.config.start_year), int(max(data_years)) + 1)
+        }
+
+    def capped_hydrogen_costs_for_year(self, year: Year) -> dict[str, float]:
+        """
+        Look up the precomputed capped LCOH dict (geo_key -> USD/kg) for a year.
+
+        Args:
+            year: Any simulation or forecast year.
+
+        Returns:
+            The precomputed dict for that year; beyond the data horizon the last
+            covered year's prices apply (trajectories end in 2050, NPVs look past it).
+
+        Notes:
+            Raises if the series was not precomputed; years inside the covered range
+            but absent from it raise KeyError rather than silently degrading.
+        """
+        if not self.capped_hydrogen_costs_by_year:
+            raise ValueError("Capped hydrogen costs not precomputed; call initiate_capped_hydrogen_costs_by_year first")
+        last_year = max(self.capped_hydrogen_costs_by_year)
+        if year > last_year:
+            return self.capped_hydrogen_costs_by_year[last_year]
+        return self.capped_hydrogen_costs_by_year[year]
 
     def get_eu_countries(self) -> list[str]:
         logger = logging.getLogger(f"{__name__}.Environment.get_eu_countries")

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -13,17 +13,18 @@ from typing import TYPE_CHECKING, TypeVar, ClassVar, FrozenSet, Dict, Tuple, Uni
 from collections import defaultdict, Counter
 from steelo.domain import events, commands
 from steelo.domain.calculate_costs import (
+    build_direct_ghg_lookup,
     calculate_capex_with_subsidies,
     calculate_debt_with_subsidies,
     calculate_energy_costs_and_most_common_reductant,
     calculate_opex_list_with_subsidies,
-    calculate_secondary_output_adjustment_per_tonne,
     calculate_unit_total_opex,
     calculate_variable_opex,
     filter_subsidies_for_year,
     get_subsidised_energy_costs,
     collect_active_subsidies_over_period,
     collect_subsidies_for_geo,
+    score_reductants_for_business_cases,
     ENERGY_FEEDSTOCK_KEYS,
 )
 from steelo.utilities.utils import normalize_name
@@ -2910,84 +2911,27 @@ class FurnaceGroup:
             masters author materials identically across reductants.
         """
         logger = logging.getLogger(f"{__name__}.generate_energy_vopex_by_reductant")
-        energy_vopex_by_input: dict[str, dict[str, float]] = {}
-        energy_breakdown_by_input: dict[str, dict[str, dict[str, float]]] = {}
-        extra_score_by_input: dict[str, dict[str, float]] = {}
-        material_profile_by_input: dict[str, dict[str, tuple]] = {}
         if self.technology.dynamic_business_case is None:
             return {}
 
-        # Direct GHG factors for the chosen boundary, same matching rules as calculate_emissions
-        ef_by_key: dict[tuple[str, str, str], float] = {}
-        if technology_emission_factors is not None:
-            for factor in technology_emission_factors:
-                if factor.boundary != chosen_emissions_boundary:
-                    continue
-                ef_by_key[(factor.technology.lower(), normalize_name(factor.reductant), factor.metallic_charge)] = (
-                    factor.direct_ghg_factor
-                )
+        ef_by_key = (
+            build_direct_ghg_lookup(technology_emission_factors, chosen_emissions_boundary)
+            if technology_emission_factors is not None
+            else None
+        )
+        scores = score_reductants_for_business_cases(
+            self.technology.dynamic_business_case,
+            self.energy_costs,
+            self.output_energy_costs,
+            carbon_price,
+            ef_by_key,
+            self.disposal_cost_outputs,
+        )
+        energy_vopex_by_input = scores.energy_vopex_by_input
+        energy_breakdown_by_input = scores.energy_breakdown_by_input
+        score_by_input = scores.score_by_input
 
-        for dbc in self.technology.dynamic_business_case:
-            metallic_input = dbc.metallic_charge
-            raw_energy_req = dbc.energy_requirements or {}
-            raw_secondary = dbc.secondary_feedstock or {}
-
-            combined_requirements: dict[str, float] = {}
-            for energy_type, volume in raw_energy_req.items():
-                normalized_energy = normalize_name(energy_type)
-                if normalized_energy not in ENERGY_FEEDSTOCK_KEYS:
-                    continue
-                combined_requirements[normalized_energy] = combined_requirements.get(normalized_energy, 0.0) + volume
-
-            non_energy_secondary: dict[str, float] = {}
-            for secondary_type, volume in raw_secondary.items():
-                normalized_secondary = normalize_name(secondary_type)
-                if normalized_secondary not in ENERGY_FEEDSTOCK_KEYS:
-                    non_energy_secondary[normalized_secondary] = volume
-                    continue
-                combined_requirements[normalized_secondary] = (
-                    combined_requirements.get(normalized_secondary, 0.0) + volume
-                )
-
-            # Material profile per reductant, only for the data-drift warning below
-            material_profile_by_input.setdefault(metallic_input, {})[dbc.reductant] = (
-                dbc.required_quantity_per_ton_of_product,
-                tuple(sorted(non_energy_secondary.items())),
-            )
-
-            if not combined_requirements:
-                continue
-
-            if metallic_input not in energy_vopex_by_input:
-                energy_vopex_by_input[metallic_input] = {}
-            if dbc.reductant not in energy_vopex_by_input[metallic_input]:
-                energy_vopex_by_input[metallic_input][dbc.reductant] = 0.0
-            energy_breakdown_by_input.setdefault(metallic_input, {}).setdefault(dbc.reductant, defaultdict(float))
-
-            for energy_type, volume in combined_requirements.items():
-                normalized_energy = normalize_name(energy_type)
-                price = self.energy_costs.get(normalized_energy, self.energy_costs.get(energy_type, 0.0))
-                cost_value = volume * price
-                energy_vopex_by_input[metallic_input][dbc.reductant] += cost_value
-                energy_breakdown_by_input[metallic_input][dbc.reductant][normalized_energy] += cost_value
-
-            if technology_emission_factors is not None:
-                # Hard lookup: a missing EF row would silently bias the pick towards dirty
-                # reductants if defaulted to 0, so fail loudly instead
-                direct_ghg_factor = ef_by_key[
-                    (dbc.technology.lower(), normalize_name(dbc.reductant), dbc.metallic_charge)
-                ]
-                secondary_adjustment = calculate_secondary_output_adjustment_per_tonne(
-                    dbc,
-                    self.output_energy_costs,
-                    self.disposal_cost_outputs,
-                )
-                extra = carbon_price * direct_ghg_factor + secondary_adjustment
-                extra_score_by_input.setdefault(metallic_input, {})[dbc.reductant] = (
-                    extra_score_by_input.get(metallic_input, {}).get(dbc.reductant, 0.0) + extra
-                )
-
-        for metallic_input, profiles in material_profile_by_input.items():
+        for metallic_input, profiles in scores.material_profile_by_input.items():
             if len(set(profiles.values())) > 1:
                 logger.warning(
                     "[REDUCTANT SCORE] FG %s: material requirements for charge '%s' differ across "
@@ -2997,18 +2941,6 @@ class FurnaceGroup:
                     metallic_input,
                     ", ".join(sorted(profiles)),
                 )
-
-        if technology_emission_factors is not None:
-            # extra_score_by_input is populated in lockstep with energy_vopex_by_input above
-            score_by_input = {
-                metallic_input: {
-                    reductant: energy_cost + extra_score_by_input[metallic_input][reductant]
-                    for reductant, energy_cost in reductant_costs.items()
-                }
-                for metallic_input, reductant_costs in energy_vopex_by_input.items()
-            }
-        else:
-            score_by_input = energy_vopex_by_input
 
         mins = [min(costs, key=lambda k: costs[k]) for costs in score_by_input.values() if costs]
         counts = Counter(mins)

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -1168,9 +1168,9 @@ class SimulationRunner:
             bus.env.pass_fopex_for_iso3_to_plants(bus.uow.plants.list())
             # bus.env.set_capex_and_debt_in_furnace_groups(bus.uow.plants.list())  # no need for this because we are not using learning rate - capex and debt (with subsidy) set when fgs are renovated, changed or created
             bus.env.update_furnace_capex_renovation_share(bus.uow.plants.list())
-            capped_hydrogen_cost_dict = (
-                bus.env.calculate_capped_hydrogen_costs_per_country()
-            )  # Calculate for all countries once per year (iso3 -> cost)
+            capped_hydrogen_cost_dict = bus.env.capped_hydrogen_costs_for_year(
+                bus.env.year
+            )  # Precomputed at bootstrap (iso3 -> cost); the series is fully exogenous
             logging.info(f"\n Steel demand in year {bus.env.year}: \t {bus.env.current_demand * T_TO_KT:,.0f} kt \n")
 
             # Initialise OPEX subsidies for Year 1 (subsequent years handled by finalise_iteration)

--- a/tests/unit/test_capped_hydrogen_precompute.py
+++ b/tests/unit/test_capped_hydrogen_precompute.py
@@ -1,0 +1,96 @@
+"""Tests for the bootstrap precompute of the capped-LCOH series."""
+
+from pathlib import Path
+
+import pytest
+
+from steelo.domain.models import CountryMapping, Environment, Year
+from steelo.simulation import SimulationConfig
+
+
+def _make_mapping(country: str, iso2: str, iso3: str, region: str) -> CountryMapping:
+    return CountryMapping(
+        country=country,
+        iso2=iso2,
+        iso3=iso3,
+        irena_name=country,
+        region_for_outputs=region,
+        ssp_region=region,
+        tiam_ucl_region=region,
+    )
+
+
+def _make_env(tmp_path: Path) -> Environment:
+    config = SimulationConfig(
+        start_year=Year(2025),
+        end_year=Year(2027),
+        master_excel_path=Path("test.xlsx"),
+        output_dir=tmp_path,
+    )
+    tech_switches_csv = tmp_path / "tech_switches_allowed.csv"
+    tech_switches_csv.write_text("origin,BF\nBF,YES\n", encoding="utf-8")
+    env = Environment(config=config, tech_switches_csv=tech_switches_csv)
+    env.year = Year(2025)
+    years = [Year(2025), Year(2026), Year(2027)]
+    env.input_costs = {
+        "AAA": {y: {"electricity": 0.05 + 0.01 * i} for i, y in enumerate(years)},
+        "BBB": {y: {"electricity": 0.09 - 0.01 * i} for i, y in enumerate(years)},
+    }
+    env.hydrogen_efficiency = {y: 0.05 for y in years}
+    env.hydrogen_capex_opex = {
+        "AAA": {y: 1.0 for y in years},
+        "BBB": {y: 1.5 for y in years},
+    }
+    env.initiate_country_mappings(
+        country_mappings=[
+            _make_mapping("Aland", "AA", "AAA", "TestRegion"),
+            _make_mapping("Bland", "BB", "BBB", "TestRegion"),
+        ]
+    )
+    return env
+
+
+def test_precomputed_series_matches_per_year_computation(tmp_path: Path) -> None:
+    """Each precomputed year equals a direct per-year computation, including the env.year path."""
+    env = _make_env(tmp_path)
+    env.initiate_capped_hydrogen_costs_by_year()
+
+    assert sorted(env.capped_hydrogen_costs_by_year) == [Year(2025), Year(2026), Year(2027)]
+    for year in env.capped_hydrogen_costs_by_year:
+        assert env.capped_hydrogen_costs_by_year[year] == env.calculate_capped_hydrogen_costs_per_country(year=year)
+        env.year = year
+        assert env.capped_hydrogen_costs_for_year(year) == env.calculate_capped_hydrogen_costs_per_country()
+
+
+def test_prices_vary_across_years(tmp_path: Path) -> None:
+    """The series reflects the year-indexed electricity trajectory, not a frozen snapshot."""
+    env = _make_env(tmp_path)
+    env.initiate_capped_hydrogen_costs_by_year()
+
+    aaa_prices = [env.capped_hydrogen_costs_for_year(Year(y))["AAA"] for y in (2025, 2026, 2027)]
+    assert aaa_prices[0] < aaa_prices[1] < aaa_prices[2]
+
+
+def test_lookup_beyond_horizon_clamps_to_last_year(tmp_path: Path) -> None:
+    """Years past the data end reuse the last covered year's prices."""
+    env = _make_env(tmp_path)
+    env.initiate_capped_hydrogen_costs_by_year()
+
+    assert env.capped_hydrogen_costs_for_year(Year(2040)) == env.capped_hydrogen_costs_for_year(Year(2027))
+
+
+def test_lookup_before_precompute_raises(tmp_path: Path) -> None:
+    """The accessor fails loudly when the series was never precomputed."""
+    env = _make_env(tmp_path)
+
+    with pytest.raises(ValueError, match="not precomputed"):
+        env.capped_hydrogen_costs_for_year(Year(2025))
+
+
+def test_lookup_before_covered_range_raises(tmp_path: Path) -> None:
+    """Years before the covered range raise rather than silently degrading."""
+    env = _make_env(tmp_path)
+    env.initiate_capped_hydrogen_costs_by_year()
+
+    with pytest.raises(KeyError):
+        env.capped_hydrogen_costs_for_year(Year(2020))

--- a/tests/unit/test_reductant_data_validation.py
+++ b/tests/unit/test_reductant_data_validation.py
@@ -1,0 +1,137 @@
+"""Tests for bootstrap-time validation of EF coverage and material invariance."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from steelo.domain.models import Environment, PrimaryFeedstock, TechnologyEmissionFactors, Year
+from steelo.simulation import SimulationConfig
+
+
+def _make_env(tmp_path: Path) -> Environment:
+    config = SimulationConfig(
+        start_year=Year(2025),
+        end_year=Year(2027),
+        master_excel_path=Path("test.xlsx"),
+        output_dir=tmp_path,
+    )
+    tech_switches_csv = tmp_path / "tech_switches_allowed.csv"
+    tech_switches_csv.write_text("origin,BF\nBF,YES\n", encoding="utf-8")
+    return Environment(config=config, tech_switches_csv=tech_switches_csv)
+
+
+def _feedstock(technology: str, metallic_charge: str, reductant: str, quantity: float = 1.5) -> PrimaryFeedstock:
+    pf = PrimaryFeedstock(metallic_charge=metallic_charge, reductant=reductant, technology=technology)
+    pf.required_quantity_per_ton_of_product = quantity
+    return pf
+
+
+def _ef(
+    technology: str, metallic_charge: str, reductant: str, boundary: str = "rs-inspired"
+) -> TechnologyEmissionFactors:
+    return TechnologyEmissionFactors(
+        business_case=f"{metallic_charge}_{reductant}_{technology}",
+        technology=technology,
+        boundary=boundary,
+        metallic_charge=metallic_charge,
+        reductant=reductant,
+        direct_ghg_factor=1.0,
+        direct_with_biomass_ghg_factor=1.0,
+        indirect_ghg_factor=0.5,
+    )
+
+
+def test_ef_initiation_accepts_full_coverage(tmp_path: Path) -> None:
+    """A complete EF table for the configured boundary initialises without error."""
+    env = _make_env(tmp_path)
+    env.initiate_dynamic_feedstocks([_feedstock("BF", "IO_low", "Coke+PCI")])
+
+    env.initiate_technology_emission_factors([_ef("BF", "IO_low", "Coke+PCI")])
+
+    assert len(env.technology_emission_factors) == 1
+
+
+def test_ef_initiation_raises_on_missing_business_case_key(tmp_path: Path) -> None:
+    """A business-case key without an EF row fails at load time, not mid-run."""
+    env = _make_env(tmp_path)
+    env.initiate_dynamic_feedstocks([_feedstock("BF", "IO_low", "Coke+PCI"), _feedstock("BF", "IO_low", "Bio-PCI")])
+
+    with pytest.raises(ValueError, match="incomplete for boundary"):
+        env.initiate_technology_emission_factors([_ef("BF", "IO_low", "Coke+PCI")])
+
+
+def test_ef_initiation_raises_on_empty_table_with_feedstocks(tmp_path: Path) -> None:
+    """An empty EF table with business cases present is a load-time error."""
+    env = _make_env(tmp_path)
+    env.initiate_dynamic_feedstocks([_feedstock("BF", "IO_low", "Coke+PCI")])
+
+    with pytest.raises(ValueError, match="No technology emission factors"):
+        env.initiate_technology_emission_factors([])
+
+
+def test_ef_initiation_raises_when_configured_boundary_absent(tmp_path: Path) -> None:
+    """EF rows that never cover the configured boundary fail loudly."""
+    env = _make_env(tmp_path)
+    env.initiate_dynamic_feedstocks([_feedstock("BF", "IO_low", "Coke+PCI")])
+
+    with pytest.raises(ValueError, match="rs-inspired"):
+        env.initiate_technology_emission_factors([_ef("BF", "IO_low", "Coke+PCI", boundary="worldsteel_opt_credits")])
+
+
+def test_ef_initiation_skips_validation_without_feedstocks(tmp_path: Path) -> None:
+    """Test environments without business cases can still set an empty EF list."""
+    env = _make_env(tmp_path)
+
+    env.initiate_technology_emission_factors([])
+
+    assert env.technology_emission_factors == []
+
+
+def test_invariance_warns_on_charge_missing_for_a_reductant(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A metallic charge authored for only one of a tech's reductants is flagged."""
+    env = _make_env(tmp_path)
+    env.initiate_dynamic_feedstocks(
+        [
+            _feedstock("DRI", "IO_low", "natural_gas"),
+            _feedstock("DRI", "IO_low", "hydrogen"),
+            _feedstock("DRI", "IO_high", "natural_gas"),
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        env.validate_reductant_material_invariance()
+
+    assert any("authored only for reductant" in message for message in caplog.messages)
+
+
+def test_invariance_warns_on_differing_quantities(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Required quantities differing across reductants are flagged."""
+    env = _make_env(tmp_path)
+    env.initiate_dynamic_feedstocks(
+        [
+            _feedstock("DRI", "IO_low", "natural_gas", quantity=1.5),
+            _feedstock("DRI", "IO_low", "hydrogen", quantity=1.6),
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        env.validate_reductant_material_invariance()
+
+    assert any("material requirements" in message for message in caplog.messages)
+
+
+def test_invariance_silent_on_identical_authoring(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Identical material authoring across reductants produces no warnings."""
+    env = _make_env(tmp_path)
+    env.initiate_dynamic_feedstocks(
+        [
+            _feedstock("DRI", "IO_low", "natural_gas"),
+            _feedstock("DRI", "IO_low", "hydrogen"),
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        env.validate_reductant_material_invariance()
+
+    assert not [message for message in caplog.messages if "[REDUCTANT DATA]" in message]

--- a/tests/unit/test_simulation_runner_factory.py
+++ b/tests/unit/test_simulation_runner_factory.py
@@ -34,14 +34,26 @@ def test_factory_configures_environment_from_config(tmp_path):
     (fixtures_dir / "subsidies.json").write_text('{"root": []}')
     (fixtures_dir / "carbon_costs.json").write_text('{"root": []}')
     (fixtures_dir / "primary_feedstocks.json").write_text('{"root": []}')
-    (fixtures_dir / "input_costs.json").write_text('{"root": []}')
+    (fixtures_dir / "input_costs.json").write_text(
+        '{"root": ['
+        '{"iso3": "DEU", "year": 2025, "costs": {"electricity": 0.05}},'
+        '{"iso3": "DEU", "year": 2026, "costs": {"electricity": 0.05}}'
+        "]}"
+    )
     (fixtures_dir / "region_emissivity.json").write_text('{"root": []}')
     (fixtures_dir / "capex.json").write_text('{"root": []}')
     (fixtures_dir / "cost_of_capital.json").write_text('{"root": []}')
     (fixtures_dir / "legal_process_connectors.json").write_text("[]")
-    (fixtures_dir / "country_mappings.json").write_text("[]")
-    (fixtures_dir / "hydrogen_efficiency.json").write_text("[]")
-    (fixtures_dir / "hydrogen_capex_opex.json").write_text("[]")
+    (fixtures_dir / "country_mappings.json").write_text(
+        '[{"country": "Germany", "iso2": "DE", "iso3": "DEU", "irena_name": "Germany",'
+        ' "region_for_outputs": "Europe", "ssp_region": "EUR", "tiam-ucl_region": "Rest of World"}]'
+    )
+    (fixtures_dir / "hydrogen_efficiency.json").write_text(
+        '[{"year": 2025, "efficiency": 0.05}, {"year": 2026, "efficiency": 0.05}]'
+    )
+    (fixtures_dir / "hydrogen_capex_opex.json").write_text(
+        '[{"country_code": "DEU", "values": {"2025": 1.0, "2026": 1.0}}]'
+    )
     (fixtures_dir / "transport_emissions.json").write_text("[]")
     (fixtures_dir / "biomass_availability.json").write_text("[]")
     (data_dir / "railway_costs.json").write_text('{"root": []}')


### PR DESCRIPTION
Groundwork for pricing reductants year by year in investment NPVs. No decision path changes here.

- Capped LCOH is precomputed for the whole data horizon at bootstrap, so the year loop reads `year -> geo_key -> USD/kg` instead of recomputing per candidate-year. The accessor clamps beyond the horizon and fails loudly otherwise.
- Emission-factor coverage is validated at load time: missing rows, an empty table or an absent configured boundary now raise at bootstrap rather than blowing up mid-run on the score's hard lookup. A companion check warns when a metallic charge is authored for only some reductants, or with different material profiles across them.
- The per-(charge, reductant) scorer moves to module level in `calculate_costs.py` so the investment NPV can reuse the exact scoring the annual re-pick uses. `generate_energy_vopex_by_reductant` delegates to it; behaviour unchanged.
