### PR TITLE
Add the year-wise reductant-optimised score series

### DIFF
--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -1922,6 +1922,18 @@ class ReductantScores(NamedTuple):
     material_profile_by_input: dict[str, dict[str, tuple]]
 
 
+class ReductantScoreSeries(NamedTuple):
+    """Year-wise reductant-optimised score series for one candidate technology.
+
+    One entry per operating year: the output-share-weighted score of the year's
+    picked reductant, and the pick itself. picks[0] is the operating-start-year
+    reductant an investment would commit.
+    """
+
+    scores: list[float]
+    picks: list[str]
+
+
 def build_direct_ghg_lookup(
     technology_emission_factors: list["TechnologyEmissionFactors"],
     chosen_emissions_boundary: str,

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -26,6 +26,7 @@ from steelo.domain.calculate_costs import (
     collect_subsidies_for_geo,
     score_reductants_for_business_cases,
     ENERGY_FEEDSTOCK_KEYS,
+    ReductantScoreSeries,
 )
 from steelo.utilities.utils import normalize_name
 from steelo.domain.calculate_emissions import (
@@ -8324,6 +8325,181 @@ class Environment:
         if year > last_year:
             return self.capped_hydrogen_costs_by_year[last_year]
         return self.capped_hydrogen_costs_by_year[year]
+
+    def carbon_price_for_year(self, iso3: str, year: Year) -> float:
+        """
+        Country carbon price for a year, clamped to the last covered year.
+
+        Args:
+            iso3: Country code.
+            year: Any simulation or forecast year.
+
+        Returns:
+            The exogenous carbon price; 0.0 for countries without a carbon-price
+            series (no policy). Years beyond the series reuse its last value; years
+            missing inside the covered range raise KeyError rather than pricing
+            carbon as zero.
+        """
+        series = self.carbon_costs.get(iso3)
+        if not series:
+            return 0.0
+        last_year = max(series)
+        return series[min(year, last_year)]
+
+    def candidate_energy_costs_for_year(
+        self,
+        location: "Location",
+        technology_name: str,
+        year: Year,
+        overrides: dict[str, float] | None = None,
+        override_reference_year: Year | None = None,
+    ) -> tuple[dict[str, float], dict[str, float]]:
+        """
+        Candidate energy prices (input and output side) at a location for any year.
+
+        Mirrors the year-start price refresh generalised to a future year: the
+        exogenous input-cost trajectory at ``year`` (clamped to its last data year,
+        sign handling as in set_energy_costs), hydrogen from the precomputed
+        capped-LCOH series, and energy-carrier subsidies scoped to the candidate
+        technology filtered for ``year`` (the A2 treatment, per year).
+
+        Args:
+            location: Plant/site location (geo_key resolution, finest available).
+            technology_name: Candidate technology whose energy subsidies apply.
+            year: The year to price.
+            overrides: Site-specific current prices per carrier (e.g. a GEO site's
+                own power price). Each override replaces the country level but keeps
+                the country trajectory: price_t = override x country_t / country_ref.
+            override_reference_year: Year the override prices belong to; required
+                when overrides are given.
+
+        Returns:
+            (input_costs, output_costs) per normalised carrier for that year.
+
+        Notes:
+            Years missing inside the input-cost trajectory raise (no silent gaps).
+        """
+        year_costs = location.resolve(self.input_costs, what="input costs")
+        if year_costs is None:
+            raise ValueError(f"No input costs found for {location.geo_key}")
+        clamped_year = min(year, max(year_costs))
+        base: dict[str, float] = {}
+        for raw_key, price in year_costs[clamped_year].items():
+            normalized_key = normalize_name(raw_key)
+            base[normalized_key] = price if normalized_key.startswith("co2") else abs(price)
+        capped_lcoh = location.resolve(self.capped_hydrogen_costs_for_year(year), what="hydrogen price")
+        if capped_lcoh is None:
+            raise ValueError(f"No hydrogen price for {location.geo_key}")
+        base["hydrogen"] = capped_lcoh * T_TO_KG
+
+        if overrides:
+            if override_reference_year is None:
+                raise ValueError("override_reference_year is required when overrides are given")
+            reference, _ = self.candidate_energy_costs_for_year(location, technology_name, override_reference_year)
+            for carrier, site_price in overrides.items():
+                normalized_carrier = normalize_name(carrier)
+                reference_price = reference[normalized_carrier]
+                if reference_price == 0.0:
+                    raise ValueError(
+                        f"Cannot trajectory-scale '{normalized_carrier}' for {location.geo_key}: "
+                        f"reference price in {override_reference_year} is zero"
+                    )
+                base[normalized_carrier] = site_price * base[normalized_carrier] / reference_price
+
+        active_subsidies: dict[str, list[Subsidy]] = {}
+        for carrier, subsidies_by_geo in self.energy_subsidies.items():
+            subsidies = collect_subsidies_for_geo(subsidies_by_geo, location.geo_key).get(technology_name, [])
+            active = filter_subsidies_for_year(subsidies, year)
+            if active:
+                active_subsidies[carrier] = active
+        if not active_subsidies:
+            return base, base.copy()
+        input_costs, output_costs, _ = get_subsidised_energy_costs(base, active_subsidies)
+        return input_costs, output_costs
+
+    def reductant_score_series(
+        self,
+        location: "Location",
+        technology_name: str,
+        output_shares: dict[str, float],
+        start_year: Year,
+        end_year: Year,
+        overrides: dict[str, float] | None = None,
+        override_reference_year: Year | None = None,
+    ) -> "ReductantScoreSeries":
+        """
+        Year-wise reductant-optimised score series for a candidate technology.
+
+        For each year in [start_year, end_year) the per-(charge, reductant) score
+        (energy VOPEX + carbon x direct GHG + secondary-output adjustment) is
+        evaluated at that year's exogenous prices; the reductant is picked with the
+        same rule the annual re-pick uses (per-charge argmin, mode across charges),
+        and the year's value is the output-share-weighted score of that pick. The
+        NPV built on this series therefore forecasts exactly what the committed
+        asset will do under the annual re-pick.
+
+        Args:
+            location: Plant/site location.
+            technology_name: Candidate technology.
+            output_shares: Metallic charge -> share of product (from the candidate
+                BOM build; reductant-invariant).
+            start_year: First operating year (inclusive).
+            end_year: Last operating year (exclusive).
+            overrides / override_reference_year: Site-price overrides, see
+                candidate_energy_costs_for_year.
+
+        Returns:
+            ReductantScoreSeries with one score and one pick per operating year.
+
+        Notes:
+            Missing EF rows raise (hard lookup); bootstrap validation guarantees
+            coverage for real data.
+        """
+        dynamic_business_case = self.dynamic_feedstocks.get(technology_name) or self.dynamic_feedstocks.get(
+            technology_name.lower()
+        )
+        if not dynamic_business_case:
+            raise ValueError(f"No dynamic business case for technology '{technology_name}'")
+        if self.config is None:
+            raise ValueError("SimulationConfig is required for reductant score series")
+        ef_by_key = build_direct_ghg_lookup(
+            self.technology_emission_factors,
+            self.config.chosen_emissions_boundary_for_carbon_costs,
+        )
+        scores: list[float] = []
+        picks: list[str] = []
+        for year in range(int(start_year), int(end_year)):
+            input_costs, output_costs = self.candidate_energy_costs_for_year(
+                location,
+                technology_name,
+                Year(year),
+                overrides=overrides,
+                override_reference_year=override_reference_year,
+            )
+            carbon_price = self.carbon_price_for_year(location.iso3, Year(year))
+            year_scores = score_reductants_for_business_cases(
+                dynamic_business_case,
+                input_costs,
+                output_costs,
+                carbon_price,
+                ef_by_key,
+                self.config.disposal_cost_outputs,
+            )
+            mins = [min(costs, key=lambda k: costs[k]) for costs in year_scores.score_by_input.values() if costs]
+            counts = Counter(mins)
+            if not counts:
+                scores.append(0.0)
+                picks.append("")
+                continue
+            pick, _ = counts.most_common(1)[0]
+            value = sum(
+                share * year_scores.score_by_input[charge][pick]
+                for charge, share in output_shares.items()
+                if pick in year_scores.score_by_input.get(charge, {})
+            )
+            scores.append(value)
+            picks.append(str(pick))
+        return ReductantScoreSeries(scores=scores, picks=picks)
 
     def get_eu_countries(self) -> list[str]:
         logger = logging.getLogger(f"{__name__}.Environment.get_eu_countries")

--- a/tests/unit/test_reductant_score_series.py
+++ b/tests/unit/test_reductant_score_series.py
@@ -1,0 +1,219 @@
+"""Tests for the year-wise reductant-optimised score series (B3 core)."""
+
+from pathlib import Path
+
+import pytest
+
+from steelo.domain.calculate_costs import build_direct_ghg_lookup, score_reductants_for_business_cases
+from steelo.domain.models import (
+    CountryMapping,
+    Environment,
+    Location,
+    PrimaryFeedstock,
+    Subsidy,
+    TechnologyEmissionFactors,
+    Year,
+)
+from steelo.simulation import SimulationConfig
+
+YEARS = [Year(y) for y in range(2025, 2031)]
+LOCATION = Location(lat=0.0, lon=0.0, country="Aland", region="TestRegion", iso3="AAA")
+
+
+def _feedstock(reductant: str, energy: dict[str, float]) -> PrimaryFeedstock:
+    pf = PrimaryFeedstock(metallic_charge="IO_low", reductant=reductant, technology="DRI")
+    pf.required_quantity_per_ton_of_product = 1.5
+    for carrier, volume in energy.items():
+        pf.add_energy_requirement(carrier, volume)
+    return pf
+
+
+def _ef(reductant: str, factor: float) -> TechnologyEmissionFactors:
+    return TechnologyEmissionFactors(
+        business_case=f"IO_low_{reductant}_DRI",
+        technology="DRI",
+        boundary="rs-inspired",
+        metallic_charge="IO_low",
+        reductant=reductant,
+        direct_ghg_factor=factor,
+        direct_with_biomass_ghg_factor=factor,
+        indirect_ghg_factor=0.0,
+    )
+
+
+def _make_env(tmp_path: Path, carbon_by_year: dict[int, float] | None = None) -> Environment:
+    config = SimulationConfig(
+        start_year=Year(2025),
+        end_year=Year(2030),
+        master_excel_path=Path("test.xlsx"),
+        output_dir=tmp_path,
+    )
+    tech_switches_csv = tmp_path / "tech_switches_allowed.csv"
+    tech_switches_csv.write_text("origin,DRI\nDRI,YES\n", encoding="utf-8")
+    env = Environment(config=config, tech_switches_csv=tech_switches_csv)
+    env.year = Year(2025)
+    # Electricity falls steeply (drives LCOH down); natural gas rises slowly.
+    env.input_costs = {
+        "AAA": {
+            year: {"electricity": 0.10 - 0.015 * i, "natural_gas": 0.03 + 0.002 * i} for i, year in enumerate(YEARS)
+        }
+    }
+    env.hydrogen_efficiency = {year: 0.05 for year in YEARS}
+    env.hydrogen_capex_opex = {"AAA": {year: 1.0 for year in YEARS}}
+    env.initiate_country_mappings(
+        country_mappings=[
+            CountryMapping(
+                country="Aland",
+                iso2="AA",
+                iso3="AAA",
+                irena_name="Aland",
+                region_for_outputs="TestRegion",
+                ssp_region="TestRegion",
+                tiam_ucl_region="TestRegion",
+            )
+        ]
+    )
+    env.initiate_capped_hydrogen_costs_by_year()
+    # DRI with a cheap-now fossil reductant and a clean one that wins once LCOH falls.
+    env.initiate_dynamic_feedstocks(
+        [
+            _feedstock("natural_gas", {"natural_gas": 10.0}),
+            _feedstock("hydrogen", {"hydrogen": 0.055}),
+        ]
+    )
+    env.initiate_technology_emission_factors([_ef("natural_gas", 1.4), _ef("hydrogen", 0.1)])
+    if carbon_by_year is not None:
+        env.carbon_costs = {"AAA": {Year(y): price for y, price in carbon_by_year.items()}}
+    return env
+
+
+SHARES = {"IO_low": 1.0}
+
+
+def _fixed_reductant_scores(env: Environment, reductant: str, years: list[Year]) -> list[float]:
+    """Brute-force per-year score for one fixed reductant, via the shared scorer."""
+    ef_by_key = build_direct_ghg_lookup(env.technology_emission_factors, "rs-inspired")
+    values = []
+    for year in years:
+        input_costs, output_costs = env.candidate_energy_costs_for_year(LOCATION, "DRI", year)
+        scores = score_reductants_for_business_cases(
+            env.dynamic_feedstocks["dri"],
+            input_costs,
+            output_costs,
+            env.carbon_price_for_year("AAA", year),
+            ef_by_key,
+            env.config.disposal_cost_outputs,
+        )
+        values.append(scores.score_by_input["IO_low"][reductant])
+    return values
+
+
+def test_series_equals_pointwise_min_of_fixed_reductant_scores(tmp_path: Path) -> None:
+    """The year-wise series is the pointwise minimum over fixed-reductant score series."""
+    env = _make_env(tmp_path, carbon_by_year={y: 100.0 for y in range(2025, 2031)})
+    series = env.reductant_score_series(LOCATION, "DRI", SHARES, Year(2025), Year(2031))
+
+    gas = _fixed_reductant_scores(env, "natural_gas", YEARS)
+    hydrogen = _fixed_reductant_scores(env, "hydrogen", YEARS)
+    assert series.scores == pytest.approx([min(g, h) for g, h in zip(gas, hydrogen)])
+
+
+def test_series_picks_flip_at_the_crossover(tmp_path: Path) -> None:
+    """Falling LCOH flips the pick from natural gas to hydrogen mid-horizon."""
+    env = _make_env(tmp_path, carbon_by_year={y: 100.0 for y in range(2025, 2031)})
+    series = env.reductant_score_series(LOCATION, "DRI", SHARES, Year(2025), Year(2031))
+
+    assert series.picks[0] == "natural_gas"
+    assert series.picks[-1] == "hydrogen"
+    flip = series.picks.index("hydrogen")
+    assert all(pick == "hydrogen" for pick in series.picks[flip:])
+
+
+def test_series_pick_matches_annual_repick_rule(tmp_path: Path) -> None:
+    """For any year, the series pick equals what the B5 annual re-pick would choose."""
+    from steelo.domain.models import FurnaceGroup, PointInTime, Technology, TimeFrame
+
+    env = _make_env(tmp_path, carbon_by_year={y: 100.0 for y in range(2025, 2031)})
+    series = env.reductant_score_series(LOCATION, "DRI", SHARES, Year(2025), Year(2031))
+
+    for i, year in enumerate(YEARS):
+        input_costs, output_costs = env.candidate_energy_costs_for_year(LOCATION, "DRI", year)
+        fg = FurnaceGroup(
+            furnace_group_id="fg_test",
+            capacity=1000.0,
+            status="operating",
+            last_renovation_date=None,
+            technology=Technology(name="DRI", product="dri", dynamic_business_case=env.dynamic_feedstocks["dri"]),
+            historical_production={},
+            utilization_rate=0.8,
+            lifetime=PointInTime(
+                current=Year(2025),
+                time_frame=TimeFrame(start=Year(2025), end=Year(2045)),
+                plant_lifetime=20,
+            ),
+            chosen_reductant="",
+        )
+        fg.energy_costs = input_costs
+        fg.output_energy_costs = output_costs
+        fg.disposal_cost_outputs = env.config.disposal_cost_outputs
+        fg.generate_energy_vopex_by_reductant(
+            carbon_price=env.carbon_price_for_year("AAA", year),
+            technology_emission_factors=env.technology_emission_factors,
+            chosen_emissions_boundary="rs-inspired",
+        )
+        assert fg.chosen_reductant == series.picks[i], f"year {year}"
+
+
+def test_candidate_subsidy_expiry_moves_the_pick(tmp_path: Path) -> None:
+    """A hydrogen subsidy scoped to the candidate flips the pick only while active."""
+    env = _make_env(tmp_path, carbon_by_year={y: 100.0 for y in range(2025, 2031)})
+    baseline = env.reductant_score_series(LOCATION, "DRI", SHARES, Year(2025), Year(2031))
+    first_hydrogen_year = baseline.picks.index("hydrogen")
+    assert first_hydrogen_year > 1  # gas wins early without support
+
+    env.initiate_energy_subsidies(
+        [
+            Subsidy(
+                scenario_name="test",
+                iso3="AAA",
+                start_year=Year(2025),
+                end_year=Year(2025),
+                technology_name="DRI",
+                cost_item="hydrogen",
+                subsidy_type="relative",
+                subsidy_amount=0.9,
+            )
+        ]
+    )
+    subsidised = env.reductant_score_series(LOCATION, "DRI", SHARES, Year(2025), Year(2031))
+
+    assert subsidised.picks[0] == "hydrogen"  # subsidy active
+    assert subsidised.picks[1] == "natural_gas"  # expired, back to gas
+    assert subsidised.picks[first_hydrogen_year:] == baseline.picks[first_hydrogen_year:]
+
+
+def test_scores_clamp_beyond_the_data_horizon(tmp_path: Path) -> None:
+    """Years past the input-cost horizon reuse the last data year's prices."""
+    env = _make_env(tmp_path, carbon_by_year={y: 100.0 for y in range(2025, 2051)})
+    series = env.reductant_score_series(LOCATION, "DRI", SHARES, Year(2029), Year(2036))
+
+    assert series.scores[1] == pytest.approx(series.scores[-1])  # 2030 == 2035
+    assert series.picks[1] == series.picks[-1]
+
+
+def test_site_overrides_follow_the_country_trajectory(tmp_path: Path) -> None:
+    """A site electricity override is scaled by the country trajectory ratio."""
+    env = _make_env(tmp_path, carbon_by_year={y: 0.0 for y in range(2025, 2031)})
+    # Site pays half the country electricity price in 2025.
+    site_electricity = 0.05
+    input_2027, _ = env.candidate_energy_costs_for_year(
+        LOCATION,
+        "DRI",
+        Year(2027),
+        overrides={"electricity": site_electricity},
+        override_reference_year=Year(2025),
+    )
+    country_2025 = env.input_costs["AAA"][Year(2025)]["electricity"]
+    country_2027 = env.input_costs["AAA"][Year(2027)]["electricity"]
+
+    assert input_2027["electricity"] == pytest.approx(site_electricity * country_2027 / country_2025)


### PR DESCRIPTION
The scoring machinery for the year-wise investment NPV. Additive only - nothing calls it yet, so it can be reviewed purely on whether the pricing is right.

- `candidate_energy_costs_for_year` prices a candidate at any year: input-cost trajectory (clamped past the data end, loud on interior gaps), precomputed capped LCOH, candidate-scoped energy subsidies filtered to that year, optional site-price overrides scaled by the country trajectory.
- `reductant_score_series` runs the scorer at each operating year's prices and picks with the same rule the annual re-pick uses (per-charge argmin, mode across charges), so the forecast matches the decision the plant will actually make each year.
- `carbon_price_for_year` clamps past the end of the series instead of silently pricing carbon at zero.
