### PR TITLE
Count full fixed OPEX in investment NPVs

### DIFF
--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -759,6 +759,32 @@ def calculate_unit_total_opex(unit_vopex: float, unit_fopex: float, utilization_
         return 0.0
 
 
+def scale_fopex_to_production(tech_unit_fopex: float, expected_utilisation_rate: float) -> float:
+    """
+    Convert fixed OPEX per tonne of capacity to fixed OPEX per tonne of production.
+
+    Technology fixed OPEX inputs are quoted per tonne of capacity per year. NPV cash flows
+    multiply unit costs by expected production (utilisation x capacity), so the per-capacity
+    figure must be spread over the production share to count the full fixed cost.
+
+    Args:
+        tech_unit_fopex (float): Fixed OPEX per tonne of capacity per year ($/t capacity).
+        expected_utilisation_rate (float): Expected utilisation rate (0.0 to 1.0, exclusive of 0).
+
+    Returns:
+        float: Fixed OPEX per tonne of production ($/t).
+
+    Raises:
+        ValueError: If expected_utilisation_rate is not positive — an investment candidate
+            with no expected production cannot be priced.
+    """
+    if expected_utilisation_rate <= 0:
+        raise ValueError(
+            f"Expected utilisation rate must be positive to scale fixed OPEX, got {expected_utilisation_rate}"
+        )
+    return tech_unit_fopex / expected_utilisation_rate
+
+
 def calculate_debt_repayment(
     total_investment: float,
     equity_share: float,
@@ -1245,6 +1271,8 @@ def calculate_business_opportunity_npvs(
         - The plant capacity does not affect the NPV calculation.
         - cost_data has been validated by validate_and_clean_cost_data to ensure all required fields are
           present with correct types (floats for costs, dict for bom).
+        - The per-capacity fixed OPEX is converted to per-production terms (divided by the expected
+          utilisation rate) so the full fixed cost is counted in the cash flows.
     """
     from steelo.domain.calculate_costs import calculate_npv_full, collect_active_subsidies_over_period
 
@@ -1269,8 +1297,10 @@ def calculate_business_opportunity_npvs(
                 # Materials-only variable OPEX plus fixed OPEX; energy, carbon and
                 # by-products enter through the per-year reductant score
                 unit_vopex = calculate_variable_opex(bom["materials"], {})
-                unit_fopex = bo_costs["fopex"]
-                assert isinstance(unit_fopex, (int, float)), f"Expected fopex to be numeric, got {type(unit_fopex)}"
+                raw_fopex = bo_costs["fopex"]
+                assert isinstance(raw_fopex, (int, float)), f"Expected fopex to be numeric, got {type(raw_fopex)}"
+                # Per-capacity fixed OPEX spread over the production the NPV multiplies by
+                unit_fopex = scale_fopex_to_production(raw_fopex, bo_costs["utilization_rate"])  # type: ignore[arg-type]
                 score_series = bo_costs["score_series"]
                 assert isinstance(score_series, list), f"Expected score_series to be list, got {type(score_series)}"
                 unit_total_opex_list = calculate_opex_list_with_subsidies(

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -20,6 +20,7 @@ from steelo.domain.calculate_costs import (
     calculate_opex_list_with_subsidies,
     calculate_unit_total_opex,
     calculate_variable_opex,
+    scale_fopex_to_production,
     filter_subsidies_for_year,
     get_subsidised_energy_costs,
     collect_active_subsidies_over_period,
@@ -2700,7 +2701,7 @@ class FurnaceGroup:
                     raise ValueError(f"Unit FOPEX for technology {tech} not found")
 
                 unit_base_opex = calculate_unit_total_opex(
-                    unit_fopex=unit_fopex,
+                    unit_fopex=scale_fopex_to_production(unit_fopex, util_rate),
                     unit_vopex=calculate_variable_opex(bill_of_materials["materials"], {}),
                     utilization_rate=util_rate,
                 )
@@ -5552,11 +5553,23 @@ class PlantGroup:
                     risk_free_rate=global_risk_free_rate,
                 )
 
+                product = tech_to_product[tech]
+                if not product or product not in price_series:
+                    continue
+
+                # Use maximum of technology utilization and plant's historical average
+                expected_utilisation_rate: float = (
+                    max(util_rate, excpected_utilisation[product]["utilisation_rate"])
+                    if product in excpected_utilisation
+                    else util_rate
+                )
+
                 # Calculate OPEX (fixed + variable + subsidies)
                 tech_unit_fopex_value = technology_unit_fopex.get(tech.lower())
                 if tech_unit_fopex_value is None:
                     raise ValueError(f"No fixed OPEX data for technology: {tech} in country: {plant.location.iso3}")
-                unit_fopex = float(tech_unit_fopex_value)
+                # Per-capacity fixed OPEX spread over the production the NPV multiplies by
+                unit_fopex = cc.scale_fopex_to_production(float(tech_unit_fopex_value), expected_utilisation_rate)
 
                 # Materials-only variable OPEX plus fixed OPEX; energy, carbon and
                 # by-products enter through the per-year score
@@ -5578,18 +5591,6 @@ class PlantGroup:
                     opex_subsidies=selected_opex_subsidies,
                     start_year=Year(current_year + construction_time),
                     end_year=Year(current_year + construction_time + plant_lifetime),
-                )
-
-                # Calculate NPV using full financial model
-                product = tech_to_product[tech]
-                if not product or product not in price_series:
-                    continue
-
-                # Use maximum of technology utilization and plant's historical average
-                expected_utilisation_rate: float = (
-                    max(util_rate, excpected_utilisation[product]["utilisation_rate"])
-                    if product in excpected_utilisation
-                    else util_rate
                 )
 
                 # Carbon and by-product terms are already inside the per-year opex list

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -2586,6 +2586,16 @@ class FurnaceGroup:
                 util_rate = self.utilization_rate
                 reductant = self.chosen_reductant
 
+                # A furnace group the market allocated no production cannot price a
+                # renovation on its realised utilisation; leave the incumbent out of
+                # the candidate set (at an expired boundary this closes the group)
+                if util_rate <= 0:
+                    logger.warning(
+                        f"[OPTIMAL TECH] SKIPPING {tech} - zero utilisation for furnace group "
+                        f"{self.furnace_group_id}, renovation cannot be priced"
+                    )
+                    continue
+
                 # Validate BOM structure before proceeding
                 if not bill_of_materials or "materials" not in bill_of_materials or "energy" not in bill_of_materials:
                     logger.warning(f"[OPTIMAL TECH] SKIPPING {tech} - Invalid or missing BOM structure")

--- a/tests/unit/test_fopex_scaling.py
+++ b/tests/unit/test_fopex_scaling.py
@@ -150,6 +150,40 @@ def test_switch_candidate_counts_full_fixed_cost(monkeypatch):
     assert call["unit_total_opex_list"][0] == pytest.approx(expected_vopex + 50.0 / 0.9)
 
 
+def test_zero_utilisation_incumbent_is_skipped_not_fatal(monkeypatch):
+    """A furnace group with no allocated production cannot price its renovation.
+
+    The incumbent is left out of the candidate set instead of raising from
+    scale_fopex_to_production; challengers are still priced at their BOM utilisation.
+    """
+    _capture_npv_full(monkeypatch)
+    fg = _make_fg(utilization_rate=0.0)
+
+    tech_npv_dict, _, _, bom_dict, _ = fg.optimal_technology_name(
+        market_price_series={"steel": [500.0] * 30, "iron": [400.0] * 30},
+        cost_of_debt_by_tech={"BF": 0.05, "DRI": 0.05},
+        cost_of_equity_by_tech={"BF": 0.1, "DRI": 0.1},
+        get_bom_from_avg_boms=_mock_get_bom(util_rate=0.9),
+        score_series_for_tech=_stub_score_series,
+        capex_dict={"BF": 600.0, "DRI": 500.0},
+        capex_renovation_share={"BF": 0.7},
+        technology_fopex_dict={"bf": 10.0, "dri": 50.0},
+        dynamic_business_cases={},
+        chosen_emissions_boundary_for_carbon_costs="Scope 1",
+        technology_emission_factors=[],
+        tech_to_product={"BF": "iron", "DRI": "iron"},
+        plant_lifetime=20,
+        construction_time=2,
+        current_year=Year(2025),
+        risk_free_rate=0.02,
+        allowed_furnace_transitions={"BF": ["BF", "DRI"]},
+    )
+
+    assert "BF" not in tech_npv_dict
+    assert "BF" not in bom_dict
+    assert "DRI" in tech_npv_dict
+
+
 # ── expansion path ────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_fopex_scaling.py
+++ b/tests/unit/test_fopex_scaling.py
@@ -1,0 +1,241 @@
+"""Regression tests for fixed-OPEX capacity-to-production scaling in investment NPVs.
+
+Technology fixed OPEX is quoted per tonne of capacity per year, while NPV cash flows
+multiply unit costs by expected production (utilisation x capacity). Each investment
+path (creation, switch, expansion) must therefore divide fopex by the same expected
+utilisation rate it passes to calculate_npv_full, so the full fixed cost is counted.
+"""
+
+from datetime import date
+
+import pytest
+
+from steelo.domain import calculate_costs
+from steelo.domain.calculate_costs import ReductantScoreSeries, scale_fopex_to_production
+from steelo.domain.constants import Volumes
+from steelo.domain.models import (
+    FurnaceGroup,
+    Location,
+    Plant,
+    PlantGroup,
+    PointInTime,
+    Technology,
+    Year,
+)
+
+MATERIALS = {"iron_ore": {"unit_cost": 100.0, "demand": 1.0}}
+
+
+def _stub_score_series(tech, output_shares, start, end):
+    n = int(end) - int(start)
+    return ReductantScoreSeries(scores=[0.0] * n, picks=["hydrogen"] * n)
+
+
+def _make_fg(utilization_rate: float) -> FurnaceGroup:
+    """Build a minimal operating BF furnace group with a materials-only BOM."""
+    fg = FurnaceGroup(
+        furnace_group_id="fg1",
+        capacity=100_000,
+        status="operating",
+        last_renovation_date=date(2020, 1, 1),
+        technology=Technology(name="BF", product="iron"),
+        historical_production={},
+        utilization_rate=utilization_rate,
+        lifetime=PointInTime(plant_lifetime=20, current=Year(2025)),
+        chosen_reductant="coke",
+        energy_cost_dict={},
+    )
+    fg.bill_of_materials = {
+        "materials": dict(MATERIALS),
+        "energy": {"coke": {"unit_cost": 300.0, "demand": 0.4}},
+    }
+    fg.set_energy_costs(coke=300.0, hydrogen=5000.0, electricity=0.05)
+    return fg
+
+
+def _make_plant(fg: FurnaceGroup) -> Plant:
+    return Plant(
+        plant_id="P000000000001",
+        location=Location(lat=0.0, lon=0.0, country="New Zealand", region="oceania", iso3="NZL"),
+        furnace_groups=[fg],
+        power_source="grid",
+        soe_status="private",
+        parent_gem_id="G01",
+        workforce_size=100,
+        certified=False,
+        category_steel_product=set(),
+        technology_unit_fopex={"bf": 10.0},
+    )
+
+
+def _mock_get_bom(util_rate: float):
+    """Mock get_bom_from_avg_boms returning a materials-only BOM at the given utilisation."""
+
+    def mock(energy_costs, tech, _capacity, _reductant=None):
+        return (
+            {"materials": dict(MATERIALS), "energy": {}},
+            util_rate,
+            "hydrogen",
+            {"iron_ore": 1.0},
+        )
+
+    return mock
+
+
+def _capture_npv_full(monkeypatch) -> list[dict]:
+    """Replace calculate_npv_full with a recorder; all call sites resolve it from the module."""
+    captured: list[dict] = []
+
+    def fake(**kwargs):
+        captured.append(kwargs)
+        return 0.0
+
+    monkeypatch.setattr(calculate_costs, "calculate_npv_full", fake)
+    return captured
+
+
+# ── helper ────────────────────────────────────────────────────────────────────
+
+
+def test_scale_fopex_to_production_spreads_over_utilisation():
+    """Per-capacity fopex divided by expected utilisation gives per-production fopex."""
+    assert scale_fopex_to_production(80.0, 0.8) == pytest.approx(100.0)
+    assert scale_fopex_to_production(0.0, 0.5) == 0.0
+
+
+def test_scale_fopex_to_production_rejects_non_positive_utilisation():
+    """A candidate with no expected production cannot be priced."""
+    with pytest.raises(ValueError, match="utilisation"):
+        scale_fopex_to_production(80.0, 0.0)
+    with pytest.raises(ValueError, match="utilisation"):
+        scale_fopex_to_production(80.0, -0.1)
+
+
+# ── switch path ───────────────────────────────────────────────────────────────
+
+
+def test_switch_candidate_counts_full_fixed_cost(monkeypatch):
+    """optimal_technology_name prices candidate fopex per tonne of production.
+
+    With fopex $50/t-capacity and BOM utilisation 0.9, the opex fed to the NPV must
+    carry 50/0.9 so that opex x production recovers fopex x capacity.
+    """
+    captured = _capture_npv_full(monkeypatch)
+    fg = _make_fg(utilization_rate=0.8)
+
+    fg.optimal_technology_name(
+        market_price_series={"steel": [500.0] * 30, "iron": [400.0] * 30},
+        cost_of_debt_by_tech={"BF": 0.05, "DRI": 0.05},
+        cost_of_equity_by_tech={"BF": 0.1, "DRI": 0.1},
+        get_bom_from_avg_boms=_mock_get_bom(util_rate=0.9),
+        score_series_for_tech=_stub_score_series,
+        capex_dict={"DRI": 500.0},
+        capex_renovation_share={},
+        technology_fopex_dict={"dri": 50.0},
+        dynamic_business_cases={},
+        chosen_emissions_boundary_for_carbon_costs="Scope 1",
+        technology_emission_factors=[],
+        tech_to_product={"DRI": "iron"},
+        plant_lifetime=20,
+        construction_time=2,
+        current_year=Year(2025),
+        risk_free_rate=0.02,
+        allowed_furnace_transitions={"BF": ["DRI"]},
+    )
+
+    assert len(captured) == 1
+    call = captured[0]
+    expected_vopex = calculate_costs.calculate_variable_opex(dict(MATERIALS), {})
+    assert call["expected_utilisation_rate"] == pytest.approx(0.9)
+    assert call["unit_total_opex_list"][0] == pytest.approx(expected_vopex + 50.0 / 0.9)
+
+
+# ── expansion path ────────────────────────────────────────────────────────────
+
+
+def test_expansion_candidates_count_full_fixed_cost(monkeypatch):
+    """evaluate_expansion_options scales fopex by the NPV's expected utilisation.
+
+    The NPV uses max(BOM utilisation, plant historical average) for the product, so
+    the divisor must be that same maximum: the DRI (iron) candidate takes the plant's
+    0.95 historical average over the BOM's 0.9, while the EAF (steel) candidate has
+    no historical average and keeps the BOM's 0.9.
+    """
+    captured = _capture_npv_full(monkeypatch)
+    fg = _make_fg(utilization_rate=0.95)
+    pg = PlantGroup(plant_group_id="pg1", plants=[_make_plant(fg)])
+    pg.balance = 1e12
+
+    pg.evaluate_expansion_options(
+        price_series={"steel": [500.0] * 30, "iron": [400.0] * 30},
+        capacity=Volumes(1000.0),
+        region_capex={"Region": {"DRI": 500.0, "EAF": 400.0}},
+        cost_of_debt_dict={"NZL": {"DRI": 0.05, "EAF": 0.05}},
+        cost_of_equity_dict={"NZL": {"DRI": 0.1, "EAF": 0.1}},
+        get_bom_from_avg_boms=_mock_get_bom(util_rate=0.9),
+        reductant_score_series=lambda *a, **k: ReductantScoreSeries(scores=[0.0] * 20, picks=["hydrogen"] * 20),
+        dynamic_feedstocks={},
+        fopex_for_iso3={"NZL": {"dri": 50.0, "eaf": 40.0}},
+        iso3_to_region_map={"NZL": "Region"},
+        chosen_emissions_boundary_for_carbon_costs="Scope 1",
+        technology_emission_factors=[],
+        global_risk_free_rate=0.02,
+        equity_share=0.3,
+        tech_to_product={"DRI": "iron", "EAF": "steel"},
+        plant_lifetime=20,
+        construction_time=2,
+        current_year=Year(2025),
+        allowed_techs={Year(2025): ["DRI", "EAF"]},
+        active_statuses=["operating"],
+    )
+
+    expected_vopex = calculate_costs.calculate_variable_opex(dict(MATERIALS), {})
+    by_capex = {call["capex"]: call for call in captured}
+    dri_call = by_capex[500.0]
+    assert dri_call["expected_utilisation_rate"] == pytest.approx(0.95)
+    assert dri_call["unit_total_opex_list"][0] == pytest.approx(expected_vopex + 50.0 / 0.95)
+    eaf_call = by_capex[400.0]
+    assert eaf_call["expected_utilisation_rate"] == pytest.approx(0.9)
+    assert eaf_call["unit_total_opex_list"][0] == pytest.approx(expected_vopex + 40.0 / 0.9)
+
+
+# ── creation path ─────────────────────────────────────────────────────────────
+
+
+def test_new_plant_npv_counts_full_fixed_cost(monkeypatch):
+    """calculate_business_opportunity_npvs converts the raw per-capacity fopex."""
+    captured = _capture_npv_full(monkeypatch)
+    cost_data = {
+        "iron": {
+            (0.0, 0.0, "SITE1"): {
+                "DRI": {
+                    "bom": {"materials": dict(MATERIALS), "energy": {}},
+                    "fopex": 50.0,
+                    "utilization_rate": 0.8,
+                    "score_series": [0.0] * 20,
+                    "capex": 500.0,
+                    "cost_of_debt": 0.05,
+                    "cost_of_equity": 0.1,
+                    "railway_cost": 0.0,
+                    "all_opex_subsidies": [],
+                },
+            },
+        },
+    }
+
+    npvs = calculate_costs.calculate_business_opportunity_npvs(
+        cost_data=cost_data,
+        target_year=2025,
+        market_price={"iron": [400.0] * 30},
+        steel_plant_capacity=2_500_000.0,
+        plant_lifetime=20,
+        construction_time=2,
+        equity_share=0.3,
+    )
+
+    assert len(captured) == 1
+    call = captured[0]
+    expected_vopex = calculate_costs.calculate_variable_opex(dict(MATERIALS), {})
+    assert call["expected_utilisation_rate"] == pytest.approx(0.8)
+    assert call["unit_total_opex_list"][0] == pytest.approx(expected_vopex + 50.0 / 0.8)
+    assert npvs["iron"][(0.0, 0.0, "SITE1")]["DRI"] == 0.0


### PR DESCRIPTION
`tech_unit_fopex` is fixed O&M per tonne of *capacity*, but the NPV multiplies the unit-opex list by expected *production* - so passing it unscaled counts only the utilisation share of fixed cost.

- Creation, switch and expansion all passed it raw; the opportunity re-check and COSA already scaled. The mixed convention also distorted stay-vs-switch, since the incumbent's fixed costs were priced in full while every challenger under-counted its own.
- Rough size: a 2.5 Mt EAF at 0.7 utilisation with $100/t-capacity fopex costs $250M/yr, not the $175M/yr counted - around $500M of NPV over a 20-year operating life.
- `scale_fopex_to_production` divides by the same expected utilisation the NPV multiplies production by, and raises on non-positive utilisation.
- A furnace group the LP gave zero production would hit that guard when its renovation was priced on realised utilisation, so the incumbent is now left out of its own candidate set; at an expired boundary the group closes.
- Worth knowing before merging: this shifts NPV levels on all three paths and hasn't had a full-horizon comparative run - the archived baseline predates it. Within-pool ranking should barely move (everything shifts down together); the bite is on the announce/discard threshold for marginal sites.
