### PR TITLE
Run the technology draw unconditionally

### DIFF
--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -3911,9 +3911,10 @@ class Plant:
         4. Calculate NPV for all technology options (adjusted for COSA when switching)
         5. Check if any technology option is profitable (NPV > 0)
         6. Identify optimal technology (maximum NPV)
-        7. Select technology (weighted random if probabilistic_agents=True, otherwise optimal)
-        8. If current tech is optimal and lifetime expired: evaluate renovation (gated on plant_group.balance)
-        9. If different tech is optimal: evaluate technology switch (gated on plant_group.balance)
+        7. Select technology: NPV-weighted random draw over all valid options, incumbent
+           included (probabilistic_agents=True), otherwise the max-NPV option
+        8. If the incumbent is selected and lifetime expired: evaluate renovation (gated on plant_group.balance)
+        9. If a different tech is selected: evaluate technology switch (gated on plant_group.balance)
         10. Check capacity limits for expansions/switches
         11. Apply probabilistic adoption decision (if enabled)
         12. Return appropriate command (ChangeFurnaceGroupTechnology, RenovateFurnaceGroup, CloseFurnaceGroup, or None)
@@ -4223,49 +4224,44 @@ class Plant:
         # ===== STAGE 6: Identify optimal technology =====
         current_tech = furnace_group.technology.name
         optimal_tech = max(tech_npv_dict, key=lambda k: tech_npv_dict[k])
-        is_current_best = current_tech == optimal_tech
 
-        logger.debug(
-            f"[FG STRATEGY] Current tech: {current_tech}, Optimal tech: {optimal_tech}, "
-            f"Current is best: {is_current_best}"
-        )
+        logger.debug(f"[FG STRATEGY] Current tech: {current_tech}, Optimal tech: {optimal_tech}")
 
         # ===== STAGE 7: Technology selection =====
-        # If current tech is not optimal, pick an alternative: weighted random when
-        # probabilistic_agents, otherwise the max-NPV option
-        if not is_current_best:
-            logger.debug("[FG STRATEGY] Current technology is not optimal, selecting alternative")
+        # The draw always runs: the incumbent competes on its own NPV alongside the
+        # challengers — weighted random when probabilistic_agents, otherwise max NPV
 
-            # Filter out invalid NPV values (infinite, NaN)
-            valid_techs = {
-                k: v for k, v in tech_npv_dict.items() if v is not None and not math.isinf(v) and not math.isnan(v)
-            }
-            logger.debug(f"[FG STRATEGY] Valid technology options: {list(valid_techs.keys())}")
+        # Filter out invalid NPV values (infinite, NaN)
+        valid_techs = {
+            k: v for k, v in tech_npv_dict.items() if v is not None and not math.isinf(v) and not math.isnan(v)
+        }
+        logger.debug(f"[FG STRATEGY] Valid technology options: {list(valid_techs.keys())}")
 
-            if not valid_techs:
-                logger.warning(f"[FG STRATEGY] No valid NPV values found for plant {self.plant_id}")
-                if furnace_group.lifetime.expired:
-                    return renovate_or_close_expired()
-                return None
+        if not valid_techs:
+            logger.warning(f"[FG STRATEGY] No valid NPV values found for plant {self.plant_id}")
+            if furnace_group.lifetime.expired:
+                return renovate_or_close_expired()
+            return None
 
-            weights = [max(v, 0) for v in valid_techs.values()]
-            if sum(weights) < 0.0001:
-                if furnace_group.lifetime.expired:
-                    return renovate_or_close_expired()
-                return None
+        weights = [max(v, 0) for v in valid_techs.values()]
+        total_weight = sum(weights)
+        if total_weight < 0.0001:
+            if furnace_group.lifetime.expired:
+                return renovate_or_close_expired()
+            return None
 
-            if probabilistic_agents:
-                # Weighted random selection based on NPV (negative NPVs get zero weight)
-                formatted_dict = {k: f"{v:,.0f}" for k, v in zip(valid_techs.keys(), weights)}
-                logger.debug(f"[FG STRATEGY] Selection weights: {formatted_dict}")
-                best_tech = random.choices(population=list(valid_techs.keys()), weights=weights, k=1)[0]
-                logger.debug(f"[FG STRATEGY] Selected technology: {best_tech} (weighted random)")
-            else:
-                best_tech = max(valid_techs, key=lambda k: valid_techs[k])
-                logger.debug(f"[FG STRATEGY] Selected technology: {best_tech} (deterministic, max NPV)")
+        if probabilistic_agents:
+            # Weighted random selection based on NPV (negative NPVs get zero weight)
+            best_tech = random.choices(population=list(valid_techs.keys()), weights=weights, k=1)[0]
+            shares = ", ".join(f"{k}={w / total_weight:.3f}" for k, w in zip(valid_techs.keys(), weights))
+            logger.info(
+                f"[FG STRATEGY] DRAW plant_id={self.plant_id} "
+                f"furnace_group_id={furnace_group.furnace_group_id} incumbent={current_tech} "
+                f"selected={best_tech} p({shares})"
+            )
         else:
-            logger.debug("[FG STRATEGY] Current technology is already optimal")
-            best_tech = current_tech
+            best_tech = max(valid_techs, key=lambda k: valid_techs[k])
+            logger.debug(f"[FG STRATEGY] Selected technology: {best_tech} (deterministic, max NPV)")
 
         # Final profitability check for selected technology
         if tech_npv_dict[best_tech] <= 0:

--- a/tests/integration/test_furnace_strategy_always_on_draw.py
+++ b/tests/integration/test_furnace_strategy_always_on_draw.py
@@ -1,0 +1,170 @@
+"""Tests pinning the always-on Stage-7 draw in Plant.evaluate_furnace_group_strategy.
+
+The NPV-weighted draw runs for every probabilistic evaluation, with the incumbent
+competing on its own NPV — there is no argmax-incumbent short-circuit. Weights are
+linear NPV-proportional with non-positive NPVs zeroed. Deterministic mode
+(probabilistic_agents=False) still picks the max-NPV option without any draw.
+"""
+
+from unittest.mock import MagicMock
+
+from steelo.devdata import get_furnace_group, get_plant
+from steelo.domain import PointInTime, TimeFrame, Volumes, Year
+from steelo.domain.commands import ChangeFurnaceGroupTechnology, RenovateFurnaceGroup
+from steelo.domain.models import PlantGroup
+
+REGION_CAPEX = {"EAF": 400.0, "DRI": 600.0}
+RENOVATION_SHARE = {"EAF": 0.7, "DRI": 0.7}
+ALLOWED_TECHS = {Year(year): ["EAF", "DRI"] for year in range(2020, 2031)}
+TRANSITIONS = {"EAF": ["EAF", "DRI"]}
+
+# With capacity=100 and the devdata default equity_share=0.2:
+# renovate_cost (EAF) = 400 × 100 × 0.2 = 8,000
+RENOVATE_COST = 8_000.0
+
+
+def make_plant_and_group(*, expired: bool, balance: float):
+    """Build an EAF plant plus owning group; start year controls lifetime expiry in 2025."""
+    fg = get_furnace_group(
+        fg_id="fg_draw_test",
+        utilization_rate=0.7,
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2005) if expired else Year(2015), end=Year(2045)),
+            plant_lifetime=20,
+        ),
+        capacity=100,
+        tech_name="EAF",
+    )
+    plant = get_plant(furnace_groups=[fg], plant_id="plant_draw_test")
+    plant.location.iso3 = "USA"
+    plant.technology_unit_fopex = {"EAF": 50.0, "DRI": 70.0}
+    plant.carbon_cost_series = [0.0] * 22
+    plant_group = PlantGroup(plant_group_id="gem_draw_test", plants=[plant])
+    plant_group.balance = balance
+    return plant, plant_group
+
+
+def mock_npvs(mocker, furnace_group, tech_npv_dict):
+    """Patch optimal_technology_name to return fixed NPVs with REGION_CAPEX-priced capex."""
+    bom = {
+        "materials": {"scrap": {"unit_cost": 200.0, "demand": 1.0}},
+        "energy": {"electricity": {"unit_cost": 80.0, "demand": 0.5}},
+    }
+    mocker.patch.object(
+        furnace_group,
+        "optimal_technology_name",
+        return_value=(
+            tech_npv_dict,
+            {tech: REGION_CAPEX[tech] for tech in tech_npv_dict},
+            10_000.0,
+            {tech: bom for tech in tech_npv_dict},
+            {tech: "scrap" for tech in tech_npv_dict},
+        ),
+    )
+
+
+def evaluate(plant, plant_group, *, probabilistic_agents: bool = True):
+    """Call evaluate_furnace_group_strategy with a minimal fixed argument set."""
+    furnace_group = plant.furnace_groups[0]
+    return plant.evaluate_furnace_group_strategy(
+        furnace_group_id=furnace_group.furnace_group_id,
+        plant_group=plant_group,
+        market_price_series={"steel": [600.0] * 22, "iron": [400.0] * 22},
+        region_capex=REGION_CAPEX,
+        capex_renovation_share=RENOVATION_SHARE,
+        cost_of_debt_by_tech={"EAF": 0.04, "DRI": 0.04},
+        cost_of_equity_by_tech={"EAF": 0.08, "DRI": 0.08},
+        get_bom_from_avg_boms=MagicMock(),
+        reductant_score_series=MagicMock(),
+        probabilistic_agents=probabilistic_agents,
+        dynamic_business_cases={"EAF": [], "DRI": []},
+        chosen_emissions_boundary_for_carbon_costs="scope_1",
+        technology_emission_factors=[],
+        tech_to_product={"EAF": "steel", "DRI": "iron"},
+        plant_lifetime=20,
+        construction_time=2,
+        current_year=Year(2025),
+        allowed_techs=ALLOWED_TECHS,
+        risk_free_rate=0.02,
+        allowed_furnace_transitions=TRANSITIONS,
+        capacity_limit_steel=Volumes(10_000),
+        capacity_limit_iron=Volumes(10_000),
+        installed_capacity_in_year=lambda product: Volumes(1_000),
+        new_plant_capacity_in_year=lambda product: Volumes(0),
+    )
+
+
+def test_draw_runs_when_incumbent_is_argmax_and_challenger_can_win(mocker):
+    """The argmax incumbent no longer short-circuits the draw: a challenger drawn
+    against a better incumbent switches.
+
+    Previously an argmax incumbent went straight to renovate/no-action with zero
+    probability mass on challengers.
+    """
+    plant, plant_group = make_plant_and_group(expired=False, balance=1_000_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": 1_000_000.0, "DRI": 500_000.0})
+    choices = mocker.patch("steelo.domain.models.random.choices", return_value=["DRI"])
+    mocker.patch("steelo.domain.models.random.random", return_value=0.0)
+
+    command = evaluate(plant, plant_group)
+
+    assert isinstance(command, ChangeFurnaceGroupTechnology)
+    assert command.technology_name == "DRI"
+    assert command.old_technology_name == "EAF"
+    choices.assert_called_once()
+    assert choices.call_args.kwargs["population"] == ["EAF", "DRI"]
+    assert choices.call_args.kwargs["weights"] == [1_000_000.0, 500_000.0]
+
+
+def test_incumbent_winning_draw_mid_life_takes_no_action(mocker):
+    """An incumbent that wins the draw mid-life results in no action, but the draw ran."""
+    plant, plant_group = make_plant_and_group(expired=False, balance=1_000_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": 1_000_000.0, "DRI": 500_000.0})
+    choices = mocker.patch("steelo.domain.models.random.choices", return_value=["EAF"])
+
+    command = evaluate(plant, plant_group)
+
+    assert command is None
+    choices.assert_called_once()
+
+
+def test_incumbent_winning_draw_at_boundary_renovates(mocker):
+    """An incumbent that wins the draw in its renovation-boundary year renovates."""
+    plant, plant_group = make_plant_and_group(expired=True, balance=1_000_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": 1_000_000.0, "DRI": 500_000.0})
+    mocker.patch("steelo.domain.models.random.choices", return_value=["EAF"])
+
+    command = evaluate(plant, plant_group)
+
+    assert isinstance(command, RenovateFurnaceGroup)
+    assert command.capex_no_subsidy == REGION_CAPEX["EAF"]
+    assert plant_group.balance == 1_000_000.0 - RENOVATE_COST
+
+
+def test_non_positive_npv_gets_zero_weight_in_draw(mocker):
+    """Linear weighting zeroes non-positive NPVs: a loss-making incumbent has no
+    probability mass, while positive options keep their raw NPV as weight."""
+    plant, plant_group = make_plant_and_group(expired=False, balance=1_000_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": -1_000.0, "DRI": 500_000.0})
+    choices = mocker.patch("steelo.domain.models.random.choices", return_value=["DRI"])
+    mocker.patch("steelo.domain.models.random.random", return_value=0.0)
+
+    command = evaluate(plant, plant_group)
+
+    assert isinstance(command, ChangeFurnaceGroupTechnology)
+    assert choices.call_args.kwargs["weights"] == [0, 500_000.0]
+
+
+def test_deterministic_mode_picks_argmax_without_a_draw(mocker):
+    """probabilistic_agents=False is behaviourally unchanged: max-NPV incumbent
+    renovates at the boundary and random.choices is never consulted."""
+    plant, plant_group = make_plant_and_group(expired=True, balance=1_000_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": 1_000_000.0, "DRI": 500_000.0})
+    choices = mocker.patch("steelo.domain.models.random.choices")
+
+    command = evaluate(plant, plant_group, probabilistic_agents=False)
+
+    assert isinstance(command, RenovateFurnaceGroup)
+    assert plant_group.balance == 1_000_000.0 - RENOVATE_COST
+    choices.assert_not_called()


### PR DESCRIPTION
Stage 7 only ran the weighted draw when the incumbent wasn't already the max-NPV option. An incumbent that happened to top the ranking was kept without ever facing the draw, while a challenger-led ranking put every option into the lottery - so the incumbent got a free pass for being ahead on a point estimate.

- The draw now runs for every probabilistic evaluation, with the incumbent in the pool competing on its own NPV. Weights are unchanged: linear in NPV, non-positive NPVs zeroed.
- Deterministic mode is unchanged - still the max-NPV option outright.
- Each draw logs at INFO with the incumbent, the winner and the per-tech probability shares.
- Worth knowing before merging: this roughly doubles switching activity in a run with no carbon price. Contested draws are about 2% of evaluations, with no runaway churn.
