### PR TITLE
Fix PAM execution parity: debt bookkeeping, equity share, debit ordering

### DIFF
--- a/src/steelo/domain/commands.py
+++ b/src/steelo/domain/commands.py
@@ -75,6 +75,7 @@ class AddFurnaceGroup(Command):
     capacity: float
     product: str
     chosen_reductant: str
+    equity_share: float
     equity_needed: float
     npv: float
     capex: float

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -15,6 +15,7 @@ from steelo.domain import events, commands
 from steelo.domain.calculate_costs import (
     build_direct_ghg_lookup,
     calculate_capex_with_subsidies,
+    calculate_debt_repayment,
     calculate_debt_with_subsidies,
     calculate_energy_costs_and_most_common_reductant,
     calculate_opex_list_with_subsidies,
@@ -3649,6 +3650,7 @@ class Plant:
         dynamic_business_case: list[PrimaryFeedstock] | None = None,
         bom: dict | None = None,
         chosen_reductant: str | None = None,
+        legacy_years: int | None = None,
     ) -> None:
         """
         Change the technology of a specified furnace group with debt preservation.
@@ -3682,6 +3684,10 @@ class Plant:
                 Defaults to None.
             bom (dict | None): Bill of materials for the new technology. If None, keeps existing BOM.
                 Defaults to None.
+            legacy_years (int | None): Years of the old technology's debt still outstanding, anchored
+                to the decision-time lifetime. A deferred switch executes after the furnace group's
+                lifetime has been replaced for the new cycle, so the caller must supply this; None
+                falls back to the current lifetime's remaining years (same-tick execution).
 
         Side Effects:
             - Updates furnace group's technology, lifetime, status, utilization rate, and debt schedules.
@@ -3703,13 +3709,17 @@ class Plant:
         """
         furnace_group = self.get_furnace_group(furnace_group_id)
 
-        # Capture remaining debt from the current technology before switching
+        # Capture the current technology's remaining debt tail before switching.
+        years_remaining = legacy_years if legacy_years is not None else furnace_group.lifetime.remaining_number_of_years
         old_remaining_debt = []
-        if furnace_group.lifetime.remaining_number_of_years > 0:
-            old_debt_schedule = furnace_group.debt_repayment_per_year
-            years_remaining = furnace_group.lifetime.remaining_number_of_years
-            if years_remaining > 0 and len(old_debt_schedule) >= years_remaining:
-                old_remaining_debt = old_debt_schedule[-years_remaining:]
+        if years_remaining > 0:
+            old_remaining_debt = calculate_debt_repayment(
+                total_investment=furnace_group.total_investment,
+                equity_share=furnace_group.equity_share,
+                lifetime=furnace_group.lifetime.plant_lifetime,
+                cost_of_debt=furnace_group.cost_of_debt,
+                lifetime_remaining=years_remaining,
+            )
 
         # Combine existing legacy debt with newly captured debt for cascading debt handling
         if furnace_group.legacy_debt_schedule:
@@ -4072,7 +4082,6 @@ class Plant:
             renovation_share = capex_renovation_share.get(incumbent)
             if renovation_share is None:
                 raise ValueError(f"CAPEX renovation share for technology {incumbent} not found")
-            full_capex_per_tonne = renovation_capex_per_tonne / renovation_share
             incumbent_capex_no_subsidy = region_capex.get(incumbent)
             if incumbent_capex_no_subsidy is None:
                 raise ValueError(f"CAPEX without subsidies for technology {incumbent} not found in region CAPEX dict")
@@ -4115,8 +4124,8 @@ class Plant:
             return commands.RenovateFurnaceGroup(
                 plant_id=self.plant_id,
                 furnace_group_id=furnace_group.furnace_group_id,
-                capex=full_capex_per_tonne,
-                capex_no_subsidy=incumbent_capex_no_subsidy,
+                capex=renovation_capex_per_tonne,
+                capex_no_subsidy=incumbent_capex_no_subsidy * renovation_share,
                 cost_of_debt=incumbent_cost_of_debt_with_subs,
                 cost_of_debt_no_subsidy=incumbent_cost_of_debt,
                 capex_subsidies=incumbent_capex_subs,

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -4191,6 +4191,8 @@ class Plant:
                 f"[FG STRATEGY] DECISION - No action "
                 f"(selected tech {best_tech} has NPV ${tech_npv_dict[best_tech]:,.2f} <= 0)"
             )
+            if furnace_group.lifetime.expired:
+                return renovate_or_close_expired()
             return None
 
         # ===== Filter and apply subsidies for selected technology =====
@@ -4354,15 +4356,7 @@ class Plant:
                     return None
 
             # ===== STAGE 12: Execute technology switch =====
-            # Debit group treasury and return command
-            plant_group.deduct_equity(switch_cost, reason="switch")
-            logger.info(
-                f"[FG STRATEGY] DECISION - SWITCH TECHNOLOGY {current_tech} → {best_tech} "
-                f"plant_id={self.plant_id} plant_group_id={plant_group.plant_group_id} gate_pass=True "
-                f"(NPV: ${tech_npv_dict.get(best_tech, 0):,.2f}, cost: ${switch_cost:,.2f}, "
-                f"new group balance: ${plant_group.balance:,.2f})"
-            )
-
+            # Validate the command inputs before debiting: an abort must leave the wallet intact
             npv_value = tech_npv_dict.get(best_tech)
             if npv_value is None:
                 raise ValueError(f"NPV for technology {best_tech} not found in NPV dict")
@@ -4391,6 +4385,14 @@ class Plant:
                     list(bom.keys()),
                 )
                 raise ValueError(f"Empty BOM for technology {best_tech} at switch time")
+
+            plant_group.deduct_equity(switch_cost, reason="switch")
+            logger.info(
+                f"[FG STRATEGY] DECISION - SWITCH TECHNOLOGY {current_tech} → {best_tech} "
+                f"plant_id={self.plant_id} plant_group_id={plant_group.plant_group_id} gate_pass=True "
+                f"(NPV: ${tech_npv_dict.get(best_tech, 0):,.2f}, cost: ${switch_cost:,.2f}, "
+                f"new group balance: ${plant_group.balance:,.2f})"
+            )
 
             return commands.ChangeFurnaceGroupTechnology(
                 plant_id=self.plant_id,
@@ -5939,6 +5941,7 @@ class PlantGroup:
             capacity=capacity,
             product=product,
             chosen_reductant=chosen_reductant,
+            equity_share=equity_share,
             equity_needed=equity_needed,
             npv=npv,  # type: ignore # npv is not None due to check above
             capex=capex,

--- a/src/steelo/service_layer/handlers.py
+++ b/src/steelo/service_layer/handlers.py
@@ -182,7 +182,7 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
 
     Args:
         cmd (commands.AddFurnaceGroup): Command containing furnace_group_id, plant_id,
-            technology_name, capacity, product, equity_needed (capex × capacity × equity_share),
+            technology_name, capacity, product, equity_share, equity_needed (capex × capacity × equity_share),
             npv, financial parameters (capex, capex_no_subsidy, cost_of_debt,
             cost_of_debt_no_subsidy), and subsidy lists (capex_subsidies, debt_subsidies).
         uow (UnitOfWork): Unit of work for managing the transaction and accessing repositories.
@@ -225,6 +225,7 @@ def add_furnace_group_to_plant(cmd: commands.AddFurnaceGroup, uow: UnitOfWork, e
             capex_no_subsidy=cmd.capex_no_subsidy,
             cost_of_debt=cmd.cost_of_debt,
             cost_of_debt_no_subsidy=cmd.cost_of_debt_no_subsidy,
+            equity_share=cmd.equity_share,
             current_year=env.year,
             lag=env.config.construction_time,
             status="construction",

--- a/src/steelo/service_layer/handlers.py
+++ b/src/steelo/service_layer/handlers.py
@@ -164,6 +164,7 @@ def change_furnace_group_technology(cmd: commands.ChangeFurnaceGroupTechnology, 
             cost_of_debt_no_subsidy=cmd.cost_of_debt_no_subsidy,
             capex_subsidies=cmd.capex_subsidies,
             debt_subsidies=cmd.debt_subsidies,
+            legacy_years=cmd.remaining_lifetime,
         )
         uow.commit()
 
@@ -409,6 +410,8 @@ def execute_scheduled_technology_switch(cmd: commands.Command, uow: UnitOfWork, 
         cost_of_debt_no_subsidy=cmd.cost_of_debt_no_subsidy,
         capex_subsidies=cmd.capex_subsidies,
         debt_subsidies=cmd.debt_subsidies,
+        # Anchor the old technology's debt tail to the decision-time lifetime
+        legacy_years=max(0, cmd.remaining_lifetime - env.config.construction_time),
     )
 
 

--- a/tests/integration/test_deferred_switch_legacy_debt.py
+++ b/tests/integration/test_deferred_switch_legacy_debt.py
@@ -1,0 +1,201 @@
+"""Tests that a deferred technology switch books the old technology's debt tail from
+decision-time state.
+
+A switch decided in year Y executes in year Y + construction_time, by which point
+finalise_iteration may already have replaced the furnace group's lifetime for the new
+cycle (boundary-crossing switches). Reading the lifetime at execution then re-amortises
+a fresh full-life loan of the old technology; the fix anchors the tail to the
+decision-time remaining lifetime carried on the command (``remaining_lifetime``).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from steelo.devdata import get_furnace_group, get_plant
+from steelo.domain import PointInTime, TimeFrame, Volumes, Year
+from steelo.domain import commands
+from steelo.domain.calculate_costs import calculate_debt_repayment
+from steelo.service_layer.handlers import execute_scheduled_technology_switch
+
+PLANT_LIFETIME = 20
+CONSTRUCTION_TIME = 4
+OLD_CAPEX = 400.0
+NEW_CAPEX = 600.0
+CAPACITY = 100
+BOM = {"materials": {"ore": {"unit_cost": 100.0, "demand": 1.4}}, "energy": {}}
+
+
+def make_plant(cycle_start: int, boundary_end: int):
+    """Build an EAF plant whose only furnace group runs the given renovation cycle.
+
+    Args:
+        cycle_start: First year of the furnace group's current lifetime cycle.
+        boundary_end: Renovation-boundary year (``lifetime.time_frame.end``).
+
+    Returns:
+        Tuple of (plant, furnace_group) positioned at current year 2025.
+    """
+    furnace_group = get_furnace_group(
+        fg_id="fg_probe",
+        tech_name="EAF",
+        capacity=Volumes(CAPACITY),
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(cycle_start), end=Year(boundary_end)),
+            plant_lifetime=PLANT_LIFETIME,
+        ),
+    )
+    furnace_group.technology.capex = OLD_CAPEX
+    plant = get_plant(furnace_groups=[furnace_group], plant_id="plant_probe")
+    plant.technology_unit_fopex = {"eaf": 50.0, "dri": 70.0}
+    return plant, furnace_group
+
+
+def make_switch_command(plant, furnace_group) -> commands.ChangeFurnaceGroupTechnology:
+    """Build the switch command as PAM would at decision time, capturing remaining lifetime."""
+    return commands.ChangeFurnaceGroupTechnology(
+        plant_id=plant.plant_id,
+        furnace_group_id=furnace_group.furnace_group_id,
+        technology_name="DRI",
+        old_technology_name="EAF",
+        npv=1.0,
+        cosa=0.0,
+        utilisation=0.7,
+        capex=NEW_CAPEX,
+        capex_no_subsidy=NEW_CAPEX,
+        capacity=furnace_group.capacity,
+        remaining_lifetime=furnace_group.lifetime.remaining_number_of_years,
+        bom=BOM,
+        chosen_reductant="",
+        cost_of_debt=0.05,
+        cost_of_debt_no_subsidy=0.05,
+        capex_subsidies=[],
+        debt_subsidies=[],
+    )
+
+
+def run_deferred_switch(plant, furnace_group, decision_year: int = 2025):
+    """Replay decision → finalise-iteration years → deferred execution for one switch.
+
+    Mirrors finalise_iteration's per-year steps: advance the lifetime (3a), execute the
+    scheduled switch in its effective year via the real handler (3b), and flip a
+    boundary-crossing group to "construction switching technology" with a fresh
+    lifetime (3c).
+
+    Returns:
+        The furnace group after the deferred execution.
+    """
+    year_of_switch = decision_year + CONSTRUCTION_TIME
+    cmd = make_switch_command(plant, furnace_group)
+    plant.change_furnace_group_status_to_switching_technology(furnace_group.furnace_group_id, year_of_switch, cmd)
+
+    env = SimpleNamespace(
+        config=SimpleNamespace(plant_lifetime=PLANT_LIFETIME, construction_time=CONSTRUCTION_TIME),
+        dynamic_feedstocks={},
+    )
+    uow = SimpleNamespace(plants=SimpleNamespace(get=lambda plant_id: plant))
+
+    for env_year in range(decision_year + 1, year_of_switch + 1):
+        furnace_group.lifetime.current = Year(env_year)
+        if furnace_group.future_switch_year == env_year and furnace_group.future_switch_cmd is not None:
+            execute_scheduled_technology_switch(furnace_group.future_switch_cmd, uow=uow, env=env)
+            continue
+        if (
+            furnace_group.lifetime.current > furnace_group.lifetime.time_frame.end
+            and furnace_group.status.lower() == "operating switching technology"
+        ):
+            furnace_group.status = "construction switching technology"
+            furnace_group.utilization_rate = 0.0
+            furnace_group.lifetime = PointInTime(
+                plant_lifetime=PLANT_LIFETIME,
+                current=Year(env_year),
+                time_frame=TimeFrame(
+                    start=Year(year_of_switch),
+                    end=Year(year_of_switch + PLANT_LIFETIME),
+                ),
+            )
+    return furnace_group
+
+
+def test_switch_decided_at_boundary_books_no_legacy_debt():
+    """A switch decided with zero remaining lifetime carries no old-technology debt.
+
+    Notes:
+        Regression for the phantom legacy-debt bug: the boundary crossing replaced the
+        lifetime before the deferred execution, so the capture read 20 remaining years
+        and booked a full re-amortised loan of the already-repaid old technology.
+    """
+    plant, furnace_group = make_plant(cycle_start=2005, boundary_end=2025)
+    assert furnace_group.lifetime.remaining_number_of_years == 0
+
+    run_deferred_switch(plant, furnace_group)
+
+    assert furnace_group.legacy_debt_schedule == []
+
+
+def test_switch_crossing_boundary_inside_construction_window_books_no_legacy_debt():
+    """Remaining lifetime shorter than construction time: old debt amortises out, none is booked."""
+    plant, furnace_group = make_plant(cycle_start=2007, boundary_end=2027)
+    assert furnace_group.lifetime.remaining_number_of_years == 2
+
+    run_deferred_switch(plant, furnace_group)
+
+    assert furnace_group.legacy_debt_schedule == []
+
+
+def test_mid_life_switch_books_decision_time_tail_net_of_construction():
+    """A mid-life switch books exactly the old loan's tail left after the construction window."""
+    plant, furnace_group = make_plant(cycle_start=2011, boundary_end=2031)
+    assert furnace_group.lifetime.remaining_number_of_years == 6
+
+    run_deferred_switch(plant, furnace_group)
+
+    expected_tail = calculate_debt_repayment(
+        total_investment=OLD_CAPEX * CAPACITY,
+        equity_share=furnace_group.equity_share,
+        lifetime=PLANT_LIFETIME,
+        cost_of_debt=0.05,
+        lifetime_remaining=6 - CONSTRUCTION_TIME,
+    )
+    assert furnace_group.legacy_debt_schedule == pytest.approx(expected_tail)
+    assert len(furnace_group.legacy_debt_schedule) == 2
+
+
+def test_second_switch_combines_existing_legacy_debt_once():
+    """A switch on a group already carrying legacy debt merges it into the new schedule once.
+
+    Notes:
+        The capture previously read debt_repayment_per_year, which already merges
+        legacy_debt_schedule, and then the combine step added the existing legacy
+        again — double-counting the first switch's debt on every later switch.
+    """
+    plant, furnace_group = make_plant(cycle_start=2011, boundary_end=2031)
+    prior_legacy = [100.0, 100.0, 100.0]
+    furnace_group.legacy_debt_schedule = list(prior_legacy)
+
+    plant.change_furnace_group_technology(
+        furnace_group_id=furnace_group.furnace_group_id,
+        technology_name="DRI",
+        plant_lifetime=PLANT_LIFETIME,
+        lag=0,
+        capex=NEW_CAPEX,
+        capex_no_subsidy=NEW_CAPEX,
+        cost_of_debt=0.05,
+        cost_of_debt_no_subsidy=0.05,
+        bom=BOM,
+        legacy_years=furnace_group.lifetime.remaining_number_of_years,
+    )
+
+    old_tech_tail = calculate_debt_repayment(
+        total_investment=OLD_CAPEX * CAPACITY,
+        equity_share=furnace_group.equity_share,
+        lifetime=PLANT_LIFETIME,
+        cost_of_debt=0.05,
+        lifetime_remaining=6,
+    )
+    expected = [
+        tail_payment + (prior_legacy[i] if i < len(prior_legacy) else 0.0)
+        for i, tail_payment in enumerate(old_tech_tail)
+    ]
+    assert furnace_group.legacy_debt_schedule == pytest.approx(expected)

--- a/tests/integration/test_furnace_strategy_always_on_draw.py
+++ b/tests/integration/test_furnace_strategy_always_on_draw.py
@@ -138,7 +138,7 @@ def test_incumbent_winning_draw_at_boundary_renovates(mocker):
     command = evaluate(plant, plant_group)
 
     assert isinstance(command, RenovateFurnaceGroup)
-    assert command.capex_no_subsidy == REGION_CAPEX["EAF"]
+    assert command.capex_no_subsidy == REGION_CAPEX["EAF"] * RENOVATION_SHARE["EAF"]
     assert plant_group.balance == 1_000_000.0 - RENOVATE_COST
 
 

--- a/tests/integration/test_furnace_strategy_expired_lifetime.py
+++ b/tests/integration/test_furnace_strategy_expired_lifetime.py
@@ -8,6 +8,8 @@ Plant.evaluate_furnace_group_strategy for expired furnace groups.
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from steelo.devdata import get_furnace_group, get_plant
 from steelo.domain import PointInTime, TimeFrame, Volumes, Year
 from steelo.domain.commands import CloseFurnaceGroup, RenovateFurnaceGroup
@@ -185,6 +187,48 @@ def test_renovation_debt_basis_matches_evaluated_capex(mocker):
     furnace_group = plant.furnace_groups[0]
     assert furnace_group.total_investment == command.capex * furnace_group.capacity
     assert plant_group.balance == 1_000_000.0 - command.capex * furnace_group.capacity * furnace_group.equity_share
+
+
+def test_expired_fg_renovates_when_draw_selects_non_positive_npv_tech(mocker):
+    """The post-draw NPV <= 0 guard resolves an expired lifetime instead of returning None.
+
+    The guard is unreachable through real draws (non-positive NPVs get zero weight),
+    but if it ever fires the expired furnace group must still renovate or close.
+    """
+    plant, plant_group = make_plant_and_group(expired=True, balance=1_000_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": 1_000.0, "DRI": -5.0})
+    mocker.patch("steelo.domain.models.random.choices", return_value=["DRI"])
+
+    command = evaluate(plant, plant_group, probabilistic_agents=True)
+
+    assert isinstance(command, RenovateFurnaceGroup)
+    assert plant_group.balance == 1_000_000.0 - RENOVATE_COST
+
+
+def test_switch_with_missing_bom_raises_before_debiting(mocker):
+    """A validation failure in the switch command aborts before the treasury is debited."""
+    plant, plant_group = make_plant_and_group(expired=False, balance=1_000_000.0)
+    furnace_group = plant.furnace_groups[0]
+    bom = {
+        "materials": {"scrap": {"unit_cost": 200.0, "demand": 1.0}},
+        "energy": {"electricity": {"unit_cost": 80.0, "demand": 0.5}},
+    }
+    mocker.patch.object(
+        furnace_group,
+        "optimal_technology_name",
+        return_value=(
+            {"EAF": 500.0, "DRI": 1_000_000.0},
+            {"EAF": REGION_CAPEX["EAF"], "DRI": REGION_CAPEX["DRI"]},
+            10_000.0,
+            {"EAF": bom},  # no BOM for the winning DRI switch
+            {"EAF": "scrap", "DRI": "scrap"},
+        ),
+    )
+
+    with pytest.raises(ValueError, match="BOM for technology DRI not found"):
+        evaluate(plant, plant_group)
+
+    assert plant_group.balance == 1_000_000.0
 
 
 def test_expired_fg_renovates_after_probabilistic_rejection(mocker):

--- a/tests/integration/test_furnace_strategy_expired_lifetime.py
+++ b/tests/integration/test_furnace_strategy_expired_lifetime.py
@@ -131,7 +131,7 @@ def test_expired_fg_renovates_when_switch_unaffordable(mocker):
     command = evaluate(plant, plant_group)
 
     assert isinstance(command, RenovateFurnaceGroup)
-    assert command.capex_no_subsidy == REGION_CAPEX["EAF"]
+    assert command.capex_no_subsidy == REGION_CAPEX["EAF"] * RENOVATION_SHARE["EAF"]
     assert plant_group.balance == 10_000.0 - RENOVATE_COST
 
 
@@ -155,9 +155,36 @@ def test_expired_fg_with_optimal_incumbent_renovates(mocker):
     command = evaluate(plant, plant_group)
 
     assert isinstance(command, RenovateFurnaceGroup)
-    assert command.capex == REGION_CAPEX["EAF"] / RENOVATION_SHARE["EAF"]
-    assert command.capex_no_subsidy == REGION_CAPEX["EAF"]
+    assert command.capex == REGION_CAPEX["EAF"]
+    assert command.capex_no_subsidy == REGION_CAPEX["EAF"] * RENOVATION_SHARE["EAF"]
     assert plant_group.balance == 1_000_000.0 - RENOVATE_COST
+
+
+def test_renovation_debt_basis_matches_evaluated_capex(mocker):
+    """Executing the renovation stores the evaluated renovation-basis capex as the debt basis.
+
+    Pins debt basis == NPV basis == equity basis: the capex carried on the command
+    (and stored by renovate_furnace_group) is the same share-adjusted value the NPV
+    was evaluated on and the treasury was debited against, not full greenfield.
+    """
+    plant, plant_group = make_plant_and_group(expired=True, balance=1_000_000.0)
+    mock_npvs(mocker, plant.furnace_groups[0], {"EAF": 1_000_000.0, "DRI": 500.0})
+
+    command = evaluate(plant, plant_group)
+    assert isinstance(command, RenovateFurnaceGroup)
+
+    plant.renovate_furnace_group(
+        furnace_group_id=command.furnace_group_id,
+        plant_lifetime=20,
+        capex=command.capex,
+        capex_no_subsidy=command.capex_no_subsidy,
+        cost_of_debt=command.cost_of_debt,
+        cost_of_debt_no_subsidy=command.cost_of_debt_no_subsidy,
+    )
+
+    furnace_group = plant.furnace_groups[0]
+    assert furnace_group.total_investment == command.capex * furnace_group.capacity
+    assert plant_group.balance == 1_000_000.0 - command.capex * furnace_group.capacity * furnace_group.equity_share
 
 
 def test_expired_fg_renovates_after_probabilistic_rejection(mocker):

--- a/tests/unit/test_add_furnace_group_handler.py
+++ b/tests/unit/test_add_furnace_group_handler.py
@@ -1,0 +1,98 @@
+"""Tests that expansion furnace groups are financed on the command's equity share.
+
+The AddFurnaceGroup handler must pass the evaluated equity_share through to the new
+furnace group; previously it was dropped, leaving the FurnaceGroup default (0.2) while
+the treasury was debited on the config value.
+"""
+
+from unittest.mock import MagicMock
+
+from steelo.devdata import get_furnace_group, get_plant
+from steelo.domain import Volumes
+from steelo.domain.commands import AddFurnaceGroup
+from steelo.service_layer.handlers import add_furnace_group_to_plant
+
+
+class _FakeUnitOfWork:
+    def __init__(self, plant, plant_group):
+        self.plants = MagicMock()
+        self.plants.get.return_value = plant
+        self.plant_groups = MagicMock()
+        self.plant_groups.get_by_plant_id.return_value = plant_group
+        self.committed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def commit(self):
+        self.committed = True
+
+
+def make_command(equity_share: float) -> AddFurnaceGroup:
+    return AddFurnaceGroup(
+        furnace_group_id="plant-1_new_furnace",
+        plant_id="plant-1",
+        technology_name="EAF",
+        capacity=100.0,
+        product="steel",
+        chosen_reductant="",
+        equity_share=equity_share,
+        equity_needed=400.0 * 100.0 * equity_share,
+        npv=1_000.0,
+        capex=400.0,
+        capex_no_subsidy=400.0,
+        cost_of_debt=0.05,
+        cost_of_debt_no_subsidy=0.05,
+        capex_subsidies=[],
+        debt_subsidies=[],
+    )
+
+
+def test_handler_passes_command_equity_share_to_new_furnace():
+    """The new furnace group is created with the command's equity share, not the default."""
+    plant = MagicMock()
+    plant.plant_id = "plant-1"
+    plant.added_capacity = Volumes(0)
+    plant_group = MagicMock()
+    uow = _FakeUnitOfWork(plant, plant_group)
+    env = MagicMock()
+    env.config.construction_time = 4
+    env.config.plant_lifetime = 20
+    env.dynamic_feedstocks = {}
+    cmd = make_command(equity_share=0.3)
+
+    add_furnace_group_to_plant(cmd, uow=uow, env=env)
+
+    assert plant.generate_new_furnace.call_args.kwargs["equity_share"] == 0.3
+    plant_group.deduct_equity.assert_called_once_with(cmd.equity_needed, reason="expansion")
+    assert uow.committed is True
+
+
+def test_generate_new_furnace_stores_equity_share():
+    """The factory forwards equity_share into the FurnaceGroup it builds."""
+    plant = get_plant(
+        plant_id="plant_equity_test",
+        furnace_groups=[get_furnace_group(fg_id="plant_equity_test_1")],
+    )
+
+    furnace_group = plant.generate_new_furnace(
+        technology_name="EAF",
+        product="steel",
+        current_year=2025,
+        capex=400.0,
+        capex_no_subsidy=400.0,
+        cost_of_debt=0.05,
+        cost_of_debt_no_subsidy=0.05,
+        capacity=100.0,
+        lag=4,
+        status="construction",
+        util_rate=0.0,
+        plant_lifetime=20,
+        chosen_reductant="",
+        equity_share=0.3,
+    )
+
+    assert furnace_group.equity_share == 0.3

--- a/tests/unit/test_change_furnace_group_technology_handler.py
+++ b/tests/unit/test_change_furnace_group_technology_handler.py
@@ -135,6 +135,7 @@ def test_deferred_switch_lands_with_the_committed_reductant():
         }
     )
     cmd.chosen_reductant = "natural_gas"
+    env.config.construction_time = 4
 
     execute_scheduled_technology_switch(cmd, uow=uow, env=env)
 
@@ -142,3 +143,30 @@ def test_deferred_switch_lands_with_the_committed_reductant():
     assert kwargs["chosen_reductant"] == "natural_gas"
     assert kwargs["technology_name"] == cmd.technology_name
     assert kwargs["bom"] is cmd.bom
+    # Legacy debt anchored to decision-time lifetime net of the construction window
+    assert kwargs["legacy_years"] == cmd.remaining_lifetime - 4
+
+
+def test_deferred_switch_at_boundary_carries_zero_legacy_years():
+    """A switch decided with less lifetime left than construction time books no legacy debt."""
+    from steelo.service_layer.handlers import execute_scheduled_technology_switch
+
+    plant = MagicMock()
+    plant.plant_id = "plant-1"
+    uow = _FakeUnitOfWork(plant)
+    env = MagicMock()
+    env.config.plant_lifetime = 20
+    env.config.construction_time = 4
+    env.dynamic_feedstocks = {}
+
+    cmd = _make_command(
+        bom={
+            "materials": {"io_low": {"demand": 1.0, "total_cost": 1.0, "unit_cost": 1.0, "product_volume": 1.0}},
+            "energy": {},
+        }
+    )
+    cmd.remaining_lifetime = 0
+
+    execute_scheduled_technology_switch(cmd, uow=uow, env=env)
+
+    assert plant.change_furnace_group_technology.call_args.kwargs["legacy_years"] == 0


### PR DESCRIPTION
Corrects PAM execution against what the decision evaluated.

- Deferred switches: anchor the old-debt tail to decision-time remaining lifetime and capture it once from `calculate_debt_repayment`, removing phantom legacy debt
- Store renovation-basis capex on renovation so it matches the evaluated NPV and equity debit
- Pass the command's `equity_share` to expansion furnace groups instead of the 0.2 default
- Route post-draw NPV <= 0 exits through `renovate_or_close_expired` for expired lifetimes
- Validate switch command inputs before deducting equity