### PR TITLE
Align PAM decision economics with execution

### DIFF
--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, NamedTuple, TypedDict, Any
+from typing import TYPE_CHECKING, NamedTuple, Sequence, TypedDict, Any
 import math
 
 from steelo.utilities.utils import normalize_name
@@ -939,7 +939,7 @@ def calculate_unit_production_cost(
 
 
 def calculate_gross_cash_flow(
-    total_opex: list[float], price_series: list[float], expected_production: float
+    total_opex: Sequence[float | None], price_series: list[float], expected_production: float
 ) -> list[float]:
     """
     Calculate the gross cash flow over multiple time steps.
@@ -947,21 +947,20 @@ def calculate_gross_cash_flow(
     Computes cash flow as (revenue - operating costs) for each period.
 
     Args:
-        total_opex (list[float]): List of unit total operating expenditures per time step ($/unit).
+        total_opex (Sequence[float | None]): Unit total operating expenditures per time step ($/unit).
+            None marks a non-producing period (e.g. construction) with zero cash flow; a 0.0 entry
+            is a genuine zero-cost operating year and earns full revenue.
         price_series (list[float]): The market price per unit product per time step ($/unit).
         expected_production (float): The production volume per period (units/period).
 
     Returns:
         list[float]: A list of gross cash flows for each period ($/period).
-
-    Note:
-        - When OPEX is 0 (e.g., no production), cash flow is set to 0 rather than calculating revenue.
     """
     gross_cash_flow: list[float] = []
     # Calculate cash flow for each period
     for i, unit_total_opex_per_year in enumerate(total_opex):
-        # If no operating costs, no production is occurring
-        if unit_total_opex_per_year == 0:
+        # None marks a non-producing period (construction mask)
+        if unit_total_opex_per_year is None:
             cash_flow = 0.0
         else:
             # Cash flow = (price - cost) * production volume
@@ -1123,10 +1122,9 @@ def calculate_npv_full(
         total_investment=total_investment, equity_share=equity_share, lifetime=lifetime, cost_of_debt=cost_of_debt
     )
 
-    # Apply construction time lag to debt repayments and OPEX
-    zeros = [0.0] * construction_time
-    debt_repayment_lagged = zeros + debt_repayment
-    unit_opex_lagged = zeros + unit_total_opex_list
+    # Apply construction time lag to debt repayments and OPEX (None masks the non-producing construction years)
+    debt_repayment_lagged = [0.0] * construction_time + debt_repayment
+    unit_opex_lagged: list[float | None] = [None] * construction_time + list(unit_total_opex_list)
 
     if expected_production == 0:
         func_logger.warning("[NPV FULL] Expected production is zero.")
@@ -1161,6 +1159,7 @@ def stranding_asset_cost(
     market_price_series: list[float],
     expected_production: float,
     cost_of_equity: float,
+    construction_time: int = 0,
 ) -> float:
     """
     Calculate the Cost of Stranded Asset (COSA) when switching technologies.
@@ -1169,11 +1168,14 @@ def stranding_asset_cost(
     asset would have earned over its remaining life. The remaining debt is deliberately excluded —
     it is owed whether the agent stays or switches (it persists post-switch via the legacy-debt
     schedule), so it cancels from the switch-vs-stay comparison and must not be charged here.
+    A deferred switch keeps the incumbent operating through the construction window, so those
+    years' margin is not foregone either — only years [construction_time, remaining_time) are
+    charged, at their original discount positions.
 
     Steps:
-    1. Extract OPEX and prices for the remaining asset lifetime
-    2. Calculate gross cash flow (revenue - OPEX) for remaining periods
-    3. Discount the gross cash flow to present value using cost of equity
+    1. Extract OPEX and prices for the genuinely foregone years [construction_time, remaining_time)
+    2. Calculate gross cash flow (revenue - OPEX) for those periods
+    3. Discount to present value using cost of equity, keeping discount exponents aligned
 
     Args:
         unit_total_opex_list (list[float]): Yearly unit total OPEX expenditures ($/unit).
@@ -1181,31 +1183,38 @@ def stranding_asset_cost(
         market_price_series (list[float]): Market price per unit product per year ($/unit).
         expected_production (float): Production volume per period (units/period).
         cost_of_equity (float): Annual cost of equity as discount rate (e.g., 0.08 for 8%).
+        construction_time (int): Years the incumbent keeps operating after a switch decision
+            before the new technology takes over. Defaults to 0 (charge the full remainder).
 
     Returns:
-        float: The NPV of the foregone operating margin (COSA). Negative for a loss-making
-        incumbent, which correctly rewards exit.
+        float: The NPV of the foregone operating margin (COSA). Zero when the construction
+        window covers the whole remainder; negative for a loss-making incumbent, which
+        correctly rewards exit.
     """
     # Use function-specific logger that respects the centralized configuration
     func_logger = logging.getLogger(f"{__name__}.stranding_asset_cost")
 
-    # Extract remaining time periods (first N years of OPEX/prices)
-    remaining_opex = unit_total_opex_list[:remaining_time]
-    remaining_price_series = market_price_series[:remaining_time]
+    # Only years after the construction window are foregone
+    remaining_opex = unit_total_opex_list[construction_time:remaining_time]
+    remaining_price_series = market_price_series[construction_time:remaining_time]
 
     # Foregone operating margin: gross cash flow from operations for the remaining periods
     gross_cash_flow = calculate_gross_cash_flow(remaining_opex, remaining_price_series, expected_production)
 
+    # Zero-pad the construction years so discount exponents stay anchored to today
+    lost_cash_flow = [0.0] * construction_time + gross_cash_flow
+
     # Log all intermediate calculations together for easier debugging
     func_logger.debug(
-        f"[STRANDING ASSET COST] Remaining time: {remaining_time}, Expected production: {expected_production:,.0f} kt"
+        f"[STRANDING ASSET COST] Remaining time: {remaining_time}, Construction time: {construction_time}, "
+        f"Expected production: {expected_production:,.0f} kt"
     )
     func_logger.debug(f"[STRANDING ASSET COST] Price per unit per year ($/t): {market_price_series}")
     func_logger.debug(f"[STRANDING ASSET COST] Remaining unit total OPEX: {remaining_opex}")
     func_logger.debug(f"[STRANDING ASSET COST] Gross cash flow (foregone margin): {gross_cash_flow}")
 
     # Discount the foregone operating margin to present value
-    return calculate_cost_of_stranded_asset(gross_cash_flow, cost_of_equity)
+    return calculate_cost_of_stranded_asset(lost_cash_flow, cost_of_equity)
 
 
 def calculate_business_opportunity_npvs(

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -2452,6 +2452,7 @@ class FurnaceGroup:
             market_price_series=market_price_series[self.technology.product],
             expected_production=self.production,
             cost_of_equity=incumbent_cost_of_equity,
+            construction_time=construction_time,
         )
 
         logger.debug(f"[OPTIMAL TECH] COSA (foregone operating margin): ${cosa:,.0f}")
@@ -2491,13 +2492,16 @@ class FurnaceGroup:
                 logger.info("[OPTIMAL TECH] SKIPPING BOF - Plant has no smelter furnace (required for BOF)")
                 continue
 
+            # current tech renovates in place and keeps producing, so its NPV carries no construction lag
+            tech_construction_time = 0 if tech == self.technology.name else construction_time
+
             # Collect all active subsidies for this technology
             capex_subsidies = filter_subsidies_for_year(tech_capex_subsidies.get(tech, []), current_year)
             debt_subsidies = filter_subsidies_for_year(tech_debt_subsidies.get(tech, []), current_year)
             opex_subsidies = collect_active_subsidies_over_period(
                 tech_opex_subsidies.get(tech, []),
-                start_year=Year(current_year + construction_time),
-                end_year=Year(current_year + construction_time + plant_lifetime),
+                start_year=Year(current_year + tech_construction_time),
+                end_year=Year(current_year + tech_construction_time + plant_lifetime),
             )
 
             # Apply subsidies to capex
@@ -2617,8 +2621,8 @@ class FurnaceGroup:
 
                 # Year-wise reductant-optimised score over the operating window; the NPV's
                 # energy, carbon and by-product terms all live inside this series
-                operating_start = Year(current_year + construction_time)
-                operating_end = Year(current_year + construction_time + plant_lifetime)
+                operating_start = Year(current_year + tech_construction_time)
+                operating_end = Year(current_year + tech_construction_time + plant_lifetime)
                 score_series = score_series_for_tech(tech, output_shares, operating_start, operating_end)
                 committed_reductant = score_series.picks[0] if score_series.picks else ""
                 if tech != self.technology.name and committed_reductant != reductant:
@@ -2687,7 +2691,7 @@ class FurnaceGroup:
                     expected_utilisation_rate=util_rate,
                     price_series=product_price_series,
                     lifetime=plant_lifetime,
-                    construction_time=construction_time,
+                    construction_time=tech_construction_time,
                     cost_of_debt=cost_of_debt,
                     cost_of_equity=cost_of_equity,
                     equity_share=self.equity_share,
@@ -5358,6 +5362,11 @@ class PlantGroup:
                         f"No greenfield capex data for {tech} in region {iso3_to_region_map[plant.location.iso3]}"
                     )
 
+                # Apply CAPEX subsidies before the affordability pre-filter
+                all_capex_subsidies = collect_subsidies_for_geo(capex_subsidies, plant.location.geo_key).get(tech, [])
+                selected_capex_subsidies = cc.filter_subsidies_for_year(all_capex_subsidies, current_year)
+                capex = cc.calculate_capex_with_subsidies(capex, selected_capex_subsidies)
+
                 # Skip if the group treasury cannot cover equity for this (plant, tech)
                 num_pairs_evaluated += 1
                 equity_needed_for_tech = capex * capacity * equity_share
@@ -5470,13 +5479,7 @@ class PlantGroup:
                     collect_active_subsidies_over_period,
                 )
 
-                # CAPEX subsidies (country-wide rows plus the plant's province rows, if any)
-                all_capex_subsidies = collect_subsidies_for_geo(capex_subsidies, plant.location.geo_key).get(tech, [])
-                selected_capex_subsidies = filter_subsidies_for_year(all_capex_subsidies, current_year)
-                original_capex = capex
-                capex = cc.calculate_capex_with_subsidies(original_capex, selected_capex_subsidies)
-
-                # Debt subsidies
+                # Debt subsidies (CAPEX subsidies were already applied above the affordability pre-filter)
                 all_debt_subsidies = collect_subsidies_for_geo(debt_subsidies, plant.location.geo_key).get(tech, [])
                 selected_debt_subsidies = filter_subsidies_for_year(all_debt_subsidies, current_year)
                 cost_of_debt = cc.calculate_debt_with_subsidies(

--- a/tests/integration/test_expansion_with_capex_subsidies.py
+++ b/tests/integration/test_expansion_with_capex_subsidies.py
@@ -460,6 +460,83 @@ def test_evaluate_expansion_with_combined_subsidies(
         assert abs(capex_with_subsidy - expected_capex) < 0.01
 
 
+def test_prefilter_affordability_uses_subsidised_capex(
+    setup_environment, plant_with_location, mocker, country_mappings_for_test
+):
+    """A technology affordable only thanks to its capex subsidy survives the pre-filter.
+
+    Regression for the unsubsidised pre-filter: with balance between the subsidised
+    and unsubsidised equity requirement, the option was dropped before NPV ranking —
+    exactly the policy-supported techs the subsidy is meant to enable.
+    """
+    bus = setup_environment
+    bus.uow.plants.add(plant_with_location)
+
+    pg = PlantGroup(plant_group_id="pg_test", plants=[plant_with_location])
+    # Unsubsidised equity: 400 × 1000 × 0.4 = 160,000; with the 50% subsidy: 80,000
+    pg.balance = 100_000.0
+    bus.uow.plant_groups.add(pg)
+
+    def mock_get_bom(energy_costs, tech, capacity, most_common_reductant=None):
+        return (
+            {
+                "materials": {"scrap": {"unit_cost": 100.0, "demand": 1.0}},
+                "energy": {"electricity": {"unit_cost": 50.0, "demand": 0.5}},
+            },
+            0.8,
+            "scrap",
+            {"scrap": 1.0},
+        )
+
+    mocker.patch.object(bus.env, "get_bom_from_avg_boms", side_effect=mock_get_bom)
+
+    eaf_subsidy = Subsidy(
+        scenario_name="test_scenario",
+        technology_name="EAF",
+        iso3="USA",
+        cost_item="capex",
+        subsidy_type="relative",
+        subsidy_amount=0.5,
+        start_year=Year(2020),
+        end_year=Year(2030),
+    )
+
+    price = {"steel": [600.0] * 22, "iron": [400.0] * 22}
+    allowed_techs = {Year(year): ["EAF"] for year in range(2020, 2031)}
+
+    options = pg.evaluate_expansion_options(
+        price_series=price,
+        capacity=Volumes(1000),
+        region_capex=bus.env.name_to_capex["greenfield"],
+        cost_of_debt_dict=bus.env.cost_of_debt_by_tech,
+        cost_of_equity_dict=bus.env.cost_of_equity_by_tech,
+        get_bom_from_avg_boms=bus.env.get_bom_from_avg_boms,
+        reductant_score_series=_stub_score_series,
+        dynamic_feedstocks=bus.env.dynamic_feedstocks,
+        fopex_for_iso3=bus.env.fopex_by_country,
+        iso3_to_region_map=country_mappings_for_test.iso3_to_region(),
+        chosen_emissions_boundary_for_carbon_costs=bus.env.config.chosen_emissions_boundary_for_carbon_costs,
+        tech_to_product=bus.env.technology_to_product,
+        plant_lifetime=bus.env.config.plant_lifetime,
+        construction_time=2,
+        technology_emission_factors=bus.env.technology_emission_factors,
+        global_risk_free_rate=bus.env.global_risk_free_rate,
+        equity_share=0.4,
+        current_year=bus.env.year,
+        allowed_techs=allowed_techs,
+        active_statuses=["operating"],
+        capex_subsidies={"USA": {"EAF": [eaf_subsidy]}},
+        opex_subsidies={},
+        debt_subsidies={},
+    )
+
+    plant_id = plant_with_location.plant_id
+    assert plant_id in options, "Subsidised EAF should survive the affordability pre-filter"
+    npv, best_tech, capex_with_subsidy, _reductant = options[plant_id]
+    assert best_tech == "EAF"
+    assert capex_with_subsidy == 200.0
+
+
 def test_evaluate_expansion_with_restricted_allowed_techs(
     setup_environment, plant_with_location, mocker, country_mappings_for_test
 ):

--- a/tests/unit/test_calculate_costs.py
+++ b/tests/unit/test_calculate_costs.py
@@ -441,12 +441,12 @@ def test_npv_flow_wrapper(mocker, technology, material_bill):  # FIXME: This tes
     total_investment = capex * capacity
     debt_repayment = calculate_debt_repayment(total_investment, equity_share=0.2, lifetime=20, cost_of_debt=0.05)
 
-    # Add construction time lag to match calculate_npv_full behavior
+    # Add construction time lag to match calculate_npv_full behavior:
+    # None masks the non-producing construction years, debt lags with zeros
     construction_time = 2
-    zeros = [0.0] * construction_time
-    debt_repayment_lagged = zeros + debt_repayment
+    debt_repayment_lagged = [0.0] * construction_time + debt_repayment
     Opex_list = [unit_fopex + unit_vopex] * len(debt_repayment)
-    Opex_list_lagged = zeros + Opex_list
+    Opex_list_lagged = [None] * construction_time + Opex_list
 
     gross_cash_flow = calculate_gross_cash_flow(
         total_opex=Opex_list_lagged, price_series=[price] * len(Opex_list_lagged), expected_production=float(80)
@@ -541,6 +541,73 @@ def test_stranding_asset_cost_loss_making_incumbent_is_negative():
     )
 
     assert cosa < 0
+
+
+def test_stranding_asset_cost_zero_when_construction_window_covers_remainder():
+    """A deferred switch keeps the incumbent running through construction, so a
+    remainder no longer than the construction window forgoes no margin at all.
+
+    Args/Returns/Notes:
+        Regression for the boundary anti-switch bias: COSA previously charged the
+        full remainder even though the incumbent keeps earning it.
+    """
+    cosa = stranding_asset_cost(
+        [200] * 20,
+        4,
+        [600] * 20,
+        expected_production=80.0,
+        cost_of_equity=0.05,
+        construction_time=4,
+    )
+
+    assert cosa == 0.0
+
+
+def test_stranding_asset_cost_charges_only_post_construction_years():
+    """With remaining=6 and construction=4, only years 5 and 6 are foregone, at
+    their original discount positions (t=5 and t=6)."""
+    margin = (600 - 200) * 80.0
+    expected = margin / 1.05**5 + margin / 1.05**6
+
+    cosa = stranding_asset_cost(
+        [200] * 20,
+        6,
+        [600] * 20,
+        expected_production=80.0,
+        cost_of_equity=0.05,
+        construction_time=4,
+    )
+
+    assert cosa == pytest.approx(expected)
+
+
+def test_gross_cash_flow_zero_opex_year_earns_full_revenue():
+    """A genuinely zero-cost operating year (e.g. 100% OPEX subsidy) earns full
+    revenue; only a None entry masks a non-producing construction year."""
+    gross = calculate_gross_cash_flow([0.0, None, 100.0], [600.0, 600.0, 600.0], expected_production=80.0)
+
+    assert gross[0] == 600.0 * 80.0
+    assert gross[1] == 0.0
+    assert gross[2] == (600.0 - 100.0) * 80.0
+
+
+def test_npv_full_counts_revenue_of_fully_subsidised_opex_years():
+    """calculate_npv_full no longer conflates 0.0 opex with the construction mask:
+    an all-zero opex list (fully subsidised) yields a strongly positive NPV."""
+    npv = calculate_npv_full(
+        capex=400.0,
+        capacity=100.0,
+        unit_total_opex_list=[0.0] * 20,
+        expected_utilisation_rate=0.8,
+        price_series=[600.0] * 24,
+        lifetime=20,
+        construction_time=4,
+        cost_of_debt=0.05,
+        cost_of_equity=0.08,
+        equity_share=0.2,
+    )
+
+    assert npv > 0
 
 
 @pytest.mark.skip(reason="derive_best_technology_switch function was removed")

--- a/tests/unit/test_renovation_npv_no_construction_lag.py
+++ b/tests/unit/test_renovation_npv_no_construction_lag.py
@@ -1,0 +1,118 @@
+"""Tests that the incumbent's renovation NPV carries no construction lag.
+
+Renovation executes instantaneously (lifetime restarts, status stays operating,
+production continues), so its NPV must not zero the first construction_time years
+the way greenfield challengers do.
+"""
+
+from datetime import date
+
+import pytest
+
+from steelo.domain.calculate_costs import (
+    ReductantScoreSeries,
+    calculate_npv_full,
+    calculate_unit_total_opex,
+    calculate_variable_opex,
+    scale_fopex_to_production,
+)
+from steelo.domain.models import FurnaceGroup, PointInTime, Technology, Year
+
+BOM = {
+    "materials": {"scrap": {"unit_cost": 200.0, "demand": 1.1}},
+    "energy": {"electricity": {"unit_cost": 80.0, "demand": 0.5}},
+}
+CAPEX = 400.0
+RENOVATION_SHARE = 0.7
+UNIT_FOPEX = 50.0
+UTILISATION = 0.8
+PRICES = [600.0] * 30
+
+
+def _flat_score_series(tech, output_shares, start, end):
+    n = int(end) - int(start)
+    return ReductantScoreSeries(scores=[0.0] * n, picks=[""] * n)
+
+
+def make_furnace_group() -> FurnaceGroup:
+    """Build an operating EAF furnace group with a valid BOM for renovation pricing."""
+    furnace_group = FurnaceGroup(
+        furnace_group_id="fg_renovation_lag",
+        capacity=100_000,
+        status="operating",
+        last_renovation_date=date(2015, 1, 1),
+        technology=Technology(name="EAF", product="steel"),
+        historical_production={},
+        utilization_rate=UTILISATION,
+        lifetime=PointInTime(plant_lifetime=20, current=Year(2025)),
+        chosen_reductant="",
+        energy_cost_dict={},
+    )
+    furnace_group.bill_of_materials = BOM
+    return furnace_group
+
+
+def evaluate_incumbent_npv(furnace_group: FurnaceGroup, construction_time: int) -> float:
+    """Run optimal_technology_name restricted to the incumbent and return its NPV."""
+    npv_dict, _, _, _, _ = furnace_group.optimal_technology_name(
+        market_price_series={"steel": PRICES, "iron": [400.0] * 30},
+        cost_of_debt_by_tech={"EAF": 0.05},
+        cost_of_equity_by_tech={"EAF": 0.1},
+        get_bom_from_avg_boms=None,
+        score_series_for_tech=_flat_score_series,
+        capex_dict={"EAF": CAPEX},
+        capex_renovation_share={"EAF": RENOVATION_SHARE},
+        technology_fopex_dict={"eaf": UNIT_FOPEX},
+        dynamic_business_cases={},
+        chosen_emissions_boundary_for_carbon_costs="Scope 1",
+        technology_emission_factors=[],
+        tech_to_product={"EAF": "steel"},
+        plant_lifetime=20,
+        construction_time=construction_time,
+        current_year=Year(2025),
+        risk_free_rate=0.02,
+        allowed_furnace_transitions={"EAF": ["EAF"]},
+    )
+    return npv_dict["EAF"]
+
+
+def test_incumbent_npv_invariant_to_construction_time():
+    """The renovation NPV must be identical whether construction_time is 4 or 0.
+
+    Notes:
+        Regression for the phantom construction delay: the incumbent's first
+        construction_time years of cash flow were zeroed and everything shifted
+        out, understating renovation against challengers and closing marginal
+        but viable groups at the boundary.
+    """
+    npv_lagged = evaluate_incumbent_npv(make_furnace_group(), construction_time=4)
+    npv_instant = evaluate_incumbent_npv(make_furnace_group(), construction_time=0)
+
+    assert npv_lagged == pytest.approx(npv_instant)
+
+
+def test_incumbent_npv_matches_direct_lag_free_calculation():
+    """The incumbent's NPV equals calculate_npv_full at renovation-basis capex with
+    construction_time=0 (production from year one)."""
+    furnace_group = make_furnace_group()
+    npv = evaluate_incumbent_npv(furnace_group, construction_time=4)
+
+    unit_opex = calculate_unit_total_opex(
+        unit_fopex=scale_fopex_to_production(UNIT_FOPEX, UTILISATION),
+        unit_vopex=calculate_variable_opex(BOM["materials"], {}),
+        utilization_rate=UTILISATION,
+    )
+    expected = calculate_npv_full(
+        capex=CAPEX * RENOVATION_SHARE,
+        capacity=furnace_group.capacity,
+        unit_total_opex_list=[unit_opex] * 20,
+        expected_utilisation_rate=UTILISATION,
+        price_series=PRICES,
+        lifetime=20,
+        construction_time=0,
+        cost_of_debt=0.05,
+        cost_of_equity=0.1,
+        equity_share=furnace_group.equity_share,
+    )
+
+    assert npv == pytest.approx(expected)


### PR DESCRIPTION
- COSA charges only post-construction years; the incumbent keeps its margin through the construction window
- The incumbent's renovation NPV drops the construction lag, matching instantaneous renovation in execution
- Expansion affordability pre-filter gates on subsidised capex, matching the Stage-6 check and the debit
- Construction years are masked with `None` in the NPV, so a fully subsidised zero-opex year keeps its revenue