### PR TITLE
Gate greenfield top-opportunity selection on probabilistic_agents

### DIFF
--- a/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
+++ b/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
@@ -5,7 +5,7 @@
 The new plant opening system transforms candidate locations into actual steel and iron plants through a multi-year business opportunity lifecycle. Companies identify promising locations, track their economic viability over time, announce viable projects, and eventually construct new facilities -all while accounting for uncertainty, capacity constraints, and changing market conditions.
 
 Business opportunities progress through the following stages:
-- **CONSIDERED**: Top location-technology pairs are identified based on NPV calculations and selected using weighted random sampling. Its NPV is recalculated annually with updated costs for several years; opportunities with consistently positive NPV advance to announcement (subject to probability filter), while consistently negative NPV leads to discard.
+- **CONSIDERED**: Top location-technology pairs are identified based on NPV calculations and selected using weighted random sampling (or, when `probabilistic_agents` is disabled, deterministically by highest NPV — see [Business Opportunity Identification](#business-opportunity-identification)). Its NPV is recalculated annually with updated costs for several years; opportunities with consistently positive NPV advance to announcement (subject to probability filter), while consistently negative NPV leads to discard.
 - **ANNOUNCED**: Project waits for construction start; dynamic costs continue to be updated annually; advancement to construction depends on technology remaining allowed, capacity limits, and probability filter.
 - **CONSTRUCTION**: Plant is being built over several years (handled by the plant agent model).
 - **OPERATING**: Plant is operational and removed from business opportunity tracking (fully handled by the plant agent model).
@@ -148,9 +148,9 @@ Filters technologies based on what will be allowed at the earliest possible cons
 Randomly samples a subset of top priority locations to reduce computational burden, since NPV calculations are resource-intensive.
 
 **Configuration:**
-- `calculate_npv_pct`: Percentage of locations to evaluate (default: 10%) out of the top X% extracted by the location priority selection (default: 5% of the world; see related documentation in [Priority Location Selection](priority_location_selection.md)). 
+- `calculate_npv_pct`: Percentage of locations to evaluate (default: 10%) out of the top X% extracted by the location priority selection (default: 5% of the world; see related documentation in [Priority Location Selection](priority_location_selection.md)).
 
-**Purpose:** Balance computational efficiency with coverage of good opportunities. Sampling 10% of 1000 candidate locations means evaluating 100 instead of all 1000.
+**Purpose:** Balance computational efficiency with coverage of good opportunities. Sampling 10% of 1000 candidate locations means evaluating 100 instead of all 1000. This step keeps its non-deterministic behavior for runtime efficiency — evaluating every candidate measured ~7x slower — since it is not thematically related to `probabilistic_agents`, which governs assessment of already-identified opportunities, not candidate selection.
 
 ### Step 3: Cost Data Preparation
 
@@ -203,16 +203,20 @@ Subsidies are often announced years before plants are built. Standard NPV using 
 
 **Function:** `select_top_opportunities_by_npv()`
 
-Selects top N location-technology combinations using **weighted random sampling** (instead of pure NPV ranking) to represent some randomness in human decision-making. Pure ranking would always select the absolute highest NPV locations. In reality, companies have geographic preferences, imperfect information, varying risk tolerance, and strategic considerations. Weighted random sampling ensures diversity while still strongly favoring high-NPV options.
+When `probabilistic_agents` is enabled (default), selects top N location-technology combinations using **rank-weighted random sampling** (instead of pure NPV ranking) to represent some randomness in human decision-making. Pure ranking would always select the absolute highest NPV locations. In reality, companies have geographic preferences, imperfect information, varying risk tolerance, and strategic considerations. Weighted random sampling ensures diversity while still strongly favoring high-NPV options. When `probabilistic_agents` is disabled, this step instead deterministically picks the top N by NPV — no random draw at all.
 
-**Process:**
+**Process (probabilistic_agents enabled):**
 - Filter out invalid NPVs (NaN or negative infinity from calculation failures)
-- Create weights from NPV values (shift negative NPVs to make all weights non-negative)
-- Normalize weights to probabilities
-- Randomly select top N opportunities with probability proportional to NPV
+- Rank valid candidates by NPV and trim to the best 3N (implausible sites can never be selected, regardless of NPV scale)
+- Assign linearly decreasing rank weights over the trimmed pool (best gets weight 3N, worst gets weight 1) and normalize to probabilities
+- Randomly draw N opportunities from the trimmed pool without replacement, with probability proportional to rank weight
 - If fewer valid pairs exist than requested, select all valid pairs
 
-**Purpose:** Creates geographic diversity in opportunities while maintaining economic rationality. Higher NPV opportunities have much higher selection probability, but mid-tier opportunities can also be selected.
+**Process (probabilistic_agents disabled):**
+- Filter out invalid NPVs (NaN or negative infinity from calculation failures)
+- Select the top N valid candidates by NPV directly
+
+**Purpose:** Creates geographic diversity in opportunities while maintaining economic rationality. Higher NPV opportunities have much higher selection probability, but mid-tier opportunities can also be selected. Disabling `probabilistic_agents` trades this realism for full determinism and reproducibility across runs/seeds.
 
 ## Business Opportunity Tracking
 **Function:** `update_status_of_business_opportunities()`
@@ -302,14 +306,15 @@ Models real-world risk factors: financing may fall through, permits may be denie
 | `plant_lifetime` | int | 20 years | Expected operational lifetime of plant |
 | `expanded_capacity` | float | 2.5 Mt/year | Standard capacity for new plants (same than for plant expansion) |
 | `top_n_loctechs_as_business_op` | int | 5 | Number of opportunities to track per product per year |
-| `calculate_npv_pct` | float | 0.1 | Percentage of priority locations to sample for NPV calculation (fixed) |
+| `calculate_npv_pct` | float | 0.1 | Percentage of priority locations to sample for NPV calculation (fixed; not gated by `probabilistic_agents` — evaluating all measured ~7x slower) |
 
 ### Probability Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `probability_of_announcement` | float | 0.7 | Chance viable opportunity is announced |
-| `probability_of_construction` | float | 0.9 | Chance announced project starts construction |
+| `probabilistic_agents` | bool | True | When True, Step 5 draws a rank-weighted mix of top opportunities; when False, Step 5 picks the top N by NPV deterministically. Does not affect Step 2's `calculate_npv_pct` sampling (kept probabilistic for runtime — see above) |
+| `probability_of_announcement` | float | 0.7 | Chance viable opportunity is announced. Forced to 1.0 when `probabilistic_agents` is False |
+| `probability_of_construction` | float | 0.9 | Chance announced project starts construction. Forced to 1.0 when `probabilistic_agents` is False |
 
 ### Capacity Limits
 

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -5997,6 +5997,7 @@ class PlantGroup:
         get_co2_need_by_name: Callable[[str, float, str], float] | None = None,
         co2_storage_diagnostics: Callable[[str, int], tuple[float, float, float]] | None = None,
         derive_geo_unit: Callable[[float, float, str], str | None] | None = None,
+        probabilistic_agents: bool = True,
     ) -> commands.Command:
         """
         Identifies new business opportunities for plants at given locations with specific technologies.
@@ -6049,6 +6050,11 @@ class PlantGroup:
             energy_subsidies: Dictionary mapping carrier -> iso3 -> tech -> list of energy subsidies
             derive_geo_unit: Optional ``(lat, lon, iso3) -> geo_unit | None`` derivation (injected
                 from the geospatial adapter) tagging each spawned plant's sub-national unit
+            probabilistic_agents: If True (default), step 5 draws a rank-weighted mix of top
+                opportunities. If False, step 5 deterministically picks the top N by NPV. Step 2's
+                location sampling is unaffected by this flag (measured ~7x runtime cost to evaluate
+                all candidates deterministically was judged not worth it — see
+                docs/domain_simulation_logic/geospatial_model/new_plant_opening.md).
 
         Returns:
             Command to add new Plant and FurnaceGroup objects for the identified business opportunities
@@ -6199,6 +6205,7 @@ class PlantGroup:
         top_business_opportunities = select_top_opportunities_by_npv(
             npv_dict=npv_dict,
             top_n_loctechs_as_business_op=top_n_loctechs_as_business_op,
+            probabilistic_agents=probabilistic_agents,
         )
         selected_counts, selected_total = _count_entries(top_business_opportunities)
         candidate_stats["selected_pairs_total"] = selected_total

--- a/src/steelo/domain/new_plant_opening.py
+++ b/src/steelo/domain/new_plant_opening.py
@@ -615,13 +615,18 @@ def validate_and_clean_cost_data(
 def select_top_opportunities_by_npv(
     npv_dict: dict[str, dict[Any, dict[str, float]]],
     top_n_loctechs_as_business_op: int,
+    probabilistic_agents: bool,
 ) -> dict[str, dict[tuple[float, float, str], dict[str, float]]]:
     """
-    Select top location-technology combinations with high NPVs using weighted random sampling to ensure mix of opportunities.
+    Select top location-technology combinations with high NPVs. When probabilistic_agents is True,
+    uses weighted random sampling to ensure a mix of opportunities; when False, picks the top N
+    by NPV deterministically.
 
     Args:
         npv_dict: Nested dictionary with NPV values (product -> site_id -> tech -> NPV)
         top_n_loctechs_as_business_op: Number of top location-technology combinations to select per product
+        probabilistic_agents: If True, rank-weighted random draw over the top 3N candidates (deliberate
+            realism - a mix of high and medium NPV options). If False, deterministic top-N by NPV.
 
     Returns:
         Dictionary mapping products to site IDs to technologies with their NPVs (product -> site_id (lat, lon, iso3) -> tech -> NPV)
@@ -635,17 +640,23 @@ def select_top_opportunities_by_npv(
 
     Notes:
         - Invalid NPV values (NaN, -inf) are removed before processing
-        - Candidates are ranked by NPV and only the best 3N enter a weighted draw with
-          linearly decreasing rank weights - a mix of high and medium NPV options rather
-          than only the highest, while implausible sites can never be selected
+        - When probabilistic_agents: candidates are ranked by NPV and only the best 3N enter a
+          weighted draw with linearly decreasing rank weights - a mix of high and medium NPV
+          options rather than only the highest, while implausible sites can never be selected
         - Rank weights are scale-free: the draw behaves identically for all-negative,
           mixed and all-positive pools
     """
     logger = logging.getLogger(f"{__name__}.select_top_opportunities_by_npv")
-    logger.info(
-        f"[NEW PLANTS] Drawing {top_n_loctechs_as_business_op} location-technology combinations per product from the "
-        f"top {3 * top_n_loctechs_as_business_op} by NPV (rank-weighted, without replacement)."
-    )
+    if probabilistic_agents:
+        logger.info(
+            f"[NEW PLANTS] Drawing {top_n_loctechs_as_business_op} location-technology combinations per product from the "
+            f"top {3 * top_n_loctechs_as_business_op} by NPV (rank-weighted, without replacement)."
+        )
+    else:
+        logger.info(
+            f"[NEW PLANTS] Selecting the top {top_n_loctechs_as_business_op} location-technology combinations "
+            "per product by NPV (deterministic)."
+        )
     top_business_opportunities: dict[str, dict[tuple[float, float, str], dict[str, float]]] = {}
 
     # Collect all valid (site_id, tech) pairs with their NPVs. Valid NPVs are those that are not NaN or -inf.
@@ -676,25 +687,34 @@ def select_top_opportunities_by_npv(
                 f"NPV dict for {product}: {npv_dict.get(product, {})}"
             )
 
-        # Trim to the plausible head of the pool, then draw with rank weights (best gets
-        # weight `trim`, worst weight 1). The former shift-by-min weighting degenerated
-        # to a near-uniform draw whenever the whole pool was negative.
         npvs_array = np.array(valid_npvs)
         ranked_indices = np.argsort(npvs_array)[::-1]
-        trim = min(len(ranked_indices), 3 * top_n_loctechs_as_business_op)
-        pool_indices = ranked_indices[:trim]
 
-        if trim > top_n_loctechs_as_business_op:
-            rank_weights = np.arange(trim, 0, -1, dtype=float)
-            probabilities = rank_weights / rank_weights.sum()
-            drawn = np.random.choice(trim, size=top_n_loctechs_as_business_op, replace=False, p=probabilities)
-            selected_pairs = [valid_pairs[pool_indices[i]] for i in drawn]
+        if probabilistic_agents:
+            # Trim to the plausible head of the pool, then draw with rank weights (best gets
+            # weight `trim`, worst weight 1). The former shift-by-min weighting degenerated
+            # to a near-uniform draw whenever the whole pool was negative.
+            trim = min(len(ranked_indices), 3 * top_n_loctechs_as_business_op)
+            pool_indices = ranked_indices[:trim]
+
+            if trim > top_n_loctechs_as_business_op:
+                rank_weights = np.arange(trim, 0, -1, dtype=float)
+                probabilities = rank_weights / rank_weights.sum()
+                drawn = np.random.choice(trim, size=top_n_loctechs_as_business_op, replace=False, p=probabilities)
+                selected_pairs = [valid_pairs[pool_indices[i]] for i in drawn]
+            else:
+                selected_pairs = [valid_pairs[i] for i in pool_indices]
+            logger.info(
+                f"[NEW PLANTS] {product}: drew {len(selected_pairs)} of {len(valid_pairs)} valid candidates "
+                f"(rank-weighted over the top {trim})."
+            )
         else:
-            selected_pairs = [valid_pairs[i] for i in pool_indices]
-        logger.info(
-            f"[NEW PLANTS] {product}: drew {len(selected_pairs)} of {len(valid_pairs)} valid candidates "
-            f"(rank-weighted over the top {trim})."
-        )
+            top_indices = ranked_indices[:top_n_loctechs_as_business_op]
+            selected_pairs = [valid_pairs[i] for i in top_indices]
+            logger.info(
+                f"[NEW PLANTS] {product}: selected top {len(selected_pairs)} of {len(valid_pairs)} valid candidates "
+                "by NPV (deterministic)."
+            )
 
         # Format selected (site, tech) pairs into business opportunities dict
         top_business_opportunities[product] = {}

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -293,6 +293,7 @@ class GeospatialModel:
                 get_co2_need_by_name=bus.env.get_co2_need_by_name,
                 co2_storage_diagnostics=bus.env.co2_storage_diagnostics,
                 derive_geo_unit=derive_geo_unit_for_site,
+                probabilistic_agents=bus.env.config.probabilistic_agents,
             )
         )
         step_time = time.time() - step_start

--- a/tests/unit/test_identify_new_business_opportunities_4indi.py
+++ b/tests/unit/test_identify_new_business_opportunities_4indi.py
@@ -152,6 +152,40 @@ class TestSelectLocationSubset:
         assert len(subset["steel"]) == 0
         assert len(subset["iron"]) == 0
 
+    def test_full_percentage_selects_every_candidate(self):
+        """calculate_npv_pct=1.0 includes every candidate (just reordered, none dropped)."""
+        locations = {
+            "steel": [
+                NewPlantLocation(
+                    Latitude=40.0 + i,
+                    Longitude=-100.0 - i,
+                    iso3="USA",
+                    power_price=0.05,
+                    capped_lcoh=3.0,
+                    rail_cost=10.0,
+                )
+                for i in range(10)
+            ],
+            "iron": [
+                NewPlantLocation(
+                    Latitude=50.0 + i,
+                    Longitude=-110.0 - i,
+                    iso3="DEU",
+                    power_price=0.05,
+                    capped_lcoh=3.0,
+                    rail_cost=10.0,
+                )
+                for i in range(6)
+            ],
+        }
+
+        subset = select_location_subset(locations=locations, calculate_npv_pct=1.0)
+
+        # Every candidate is present (random.sample with n == population size drops nothing,
+        # just reorders), regardless of list order.
+        assert sorted(subset["steel"], key=lambda loc: loc["Latitude"]) == locations["steel"]
+        assert sorted(subset["iron"], key=lambda loc: loc["Latitude"]) == locations["iron"]
+
 
 class TestGetListOfAllowedTechsForTargetYear:
     """Tests for get_list_of_allowed_techs_for_target_year function."""
@@ -995,7 +1029,9 @@ class TestSelectTopOpportunitiesByNpv:
                 [0],  # Select first item for iron
             ]
 
-            top_opportunities = select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=1)
+            top_opportunities = select_top_opportunities_by_npv(
+                npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+            )
 
             # Verify top opportunities were selected
             assert "steel" in top_opportunities
@@ -1023,7 +1059,9 @@ class TestSelectTopOpportunitiesByNpv:
 
         # The function uses np.random.choice which will filter out invalid NPVs
         # Just verify it runs without error and returns valid results
-        top_opportunities = select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=1)
+        top_opportunities = select_top_opportunities_by_npv(
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+        )
 
         # Should have selected 1 opportunity from the 3 valid ones
         assert "steel" in top_opportunities
@@ -1050,7 +1088,9 @@ class TestSelectTopOpportunitiesByNpv:
             # Mock returns indices of selected items
             mock_choice.return_value = [0]  # Select first item
 
-            select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=1)
+            select_top_opportunities_by_npv(
+                npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+            )
 
             # Verify np.random.choice was called with probabilities
             assert mock_choice.called
@@ -1073,6 +1113,7 @@ class TestSelectTopOpportunitiesByNpv:
         top_opportunities = select_top_opportunities_by_npv(
             npv_dict=npv_dict,
             top_n_loctechs_as_business_op=5,  # Request 5 but only 2 available
+            probabilistic_agents=True,
         )
 
         # Should return all available opportunities (2 location-tech pairs)
@@ -1085,7 +1126,9 @@ class TestSelectTopOpportunitiesByNpv:
 
         # Function raises ValueError when there are no valid NPVs
         with pytest.raises(ValueError, match="No valid NPVs found"):
-            select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=5)
+            select_top_opportunities_by_npv(
+                npv_dict=npv_dict, top_n_loctechs_as_business_op=5, probabilistic_agents=True
+            )
 
     def test_all_negative_npvs(self):
         """Test handling when all NPVs are negative but valid."""
@@ -1096,7 +1139,9 @@ class TestSelectTopOpportunitiesByNpv:
             }
         }
 
-        top_opportunities = select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=1)
+        top_opportunities = select_top_opportunities_by_npv(
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+        )
 
         # Rank weights are scale-free, so an all-negative pool still draws normally
         total_pairs = sum(len(techs) for site_techs in top_opportunities["steel"].values() for techs in [site_techs])
@@ -1110,7 +1155,9 @@ class TestSelectTopOpportunitiesByNpv:
             }
         }
 
-        top_opportunities = select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=1)
+        top_opportunities = select_top_opportunities_by_npv(
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+        )
 
         # Verify structure: product -> site_id -> tech -> NPV
         assert isinstance(top_opportunities, dict)
@@ -1494,7 +1541,7 @@ def test_selection_rank_weights_decrease_with_npv_rank():
 
     with patch("numpy.random.choice") as mock_choice:
         mock_choice.return_value = [0]
-        select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=1)
+        select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True)
 
     (pool_size,), kwargs = mock_choice.call_args
     assert pool_size == 3
@@ -1515,7 +1562,9 @@ def test_selection_never_draws_beyond_the_trimmed_pool():
 
     np.random.seed(42)
     for _ in range(25):
-        selected = select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=1)
+        selected = select_top_opportunities_by_npv(
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+        )
         (npv,) = [npv for techs in selected["steel"].values() for npv in techs.values()]
         assert npv >= -3.0
 
@@ -1527,8 +1576,41 @@ def test_selection_is_deterministic_under_a_seed():
     npv_dict = _npv_dict_from_values([-600.0, -100.0, -400.0, -200.0, -500.0, -300.0])
 
     np.random.seed(123)
-    first = select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=2)
+    first = select_top_opportunities_by_npv(
+        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=True
+    )
     np.random.seed(123)
-    second = select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=2)
+    second = select_top_opportunities_by_npv(
+        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=True
+    )
+
+    assert first == second
+
+
+def test_deterministic_mode_selects_top_n_by_npv():
+    """When probabilistic_agents is False, the top N by NPV are selected with no randomness."""
+    npv_dict = _npv_dict_from_values([-600.0, -100.0, -400.0, -200.0, -500.0, -300.0])
+
+    with patch("numpy.random.choice") as mock_choice:
+        selected = select_top_opportunities_by_npv(
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=False
+        )
+        # Deterministic mode must not touch the random draw at all
+        assert not mock_choice.called
+
+    selected_npvs = sorted(npv for techs in selected["steel"].values() for npv in techs.values())
+    assert selected_npvs == [-200.0, -100.0]
+
+
+def test_deterministic_mode_is_reproducible_without_seeding():
+    """Deterministic selection doesn't depend on RNG state at all."""
+    npv_dict = _npv_dict_from_values([-600.0, -100.0, -400.0, -200.0, -500.0, -300.0])
+
+    first = select_top_opportunities_by_npv(
+        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=False
+    )
+    second = select_top_opportunities_by_npv(
+        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=False
+    )
 
     assert first == second


### PR DESCRIPTION
select_top_opportunities_by_npv now picks the top N by NPV deterministically when probabilistic_agents is False, instead of always drawing a rank-weighted random mix - matching how brownfield decisions are already gated. 

Location sampling (select_location_subset) stays ungated: evaluating every candidate instead of the default 10% sample measured ~7x slower on real data, changing runtime significantly for switching the probabilistic_agents flag, which I want to avoid. This leaves some random behavior in candidate selection, but candidate **evaluation** (green- & brownfield) is now either deterministic or probabilistic depending on the flag with no significant runtime difference. 