### PR TITLE
GEO module audit fixes and performance improvements

### DIFF
--- a/src/steelo/adapters/geospatial/geospatial_calculations.py
+++ b/src/steelo/adapters/geospatial/geospatial_calculations.py
@@ -293,6 +293,7 @@ def calculate_distance_to_demand_and_feedstock(
     year: int,
     active_statuses: list[str],
     geo_paths: "GeoDataPaths",
+    end_year: int | None = None,
 ) -> tuple[xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray]:
     """
     Calculate the distance to demand centers and feedstock sources for iron and steel plants.
@@ -308,6 +309,9 @@ def calculate_distance_to_demand_and_feedstock(
         year: Year for which to calculate distances
         active_statuses: List of statuses considered as active (e.g., ["operating", "operating pre-retirement"])
         geo_paths: Paths to geospatial data files for plotting outputs
+        end_year: Simulation end year. The bubble-map file has no year suffix (each plot
+            overwrites the last), so it is plotted only when ``year == end_year``; if None,
+            every year is plotted.
 
     Returns:
         dist_to_ore_mines: DataArray of distances to iron ore mines (km)
@@ -342,13 +346,14 @@ def calculate_distance_to_demand_and_feedstock(
             continue
         iron_feedstock_locations_weight[supplier.location] = float(supplier.capacity_by_year[Year(year)])
     plot_paths_obj = PlotPaths(geo_plots_dir=geo_paths.geo_plots_dir)
-    plot_bubble_map(
-        data=iron_feedstock_locations_weight,
-        bubble_scaler=T_TO_MT,  # display in Mt
-        title="Iron Ore Mines and Their Capacities",
-        save_name="iron_ore_mines",
-        plot_paths=plot_paths_obj,
-    )
+    if end_year is None or year == end_year:
+        plot_bubble_map(
+            data=iron_feedstock_locations_weight,
+            bubble_scaler=T_TO_MT,  # display in Mt
+            title="Iron Ore Mines and Their Capacities",
+            save_name="iron_ore_mines",
+            plot_paths=plot_paths_obj,
+        )
     dist_to_ore_mines = distance_to_closest_location(
         iron_feedstock_locations_weight,
         target_lats=lats,

--- a/src/steelo/adapters/geospatial/geospatial_layers.py
+++ b/src/steelo/adapters/geospatial/geospatial_layers.py
@@ -549,23 +549,20 @@ def add_grid_power_price(
     logger = logging.getLogger(f"{__name__}.add_grid_power_price")
     # Pixels carry only iso3; sub-national rows reach pixels via GEO, not this country grid price
     grid_price = pd.Series({iso3: input_costs[iso3][year]["electricity"] for iso3 in input_costs if ":" not in iso3})
-    fallback_mask = ~np.isin(ds["iso3"].values, grid_price.index.to_numpy()) & (ds["feasibility_mask"].values > 0)
+    iso3_vals = ds["iso3"].values
+    known_mask = np.isin(iso3_vals, grid_price.index.to_numpy())
+    fallback_mask = ~known_mask & (ds["feasibility_mask"].values > 0)
     fallback_count = int(fallback_mask.sum())
     if fallback_count:
-        fallback_iso3 = sorted(set(ds["iso3"].values[fallback_mask].tolist()))
+        fallback_iso3 = sorted(set(iso3_vals[fallback_mask].tolist()))
         logger.warning(
             f"[GEO LAYERS] {fallback_count} feasible cells have no grid price for iso3 {fallback_iso3}; "
             f"assigning the maximum grid price as a never-site-here fallback."
         )
-    ds["grid_price"] = xr.apply_ufunc(
-        lambda iso3: grid_price.loc[iso3]
-        if (isinstance(iso3, str) and iso3 in grid_price.index and not pd.isna(iso3))
-        else grid_price.max(),
-        ds["iso3"],
-        vectorize=True,
-        dask="parallelized",
-        output_dtypes=[float],
-    )
+    # One reindex over the flattened grid replaces a per-cell Python lambda (~1M calls/year)
+    prices = grid_price.reindex(iso3_vals.ravel()).to_numpy(dtype=float)
+    prices[~known_mask.ravel()] = grid_price.max()
+    ds["grid_price"] = (("lat", "lon"), prices.reshape(iso3_vals.shape))
 
     plot_paths_obj = PlotPaths(geo_plots_dir=geo_paths.geo_plots_dir)
     plot_screenshot(
@@ -610,7 +607,7 @@ def add_power_price(
         Dataset with added 'power_price' variable containing combined power price (USD/kWh)
 
     Side Effects:
-        - Generates and saves plot of power prices (milestone years only) and histogram (every year)
+        - Generates and saves plot of power prices (milestone years only) and histogram (final year only)
 
     Note:
         The baseload LCOE is already calculated for the specified coverage percentage, so no additional
@@ -651,17 +648,18 @@ def add_power_price(
             save_name=f"power_price_100cov_{str(year)}",
             plot_paths=plot_paths_obj,
         )
-    p = int((1 - baseload_coverage) * 100)
-    plot_value_histogram(
-        ds,
-        var_name="power_price",
-        bins=100,
-        log_scale=True,
-        plot_paths=plot_paths_obj,
-        title="Power price distribution across feasible grid cells (USD/kWh)",
-        subtitle=f"Grid + baseload mix at {100 - p}% baseload + {p}% grid · year {year} · cell count on log scale",
-        xlabel="Power price (USD/kWh)",
-    )
+    if end_year is None or year == end_year:
+        p = int((1 - baseload_coverage) * 100)
+        plot_value_histogram(
+            ds,
+            var_name="power_price",
+            bins=100,
+            log_scale=True,
+            plot_paths=plot_paths_obj,
+            title="Power price distribution across feasible grid cells (USD/kWh)",
+            subtitle=f"Grid + baseload mix at {100 - p}% baseload + {p}% grid · year {year} · cell count on log scale",
+            xlabel="Power price (USD/kWh)",
+        )
 
     return ds
 
@@ -940,7 +938,7 @@ def add_transportation_costs(
 
     # Calculate distances to ore mines, iron plants, steel plants, and demand centers
     dist_to_ore_mines, dist_to_iron_plants, dist_to_steel_plants, dist_to_demand_centers = (
-        calculate_distance_to_demand_and_feedstock(repository, year, active_statuses, geo_paths)
+        calculate_distance_to_demand_and_feedstock(repository, year, active_statuses, geo_paths, end_year=end_year)
     )
     ds_ = xr.merge(
         [

--- a/src/steelo/adapters/geospatial/geospatial_layers.py
+++ b/src/steelo/adapters/geospatial/geospatial_layers.py
@@ -306,11 +306,10 @@ def add_feasibility_mask(ds: xr.Dataset, geo_config: "GeoConfig", geo_paths: "Ge
             plot_paths=plot_paths_obj,
         )
 
-        # Altitude
+        # Altitude (land at or below sea level is feasible; water is excluded by the land-sea mask)
         geopotential = terrain["z"]
         altitude = geopotential / GRAVITY_ACCELERATION  # Convert geopotential to altitude in meters
-        altitude_pos = altitude.where(altitude > 0)
-        altitude_bin = xr.where(altitude_pos < geo_config.max_altitude, 1, 0)
+        altitude_bin = xr.where(altitude < geo_config.max_altitude, 1, 0)
         plot_screenshot(
             altitude_bin,
             title="Binary Altitude",

--- a/src/steelo/adapters/geospatial/geospatial_layers.py
+++ b/src/steelo/adapters/geospatial/geospatial_layers.py
@@ -1068,14 +1068,10 @@ def add_landtype_factor(ds: xr.Dataset, geo_config: "GeoConfig", geo_paths: "Geo
             factor = string_to_factor[landtype_str]
             landtype_factors += landtype_percentage.sel(landtype=landtype_str).values * factor
 
-    # Fill zeros with nans and ensure minimum value is 1
+    # Cells without LULC data (zero sum) and sub-1 factors land on the neutral minimum of 1.0
     landtype_factors = cast(
         np.ndarray[tuple[int, int], np.dtype[np.float32]],
-        np.where(landtype_factors == 0, np.nan, landtype_factors).astype(np.float32),
-    )
-    landtype_factors = cast(
-        np.ndarray[tuple[int, int], np.dtype[np.float32]],
-        np.where(landtype_factors < 1, 1, landtype_factors).astype(np.float32),
+        np.where(~(landtype_factors >= 1), 1.0, landtype_factors).astype(np.float32),
     )
 
     # Add landtype factors to the global grid

--- a/src/steelo/adapters/geospatial/geospatial_layers.py
+++ b/src/steelo/adapters/geospatial/geospatial_layers.py
@@ -546,8 +546,17 @@ def add_grid_power_price(
     Note:
         For grid cells without a matching ISO3 code, the maximum grid price is used as a fallback.
     """
+    logger = logging.getLogger(f"{__name__}.add_grid_power_price")
     # Pixels carry only iso3; sub-national rows reach pixels via GEO, not this country grid price
     grid_price = pd.Series({iso3: input_costs[iso3][year]["electricity"] for iso3 in input_costs if ":" not in iso3})
+    fallback_mask = ~np.isin(ds["iso3"].values, grid_price.index.to_numpy()) & (ds["feasibility_mask"].values > 0)
+    fallback_count = int(fallback_mask.sum())
+    if fallback_count:
+        fallback_iso3 = sorted(set(ds["iso3"].values[fallback_mask].tolist()))
+        logger.warning(
+            f"[GEO LAYERS] {fallback_count} feasible cells have no grid price for iso3 {fallback_iso3}; "
+            f"assigning the maximum grid price as a never-site-here fallback."
+        )
     ds["grid_price"] = xr.apply_ufunc(
         lambda iso3: grid_price.loc[iso3]
         if (isinstance(iso3, str) and iso3 in grid_price.index and not pd.isna(iso3))

--- a/src/steelo/adapters/geospatial/priority_kpi.py
+++ b/src/steelo/adapters/geospatial/priority_kpi.py
@@ -98,7 +98,7 @@ def calculate_outgoing_cashflow_proxy(
     outgoing_cashflow = sum(cost_components.values())
     if not isinstance(outgoing_cashflow, xr.DataArray):
         outgoing_cashflow = xr.DataArray(outgoing_cashflow)
-    if outgoing_cashflow.all() == 0:
+    if bool((outgoing_cashflow.fillna(0) == 0).all()):
         raise ValueError("All locations have zero outgoing cashflow!")
     logger.info("Global average contribution to outgoing cashflow:")
     for component, value in cost_components.items():

--- a/src/steelo/adapters/geospatial/priority_kpi.py
+++ b/src/steelo/adapters/geospatial/priority_kpi.py
@@ -161,7 +161,7 @@ def calculate_outgoing_cashflow_proxy(
 
 
 def extract_priority_locations(
-    ds: xr.Dataset, var_name: str, top_pct: int, random_seed: int, invert: bool = False
+    ds: xr.Dataset, var_name: str, top_pct: float, random_seed: int, invert: bool = False
 ) -> tuple[xr.DataArray, pd.DataFrame]:
     """
     Extract the locations of the top X% values for a given variable in the dataset.
@@ -288,7 +288,7 @@ def find_top_locations_per_country(
             top_values_iso3, top_locations_iso3 = extract_priority_locations(
                 ds_iso3,
                 f"outgoing_cashflow_{product}",
-                top_pct=int(priority_pct / 10),
+                top_pct=priority_pct / 10,
                 random_seed=random_seed,
                 invert=True,
             )

--- a/src/steelo/adapters/geospatial/priority_kpi.py
+++ b/src/steelo/adapters/geospatial/priority_kpi.py
@@ -281,9 +281,11 @@ def find_top_locations_per_country(
     iso3_values = ds["iso3"].values.flatten()
     unique_iso3 = np.unique(iso3_values[(~pd.isnull(iso3_values)) & (iso3_values != "nan")])
 
+    # Only the three variables the extraction reads
+    ds_lottery_vars = ds[["iso3", f"outgoing_cashflow_{product}", "feasibility_mask"]]
     for iso3 in unique_iso3:
         # Get the top locations for the current ISO3 code (if not empty)
-        ds_iso3 = ds.where(ds["iso3"] == iso3)
+        ds_iso3 = ds_lottery_vars.where(ds_lottery_vars["iso3"] == iso3)
         if np.any(~np.isnan(ds_iso3[f"outgoing_cashflow_{product}"].values)):
             top_values_iso3, top_locations_iso3 = extract_priority_locations(
                 ds_iso3,
@@ -408,12 +410,11 @@ def calculate_priority_location_kpi(
                 plot_paths=plot_paths_obj,
             )
 
-        # For each location, pass NPV calculation inputs
-        for row in top_locations_wlottery[product].itertuples():
-            lat = row.Latitude
-            lon = row.Longitude
-            for col in ["iso3", "rail_cost", "power_price", "capped_lcoh"]:
-                top_locations_wlottery[product].loc[row.Index, col] = ds_masked[col].sel(lat=lat, lon=lon).item()
+        # For each location, pass NPV calculation inputs (pointwise selection over all sites at once)
+        site_lats = xr.DataArray(top_locations_wlottery[product]["Latitude"].values, dims="site")
+        site_lons = xr.DataArray(top_locations_wlottery[product]["Longitude"].values, dims="site")
+        for col in ["iso3", "rail_cost", "power_price", "capped_lcoh"]:
+            top_locations_wlottery[product][col] = ds_masked[col].sel(lat=site_lats, lon=site_lons).values
 
     # Filter out empty records
     top_locations_wlottery_dict = {}

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -6232,8 +6232,8 @@ class PlantGroup:
                         disposal_cost_outputs=disposal_cost_outputs,
                         derive_geo_unit=derive_geo_unit,
                     )
-                all_plant_ids.append(new_plant.plant_id)
-                new_plants.append(new_plant)
+                    all_plant_ids.append(new_plant.plant_id)
+                    new_plants.append(new_plant)
         candidate_stats["new_plants_created"] = len(new_plants)
         stats_payload = " ".join(f"{key}={value}" for key, value in candidate_stats.items())
         logger.info(f"operation=new_plant_candidate_summary {stats_payload}")

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -3136,7 +3136,7 @@ class FurnaceGroup:
                         f"[NEW PLANTS] Announcing the business opportunity for {self.technology} at ({location.lat}, {location.lon}) in {location.iso3} - NPV-positive for {consideration_time} years in a row."
                     )
                     return commands.UpdateFurnaceGroupStatus(
-                        fg_id=self.get_furnace_plant_id(), plant_id=self.furnace_group_id, new_status="announced"
+                        fg_id=self.furnace_group_id, plant_id=self.get_furnace_plant_id(), new_status="announced"
                     )
                 if status_stats is not None:
                     status_stats["announcement_probability_failed"] += 1
@@ -3149,7 +3149,7 @@ class FurnaceGroup:
                     f"[NEW PLANTS] Discarding the business opportunity for {self.technology} at ({location.lat}, {location.lon}) in {location.iso3} - NPV-negative for {consideration_time} years in a row."
                 )
                 return commands.UpdateFurnaceGroupStatus(
-                    fg_id=self.get_furnace_plant_id(), plant_id=self.furnace_group_id, new_status="discarded"
+                    fg_id=self.furnace_group_id, plant_id=self.get_furnace_plant_id(), new_status="discarded"
                 )
             else:
                 if status_stats is not None:
@@ -3218,7 +3218,7 @@ class FurnaceGroup:
             if status_stats is not None:
                 status_stats["tech_not_allowed"] += 1
             return commands.UpdateFurnaceGroupStatus(
-                fg_id=self.get_furnace_plant_id(), plant_id=self.furnace_group_id, new_status="discarded"
+                fg_id=self.furnace_group_id, plant_id=self.get_furnace_plant_id(), new_status="discarded"
             )
 
         # Get capacity from NEW PLANTS only (not expansions) and calculate limits
@@ -3267,8 +3267,8 @@ class FurnaceGroup:
                     if status_stats is not None:
                         status_stats["co2_storage_blocked"] += 1
                     return commands.UpdateFurnaceGroupStatus(
-                        fg_id=self.get_furnace_plant_id(),
-                        plant_id=self.furnace_group_id,
+                        fg_id=self.furnace_group_id,
+                        plant_id=self.get_furnace_plant_id(),
                         new_status="discarded",
                     )
 
@@ -3285,8 +3285,8 @@ class FurnaceGroup:
             if status_stats is not None:
                 status_stats["construction_started"] += 1
             return commands.UpdateFurnaceGroupStatus(
-                fg_id=self.get_furnace_plant_id(),
-                plant_id=self.furnace_group_id,
+                fg_id=self.furnace_group_id,
+                plant_id=self.get_furnace_plant_id(),
                 new_status="construction",
             )
 

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -6390,7 +6390,9 @@ class PlantGroup:
                     # Apply energy carrier subsidies
                     active_energy_subs: dict[str, list] = {}
                     for carrier, carrier_subs in energy_subsidies.items():
-                        all_subs = carrier_subs.get(iso3, {}).get(fg.technology.name, [])
+                        all_subs = collect_subsidies_for_geo(carrier_subs, plant.location.geo_key).get(
+                            fg.technology.name, []
+                        )
                         active = filter_subsidies_for_year(all_subs, year)
                         if active:
                             active_energy_subs[carrier] = active

--- a/src/steelo/domain/new_plant_opening.py
+++ b/src/steelo/domain/new_plant_opening.py
@@ -45,7 +45,8 @@ def select_location_subset(
         logger.info(
             f"[NEW PLANTS] For {product}: Sampling n = {n} out of total locations = {len(locations.get(product, []))} for NPV calculation."
         )
-        logger.info(f"[NEW PLANTS] Sample {product} location: {locations[product][0]}")
+        if best_locations_subset[product]:
+            logger.info(f"[NEW PLANTS] Sample {product} location: {best_locations_subset[product][0]}")
     return best_locations_subset
 
 
@@ -214,6 +215,9 @@ def prepare_cost_data_for_business_opportunity(
             energy_costs_site = None
             if site["iso3"] not in energy_costs:
                 site_missing_fields.append("energy_costs")
+                incomplete_site = True
+            elif current_year not in energy_costs[site["iso3"]]:
+                site_missing_fields.append(f"energy_costs for year {current_year}")
                 incomplete_site = True
             else:
                 energy_costs_site = energy_costs[site["iso3"]][current_year].copy()  # Copy to avoid modifying original
@@ -415,7 +419,8 @@ def prepare_cost_data_for_business_opportunity(
                     )
 
     # Log error if more than 30% of the sampled locations have anomalous power prices
-    if anomalous_power_prices_count > len(sites) * 0.3:
+    total_sites = sum(len(product_sites) for product_sites in best_locations_subset.values())
+    if anomalous_power_prices_count > total_sites * 0.3:
         logger.error(
             """[NEW PLANTS] More than 30% of the sampled locations have power prices for the own power parc that differ from the local grid " \n
             power price by more than one OOM. Please check the units (expected in USD/kWh)."""

--- a/tests/unit/test_geospatial_layers.py
+++ b/tests/unit/test_geospatial_layers.py
@@ -834,3 +834,46 @@ def test_add_landtype_factor_fills_missing_coverage_with_neutral(sample_dataset,
     assert not np.any(np.isnan(factors.values))
     assert factors.values[0, 0] == 1.0  # no-data cell lands on the neutral minimum
     assert factors.values[1, 1] == pytest.approx(100.0 * 1.1)  # covered cells keep their factor
+
+
+def test_add_feasibility_mask_keeps_land_at_or_below_sea_level(sample_dataset, mock_geo_config, mock_geo_paths):
+    """Land cells at 0 m or below sea level are feasible; only max_altitude excludes by height.
+
+    Notes:
+        Guards against the former ``altitude.where(altitude > 0)`` clause, which
+        turned coastal and below-sea-level land (grid-mean altitude <= 0 m) into
+        NaN and thereby marked it infeasible. Water stays excluded via the
+        land-sea mask, high terrain via max_altitude.
+    """
+    from steelo.domain.constants import GRAVITY_ACCELERATION
+
+    n_lat, n_lon = len(sample_dataset.lat), len(sample_dataset.lon)
+    altitude = np.full((1, n_lat, n_lon), 100.0)
+    altitude[0, 0, 0] = 0.0  # coastal land at exactly sea level
+    altitude[0, 0, 1] = -300.0  # below-sea-level land (e.g. polder)
+    altitude[0, 0, 2] = 5000.0  # above max_altitude -> infeasible
+
+    mock_terrain = xr.Dataset(
+        {
+            "z": (("valid_time", "latitude", "longitude"), altitude * GRAVITY_ACCELERATION),
+            "slor": (("valid_time", "latitude", "longitude"), np.full((1, n_lat, n_lon), 0.001)),
+            "lsm": (("valid_time", "latitude", "longitude"), np.ones((1, n_lat, n_lon))),  # all land
+        }
+    )
+    mock_terrain.coords["valid_time"] = [0]
+    mock_terrain.coords["latitude"] = sample_dataset.lat.values
+    mock_terrain.coords["longitude"] = sample_dataset.lon.values
+
+    with (
+        patch("xarray.open_dataset") as mock_open,
+        patch("steelo.adapters.geospatial.geospatial_layers.plot_screenshot"),
+        patch.object(xr.DataArray, "to_netcdf"),
+    ):
+        mock_open.return_value = mock_terrain
+
+        result = add_feasibility_mask(sample_dataset, mock_geo_config, mock_geo_paths)
+
+    mask = result["feasibility_mask"]
+    assert mask.values[0, 0] == 1  # sea-level land is feasible
+    assert mask.values[0, 1] == 1  # below-sea-level land is feasible
+    assert mask.values[0, 2] == 0  # high terrain stays excluded

--- a/tests/unit/test_geospatial_layers.py
+++ b/tests/unit/test_geospatial_layers.py
@@ -790,3 +790,47 @@ def test_baseload_lcoe_interpolates_between_available_years(sample_dataset, mock
     prices = _lcoe_for_year(sample_dataset, mock_geo_paths, 2047)
 
     np.testing.assert_allclose(prices.values, 0.072)  # 80 -> 60 USD/MWh, 2/5 of the way
+
+
+def test_add_landtype_factor_fills_missing_coverage_with_neutral(sample_dataset, mock_geo_config, mock_geo_paths):
+    """Cells with no LULC coverage get the neutral minimum factor instead of NaN.
+
+    Notes:
+        Guards against zero coverage being mapped to NaN (which NaNed the whole
+        outgoing cashflow for the cell and silently removed it from the
+        candidate universe). Zeros and missing values must land on the neutral
+        minimum the docstring promises.
+    """
+    sample_dataset["feasibility_mask"] = (
+        ("lat", "lon"),
+        np.ones((len(sample_dataset.lat), len(sample_dataset.lon))),
+    )
+    mock_geo_paths.landtype_percentage_path = Mock(spec=Path)
+
+    landtype_labels = ["Cropland", "Tree Cover"]
+    landtype_data = np.zeros((len(landtype_labels), len(sample_dataset.lat), len(sample_dataset.lon)))
+    landtype_data[0, :, :] = 100.0  # 100% cropland everywhere...
+    landtype_data[:, 0, 0] = 0.0  # ...except one cell with no LULC data at all
+
+    mock_landtype = xr.DataArray(
+        landtype_data,
+        dims=["landtype", "lat", "lon"],
+        coords={
+            "landtype": landtype_labels,
+            "lat": sample_dataset.lat,
+            "lon": sample_dataset.lon,
+        },
+    )
+
+    with (
+        patch("xarray.open_dataarray") as mock_open_da,
+        patch("steelo.adapters.geospatial.geospatial_layers.plot_screenshot"),
+    ):
+        mock_open_da.return_value = mock_landtype
+
+        result = add_landtype_factor(sample_dataset, mock_geo_config, mock_geo_paths)
+
+    factors = result["landtype_factor"]
+    assert not np.any(np.isnan(factors.values))
+    assert factors.values[0, 0] == 1.0  # no-data cell lands on the neutral minimum
+    assert factors.values[1, 1] == pytest.approx(100.0 * 1.1)  # covered cells keep their factor

--- a/tests/unit/test_identify_new_business_opportunities_4indi.py
+++ b/tests/unit/test_identify_new_business_opportunities_4indi.py
@@ -1614,3 +1614,81 @@ def test_deterministic_mode_is_reproducible_without_seeding():
     )
 
     assert first == second
+
+
+def test_two_technologies_at_one_site_spawn_two_plants(monkeypatch):
+    """Step 6 creates one plant per selected (site, tech) pair, with distinct plant ids.
+
+    Notes:
+        Guards against the appends sitting at site-loop level, which silently
+        kept only the last technology drawn at a shared site and handed both
+        technologies the same plant id.
+    """
+    site_id = (40.0, -100.0, "USA")
+    tech_entry = {
+        "capex": 1000.0,
+        "capex_no_subsidy": 1200.0,
+        "cost_of_debt": 0.05,
+        "cost_of_debt_no_subsidy": 0.06,
+        "fopex": 50.0,
+        "utilization_rate": 0.7,
+        "reductant": "scrap",
+        "railway_cost": 10.0,
+        "bom": {"energy": {"electricity": {"unit_cost": 50.0, "demand": 0.5}}},
+        "energy_costs": {"electricity": 0.05, "hydrogen": 3500.0},
+        "output_shares": {"scrap": 1.0},
+    }
+    cost_data = {"steel": {site_id: {"EAF": dict(tech_entry), "BOF": dict(tech_entry)}}}
+    npv_dict = {"steel": {site_id: {"EAF": 100.0, "BOF": 90.0}}}
+
+    monkeypatch.setattr(
+        "steelo.domain.new_plant_opening.select_location_subset",
+        lambda *args, **kwargs: {"steel": [{"Latitude": 40.0, "Longitude": -100.0, "iso3": "USA"}]},
+    )
+    monkeypatch.setattr(
+        "steelo.domain.new_plant_opening.prepare_cost_data_for_business_opportunity",
+        lambda *args, **kwargs: cost_data,
+    )
+    monkeypatch.setattr(
+        "steelo.domain.calculate_costs.calculate_business_opportunity_npvs",
+        lambda *args, **kwargs: npv_dict,
+    )
+    monkeypatch.setattr(
+        "steelo.domain.new_plant_opening.select_top_opportunities_by_npv",
+        lambda *args, **kwargs: npv_dict,
+    )
+
+    plant_group = PlantGroup(plant_group_id="indi", plants=[])
+    command = plant_group.identify_new_business_opportunities_4indi(
+        current_year=Year(2025),
+        consideration_time=2,
+        construction_time=3,
+        plant_lifetime=30,
+        input_costs={"USA": {Year(2025): {"electricity": 0.05, "hydrogen": 3500.0}}},
+        locations={"steel": [{"Latitude": 40.0, "Longitude": -100.0, "iso3": "USA"}]},
+        iso3_to_region_map={"USA": "Americas"},
+        market_price={"steel": [100.0] * 50},
+        capex_dict_all_locs_techs={"Americas": {"EAF": 1000.0, "BOF": 1100.0}},
+        cost_of_debt_all_locs={"USA": {"EAF": 0.05, "BOF": 0.05}},
+        cost_of_equity_all_locs={"USA": {"EAF": 0.08, "BOF": 0.08}},
+        steel_plant_capacity=1000.0,
+        all_plant_ids=[],
+        fopex_all_locs_techs={"USA": {"eaf": 50.0, "bof": 50.0}},
+        equity_share=0.3,
+        dynamic_feedstocks={},
+        get_bom_from_avg_boms=lambda *args, **kwargs: (None, 0.7, "scrap", {}),
+        reductant_score_series=_stub_series,
+        global_risk_free_rate=0.03,
+        tech_to_product={"EAF": "steel", "BOF": "steel"},
+        allowed_techs={Year(2028): ["EAF", "BOF"]},
+        technology_emission_factors=[],
+        chosen_emissions_boundary_for_carbon_costs="scope_1",
+        carbon_costs={"USA": {Year(2028): 50.0}},
+        active_statuses=["operating"],
+        top_n_loctechs_as_business_op=2,
+    )
+
+    new_plants = command.new_plants
+    assert len(new_plants) == 2
+    assert len({plant.plant_id for plant in new_plants}) == 2
+    assert {plant.furnace_groups[0].technology.name for plant in new_plants} == {"EAF", "BOF"}

--- a/tests/unit/test_identify_new_business_opportunities_4indi.py
+++ b/tests/unit/test_identify_new_business_opportunities_4indi.py
@@ -123,13 +123,12 @@ class TestSelectLocationSubset:
         assert len(subset["iron"]) == 3  # 50% of 6
 
     def test_empty_location_list(self):
-        """Test handling of empty location lists."""
+        """Empty location lists yield empty subsets without raising."""
         locations = {"steel": [], "iron": []}
 
-        # Function accesses locations[product][0] which will raise IndexError on empty list
-        # This is a bug in the implementation - it tries to log a sample location even when list is empty
-        with pytest.raises(IndexError):
-            select_location_subset(locations=locations, calculate_npv_pct=0.1)
+        subset = select_location_subset(locations=locations, calculate_npv_pct=0.1)
+
+        assert subset == {"steel": [], "iron": []}
 
     def test_single_location_with_low_percentage(self):
         """Test that at least 0 locations are selected when percentage results in < 1."""

--- a/tests/unit/test_priority_kpi.py
+++ b/tests/unit/test_priority_kpi.py
@@ -711,3 +711,48 @@ class TestCalculatePriorityLocationKpi:
         # The 50% selection should have at least as many locations as 10%
         assert len(result["iron"]) >= len(result_small["iron"])
         assert len(result["steel"]) >= len(result_small["steel"])
+
+
+def test_country_lottery_scales_with_country_size():
+    """The per-country lottery selects ~priority_pct/10 % of each country's cells.
+
+    Notes:
+        Guards against the former ``int(priority_pct / 10)`` truncation, which
+        collapsed the lottery to a single pixel per country regardless of size.
+        With priority_pct=5 the per-country share is 0.5%, so a country with 810
+        cells must contribute several locations while a 90-cell country gets one.
+    """
+    n = 30
+    lat = np.linspace(-10.0, 10.0, n)
+    lon = np.linspace(30.0, 50.0, n)
+    iso3 = np.full((n, n), "BIG", dtype=object)
+    iso3[:, :3] = "SML"
+
+    rng = np.random.default_rng(7)
+    cashflow = rng.uniform(100.0, 1000.0, size=(n, n))
+
+    ds = xr.Dataset(
+        {
+            "iso3": xr.DataArray(iso3, coords={"lat": lat, "lon": lon}, dims=["lat", "lon"]),
+            "outgoing_cashflow_steel": xr.DataArray(cashflow, coords={"lat": lat, "lon": lon}, dims=["lat", "lon"]),
+            "top5_steel": xr.DataArray(np.zeros((n, n)), coords={"lat": lat, "lon": lon}, dims=["lat", "lon"]),
+            "feasibility_mask": xr.DataArray(np.ones((n, n)), coords={"lat": lat, "lon": lon}, dims=["lat", "lon"]),
+        }
+    )
+    top_locations = {"steel": pd.DataFrame(columns=["Latitude", "Longitude"])}
+
+    _, locations_df = find_top_locations_per_country(
+        ds=ds,
+        top_locations=top_locations,
+        product="steel",
+        priority_pct=5,
+        random_seed=42,
+    )
+
+    small_country_lons = set(lon[:3])
+    sml_count = locations_df["Longitude"].isin(small_country_lons).sum()
+    big_count = len(locations_df) - sml_count
+
+    assert sml_count >= 1
+    assert big_count >= 3  # 0.5% of 810 cells, not a single token pixel
+    assert big_count > sml_count

--- a/tests/unit/test_update_dynamic_costs_for_business_opportunities.py
+++ b/tests/unit/test_update_dynamic_costs_for_business_opportunities.py
@@ -939,3 +939,96 @@ def test_update_costs_with_energy_subsidies(
     assert "natural_gas" in cmd.new_energy_costs
     assert "natural_gas" in cmd.new_output_energy_costs
     # BOM hydrogen should use subsidised input price
+
+
+def test_update_costs_with_province_scoped_energy_subsidies(
+    mock_custom_energy_costs,
+    capex_dict_all_locs,
+    cost_debt_all_locs,
+    iso3_to_region_map,
+):
+    """Province-scoped energy subsidies are collected via the plant's geo_key in the yearly refresh.
+
+    Notes:
+        The refresh must merge country and province subsidy rows exactly like
+        opportunity creation and PAM do (via collect_subsidies_for_geo); a
+        subsidy keyed "USA:US-TX" applies to a plant whose location carries
+        geo_unit "US-TX".
+    """
+    fg = get_furnace_group(
+        fg_id="fg_province_sub",
+        tech_name="DRI",
+        capacity=150,
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2027), end=Year(2047)),
+            plant_lifetime=20,
+        ),
+        utilization_rate=0.7,
+    )
+    fg.status = "considered"
+    fg.cost_of_debt = 0.06
+    fg.technology.capex = 3000.0
+    fg.energy_costs = {"electricity": 60.0, "hydrogen": 5.0}
+    fg.energy_costs_no_subsidy = {"electricity": 60.0, "hydrogen": 5.0}
+    fg.output_energy_costs = {"electricity": 60.0, "hydrogen": 5.0}
+    fg.bill_of_materials = {
+        "energy": {
+            "electricity": {"unit_cost": 60.0, "demand": 0.4},
+            "hydrogen": {"unit_cost": 5.0, "demand": 0.8},
+        },
+        "materials": {
+            "iron_ore": {"unit_cost": 100.0, "demand": 1.5},
+        },
+    }
+
+    plant = get_plant(plant_id="plant_province_sub", furnace_groups=[fg])
+    plant.location = Location(
+        lat=31.0,
+        lon=-100.0,
+        country="USA",
+        region="Americas",
+        iso3="USA",
+        geo_unit="US-TX",
+    )
+
+    plant_group = PlantGroup(plant_group_id="test_group", plants=[plant])
+
+    h2_subsidy = Subsidy(
+        scenario_name="test",
+        iso3="USA:US-TX",
+        start_year=Year(2026),
+        end_year=Year(2035),
+        technology_name="DRI",
+        cost_item="hydrogen",
+        subsidy_type="absolute",
+        subsidy_amount=1.0,
+    )
+
+    energy_subsidies = {
+        "hydrogen": {
+            "USA:US-TX": {
+                "DRI": [h2_subsidy],
+            },
+        },
+    }
+
+    commands = plant_group.update_dynamic_costs_for_business_opportunities(
+        current_year=Year(2025),
+        consideration_time=3,
+        custom_energy_costs=mock_custom_energy_costs,
+        capex_dict_all_locs=capex_dict_all_locs,
+        cost_debt_all_locs=cost_debt_all_locs,
+        iso3_to_region_map=iso3_to_region_map,
+        global_risk_free_rate=0.02,
+        capex_subsidies={},
+        debt_subsidies={},
+        energy_subsidies=energy_subsidies,
+    )
+
+    assert len(commands) == 1
+    cmd = commands[0]
+    # Mock provides hydrogen=3.5; $1.0 absolute subsidy -> input 2.5, output 4.5
+    assert cmd.new_energy_costs["hydrogen"] == pytest.approx(2.5)
+    assert cmd.new_output_energy_costs["hydrogen"] == pytest.approx(4.5)
+    assert cmd.new_energy_costs_no_subsidy["hydrogen"] == pytest.approx(3.5)


### PR DESCRIPTION
Fixes from the GEO module audit plus the measured performance wins, one commit per fix.

- Create a plant for every selected location-technology pair instead of only the last technology at a shared site
- Stop truncating the per-country lottery share to zero so it selects proportionally to country size
- Collect province-scoped energy subsidies via geo_key in the yearly opportunity cost refresh
- Treat cells without LULC coverage as a neutral landtype factor instead of excluding them via NaN
- Keep land at or below sea level feasible in the altitude mask
- Cleanup: transposed UpdateFurnaceGroupStatus ids, inverted zero-cashflow guard, anomalous-price warning denominator, sample-log guard, missing-year error path, grid-price fallback warning
- Performance: vectorise the per-country lottery masking, site-attribute extraction and grid-price lookup; plot the overwritten-every-year histogram and bubble map only in the final year

The first three fixes change greenfield results; baselines predating this branch are not comparable for greenfield outputs.