### PR TITLE
GEO fixes: price/cost alignment, province pricing, dedup, subsidy year, dead code

### DIFF
--- a/src/steelo/adapters/geospatial/priority_kpi.py
+++ b/src/steelo/adapters/geospatial/priority_kpi.py
@@ -300,6 +300,9 @@ def find_top_locations_per_country(
             if dfs_to_concat:
                 top_locations_wlottery = pd.concat(dfs_to_concat, ignore_index=True)
     top_values = top_wlottery.astype(bool)
+    # A cell can be both in the global top and its country's lottery; duplicate rows would
+    # consume sample slots downstream and double-weight exactly the already-best sites
+    top_locations_wlottery = top_locations_wlottery.drop_duplicates(subset=["Latitude", "Longitude"], ignore_index=True)
 
     return top_values, top_locations_wlottery
 

--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -1240,7 +1240,10 @@ def calculate_business_opportunity_npvs(
     Args:
         cost_data: Nested dictionary: product -> site_id -> tech -> cost_type -> cost
         target_year: Target year for the business opportunity
-        market_price: Dictionary mapping product to list of future market prices
+        market_price: Dictionary mapping product to list of future market prices,
+            anchored at target_year (index 0 = earliest construction start), so that
+            after calculate_npv_full's construction-time padding each price year
+            matches the cost year of the operating window
         steel_plant_capacity: Capacity of the steel plant in tonnes
         plant_lifetime: Lifetime of the plant in years
         construction_time: Time required for plant construction in years

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -5984,7 +5984,6 @@ class PlantGroup:
         allowed_techs: dict[Year, list[str]],
         technology_emission_factors: list[TechnologyEmissionFactors],
         chosen_emissions_boundary_for_carbon_costs: str,
-        carbon_costs: dict[str, dict[Year, float]],
         active_statuses: list[str],
         top_n_loctechs_as_business_op: int = 5,
         capex_subsidies: dict[str, dict[str, list[Subsidy]]] = {},  # iso3 -> tech -> list of subsidies
@@ -6040,7 +6039,6 @@ class PlantGroup:
             allowed_techs: Dictionary mapping year to list of allowed technologies
             technology_emission_factors: List of technology-specific emission factors
             chosen_emissions_boundary_for_carbon_costs: Emission boundary for carbon costs
-            carbon_costs: Dictionary mapping iso3 -> year -> carbon cost
             active_statuses: Status strings whose furnace groups vote in the group's
                 most-common-reductant aggregation
             top_n_loctechs_as_business_op: Number of top opportunities to select (default: 5)
@@ -6143,7 +6141,6 @@ class PlantGroup:
             debt_subsidies=debt_subsidies,
             opex_subsidies=opex_subsidies,
             energy_subsidies=energy_subsidies,
-            carbon_costs=carbon_costs,
             most_common_reductant=self.most_common_reductant(active_statuses),
             environment_most_common_reductant=environment_most_common_reductant,
             derive_geo_unit=derive_geo_unit,

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -2973,7 +2973,9 @@ class FurnaceGroup:
         Args:
             year: Current simulation year
             location: Location of the plant (including latitude, longitude, and country ISO3)
-            market_price: Dictionary mapping product to list of future market prices
+            market_price: Dictionary mapping product to list of future market prices,
+                anchored at the current year; re-anchored to the opportunity's earliest
+                construction start before the NPV
             cost_of_equity: Cost of equity for NPV calculation
             plant_lifetime: Lifetime of the plant in years
             construction_time: Time required for plant construction in years
@@ -3020,10 +3022,14 @@ class FurnaceGroup:
             if status_stats is not None:
                 status_stats["npv_inputs_missing"] += 1
         else:
-            # Get earliest possible operational time period
+            # Earliest possible operating window, floored at the soonest path still open to a
+            # considered opportunity: announce now, construct from next year
             years_already_considered = len(self.historical_npv_business_opportunities)
             earliest_operation_start_year = Year(
-                year + consideration_time + construction_time + 1 - years_already_considered
+                max(
+                    year + consideration_time + construction_time + 1 - years_already_considered,
+                    year + 1 + construction_time,
+                )
             )  # 1 year of announcement time
             earliest_operation_end_year = Year(earliest_operation_start_year + plant_lifetime)
 
@@ -3057,12 +3063,13 @@ class FurnaceGroup:
             )
 
             # Calculate updated NPV (carbon and by-products live inside the score)
+            years_to_construction_start = int(earliest_operation_start_year) - construction_time - int(year)
             npv_value = calculate_npv_full(
                 capex=self.technology.capex,
                 capacity=self.capacity,
                 unit_total_opex_list=unit_total_opex_list,
                 expected_utilisation_rate=self.utilization_rate,
-                price_series=market_price[self.technology.product],
+                price_series=market_price[self.technology.product][years_to_construction_start:],
                 lifetime=plant_lifetime,
                 construction_time=construction_time,
                 cost_of_debt=self.cost_of_debt,
@@ -6024,7 +6031,8 @@ class PlantGroup:
             input_costs: Dictionary mapping iso3 -> year -> energy carrier -> cost
             locations: Dictionary of potential plant locations
             iso3_to_region_map: Dictionary mapping ISO3 country codes to regions
-            market_price: Dictionary mapping product to list of future prices
+            market_price: Dictionary mapping product to list of future prices, anchored
+                at the current year; re-anchored to target_year before the NPV
             capex_dict_all_locs_techs: Dictionary mapping region -> tech -> capex
             cost_of_debt_all_locs: Dictionary mapping iso3 -> tech -> cost of debt
             cost_of_equity_all_locs: Dictionary mapping iso3 -> tech -> cost of equity
@@ -6152,10 +6160,15 @@ class PlantGroup:
 
         # Step 4: Calculate NPVs for all allowed top location-technology combinations with enough data
         # npv_dict: product -> site_id (lat, lon, iso3) -> tech -> NPV
+        # Prices from construction start, so price year i is cost year i in calculate_npv_full
+        years_to_construction_start = int(target_year) - int(current_year)
+        market_price_from_construction_start = {
+            product: series[years_to_construction_start:] for product, series in market_price.items()
+        }
         npv_dict = calculate_business_opportunity_npvs(
             cost_data=cost_data,
             target_year=target_year,
-            market_price=market_price,
+            market_price=market_price_from_construction_start,
             steel_plant_capacity=steel_plant_capacity,
             plant_lifetime=plant_lifetime,
             construction_time=construction_time,
@@ -6477,7 +6490,9 @@ class PlantGroup:
         Args:
             current_year: Current simulation year
             consideration_time: Number of years to consider before announcement
-            market_price: Dictionary mapping product to list of future market prices
+            market_price: Dictionary mapping product to list of future market prices,
+                anchored at the current year; re-anchored to the opportunity's earliest
+                construction start before the NPV
             cost_of_equity_all_locs: Dictionary mapping iso3 -> tech -> cost of equity
             probability_of_announcement: Probability that a viable opportunity will be announced
             probability_of_construction: Probability that an announced plant starts construction

--- a/src/steelo/domain/new_plant_opening.py
+++ b/src/steelo/domain/new_plant_opening.py
@@ -150,7 +150,9 @@ def prepare_cost_data_for_business_opportunity(
             lon, iso3, power price, hydrogen price, railway cost)
         current_year: The current simulation year.
         target_year: The year when the plant would start operation (current year + consideration time + 1 year announcement lag)
-        energy_costs: Nested dictionary with energy costs per country and year (iso3 -> year -> energy carrier -> cost)
+        energy_costs: Nested dictionary with energy costs per geography and year (geo_key -> year ->
+            energy carrier -> cost); sub-national rows (``"ISO3:unit"``) win over country rows for
+            sites whose derived geo_unit matches
         capex_dict_all_locs_techs: Nested dictionary with CAPEX values per region and technology (region -> tech -> capex)
         cost_of_debt_all_locs: Dictionary with cost of debt per country and technology (iso3 -> tech -> cost of debt)
         cost_of_equity_all_locs: Dictionary with cost of equity per country and technology (iso3 -> tech -> cost of equity)
@@ -201,6 +203,14 @@ def prepare_cost_data_for_business_opportunity(
             # province. The same derivation runs again at spawn, so the two always agree.
             geo_unit = derive_geo_unit(site["Latitude"], site["Longitude"], site["iso3"]) if derive_geo_unit else None
             site_geo_key = compose_geo_key(site["iso3"], geo_unit)
+            site_location = Location(
+                lat=site["Latitude"],
+                lon=site["Longitude"],
+                country=site["iso3"],
+                region="",
+                iso3=site["iso3"],
+                geo_unit=geo_unit,
+            )
             if site_id not in cost_data[prod]:
                 cost_data[prod][site_id] = {}
 
@@ -208,17 +218,19 @@ def prepare_cost_data_for_business_opportunity(
             incomplete_site = False
             site_missing_fields = []
 
-            # Set the energy costs to those of the country and overwrite electricity and hydrogen costs with
-            # custom values from the own power parc
+            # Set the energy costs to those of the site's geography (province row when the site
+            # falls in one, else country — the same resolution the score series uses) and
+            # overwrite electricity and hydrogen costs with custom values from the own power parc
             energy_costs_site = None
-            if site["iso3"] not in energy_costs:
+            year_costs_for_site = site_location.resolve(energy_costs, what="business-opportunity energy costs")
+            if year_costs_for_site is None:
                 site_missing_fields.append("energy_costs")
                 incomplete_site = True
-            elif current_year not in energy_costs[site["iso3"]]:
+            elif current_year not in year_costs_for_site:
                 site_missing_fields.append(f"energy_costs for year {current_year}")
                 incomplete_site = True
             else:
-                energy_costs_site = energy_costs[site["iso3"]][current_year].copy()  # Copy to avoid modifying original
+                energy_costs_site = year_costs_for_site[current_year].copy()  # Copy to avoid modifying original
                 elec_ratio = (
                     site["power_price"] / energy_costs_site["electricity"]
                     if energy_costs_site["electricity"] != 0
@@ -324,14 +336,6 @@ def prepare_cost_data_for_business_opportunity(
                     # power/hydrogen prices are trajectory-scaled from the country series.
                     # TODO: temporary — extract the exact geo point's own year series from
                     # the rasters instead of ratio-scaling the current-year pixel prices.
-                    site_location = Location(
-                        lat=site["Latitude"],
-                        lon=site["Longitude"],
-                        country=site["iso3"],
-                        region="",
-                        iso3=site["iso3"],
-                        geo_unit=geo_unit,
-                    )
                     site_overrides = {
                         "electricity": site["power_price"],
                         "hydrogen": site["capped_lcoh"] * T_TO_KG,

--- a/src/steelo/domain/new_plant_opening.py
+++ b/src/steelo/domain/new_plant_opening.py
@@ -272,12 +272,14 @@ def prepare_cost_data_for_business_opportunity(
                 else:
                     cost_data[prod][site_id][tech]["railway_cost"] = site["rail_cost"]
 
-                # Apply energy carrier subsidies for this technology
+                # Apply energy carrier subsidies for this technology, filtered at the
+                # operating start year (matching PAM and the score-series window)
                 assert energy_costs_site is not None  # Help mypy understand the control flow
+                operating_start_year = Year(target_year + construction_time)
                 active_energy_subs: dict[str, list] = {}
                 for carrier, carrier_subs in energy_subsidies.items():
                     all_subs = cc.collect_subsidies_for_geo(carrier_subs, site_geo_key).get(tech, [])
-                    active = cc.filter_subsidies_for_year(all_subs, target_year)
+                    active = cc.filter_subsidies_for_year(all_subs, operating_start_year)
                     if active:
                         active_energy_subs[carrier] = active
 
@@ -287,7 +289,9 @@ def prepare_cost_data_for_business_opportunity(
                         active_energy_subs,
                     )
                     sub_summary = ", ".join(f"{len(s)} {c}" for c, s in active_energy_subs.items())
-                    logger.debug(f"[NEW PLANTS] {site['iso3']}/{tech} year={target_year} | Subs: {sub_summary}")
+                    logger.debug(
+                        f"[NEW PLANTS] {site['iso3']}/{tech} year={operating_start_year} | Subs: {sub_summary}"
+                    )
                 else:
                     energy_costs_tech = energy_costs_site
                     output_costs_tech = energy_costs_site

--- a/src/steelo/domain/new_plant_opening.py
+++ b/src/steelo/domain/new_plant_opening.py
@@ -136,7 +136,6 @@ def prepare_cost_data_for_business_opportunity(
     debt_subsidies: dict[str, dict[str, list[Subsidy]]],
     opex_subsidies: dict[str, dict[str, list[Subsidy]]],
     energy_subsidies: dict[str, dict[str, dict[str, list[Subsidy]]]],
-    carbon_costs: dict[str, dict[Year, float]],
     most_common_reductant: dict[str, str],
     environment_most_common_reductant: dict[str, str],
     derive_geo_unit: Callable[[float, float, str], str | None] | None = None,
@@ -164,7 +163,6 @@ def prepare_cost_data_for_business_opportunity(
         debt_subsidies: Nested dictionary with debt subsidies per country and technology (iso3 -> tech -> list of subsidies)
         opex_subsidies: Nested dictionary with OPEX subsidies per country and technology (iso3 -> tech -> list of subsidies)
         energy_subsidies: Nested dictionary with energy carrier subsidies (carrier -> iso3 -> tech -> list of subsidies)
-        carbon_costs: Dictionary with carbon cost series per country (iso3 -> year -> carbon cost)
         most_common_reductant: Dictionary mapping technology to most common reductant from plant group (tech -> reductant)
         environment_most_common_reductant: Fallback dict mapping technology to most common reductant from environment (tech -> reductant)
         derive_geo_unit: Optional ``(lat, lon, iso3) -> geo_unit | None`` derivation (injected from
@@ -409,7 +407,6 @@ def prepare_cost_data_for_business_opportunity(
                 cost_data[prod][site_id][tech]["all_opex_subsidies"] = cc.collect_subsidies_for_geo(
                     opex_subsidies, site_geo_key
                 ).get(tech, [])  # type: ignore[assignment]
-                cost_data[prod][site_id][tech]["carbon_cost_series"] = carbon_costs.get(site["iso3"])  # type: ignore[assignment]
 
                 # Raise error if any critical fields are missing
                 if missing_critical_fields:
@@ -469,7 +466,6 @@ def validate_and_clean_cost_data(
             "output_costs",
             "no_subsidy_prices",
             "bom",
-            "carbon_cost_series",
             "output_shares",
         ]
     )
@@ -541,13 +537,6 @@ def validate_and_clean_cost_data(
                             if not isinstance(tech_data[field], list):
                                 raise ValueError(
                                     f"{field} must be list, got {type(tech_data[field]).__name__}: {tech_data[field]}"
-                                )
-
-                        # carbon_cost_series: dict[Year, float] or None
-                        if tech_data["carbon_cost_series"] is not None:
-                            if not isinstance(tech_data["carbon_cost_series"], dict):
-                                raise ValueError(
-                                    f"carbon_cost_series must be dict or None, got {type(tech_data['carbon_cost_series']).__name__}"
                                 )
 
                         # output_shares: dict of floats (metallic charge -> share of product)

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -128,10 +128,18 @@ class GeospatialModel:
         for iso3, year_costs in bus.env.input_costs.items():
             if iso3 is not None:  # Filter out None keys
                 input_costs_converted[iso3] = {Year(year): costs for year, costs in year_costs.items()}
-        ## Make a price series for COSA and NPV calculations
+        ## Make a price series for COSA and NPV calculations, anchored at the current year.
+        ## Extended by consideration_time + 1 so the opportunity paths can re-anchor it at
+        ## their construction start (up to target_year) and still cover the operating window.
         future_price_series: dict[str, list[float]] = {}
         start_year = bus.env.year
-        end_year = bus.env.year + bus.env.config.construction_time + bus.env.config.plant_lifetime
+        end_year = (
+            bus.env.year
+            + bus.env.config.consideration_time
+            + 1
+            + bus.env.config.construction_time
+            + bus.env.config.plant_lifetime
+        )
         steel_demand = []
         iron_demand = []
         for product in ["steel", "iron"]:

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -281,7 +281,6 @@ class GeospatialModel:
                 top_n_loctechs_as_business_op=bus.env.config.top_n_loctechs_as_business_op,
                 technology_emission_factors=bus.env.technology_emission_factors,
                 chosen_emissions_boundary_for_carbon_costs=bus.env.config.chosen_emissions_boundary_for_carbon_costs,
-                carbon_costs=bus.env.carbon_costs,
                 capex_subsidies=bus.env.capex_subsidies,
                 debt_subsidies=bus.env.debt_subsidies,
                 opex_subsidies=bus.env.opex_subsidies,

--- a/tests/unit/test_energy_subsidies.py
+++ b/tests/unit/test_energy_subsidies.py
@@ -910,3 +910,111 @@ def test_set_input_cost_indi_uses_no_subsidy_prices():
     assert fg.energy_costs["hydrogen"] == 3500.0
     # Other carriers should come from country-level input_costs
     assert fg.energy_costs["natural_gas"] == 0.025
+
+
+# ── prepare_cost_data_for_business_opportunity: subsidy filter year (B4) ─────
+
+
+def test_prepare_cost_data_filters_energy_subsidies_at_operating_start_year():
+    """Energy subsidies for the BOM choice are filtered at the operating start year.
+
+    With target_year=2030 and construction_time=2 the plant first operates in 2032:
+    a subsidy expiring in 2031 (during construction) must not price the BOM, while
+    one starting in 2032 must — matching PAM's operating_start_year filter and the
+    window the score series already uses.
+    """
+    from steelo.domain.new_plant_opening import (
+        prepare_cost_data_for_business_opportunity,
+        NewPlantLocation,
+    )
+
+    product_to_tech = {"steel": ["BF-BOF"]}
+    best_locations_subset = {
+        "steel": [
+            NewPlantLocation(
+                Latitude=40.0,
+                Longitude=-100.0,
+                iso3="USA",
+                power_price=0.05,
+                capped_lcoh=3.0,
+                rail_cost=10.0,
+            ),
+        ],
+    }
+    energy_costs = {
+        "USA": {
+            Year(2025): {
+                "electricity": 0.05,
+                "hydrogen": 3500.0,
+                "bf_gas": 0.02,
+            },
+        },
+    }
+
+    expired_during_construction = Subsidy(
+        scenario_name="test",
+        iso3="USA",
+        start_year=Year(2025),
+        end_year=Year(2031),
+        technology_name="BF-BOF",
+        cost_item="bf_gas",
+        subsidy_type="absolute",
+        subsidy_amount=0.005,
+    )
+    starts_at_operation = Subsidy(
+        scenario_name="test",
+        iso3="USA",
+        start_year=Year(2032),
+        end_year=Year(2040),
+        technology_name="BF-BOF",
+        cost_item="bf_gas",
+        subsidy_type="absolute",
+        subsidy_amount=0.004,
+    )
+    energy_subsidies = {
+        "bf_gas": {"USA": {"BF-BOF": [expired_during_construction, starts_at_operation]}},
+    }
+
+    def _get_bom(_energy_costs, tech, _capacity, _most_common_reductant=None):
+        """Minimal BOM mock."""
+        if tech == "BF-BOF":
+            return (
+                {"energy": {"electricity": {"unit_cost": 50.0, "demand": 0.5}}},
+                0.85,
+                "coal",
+                {"scrap": 1.0},
+            )
+        return None, 0.0, None, {}
+
+    cost_data = prepare_cost_data_for_business_opportunity(
+        product_to_tech=product_to_tech,
+        best_locations_subset=best_locations_subset,
+        current_year=Year(2025),
+        target_year=Year(2030),
+        energy_costs=energy_costs,
+        capex_dict_all_locs_techs={"Americas": {"BF-BOF": 1000.0}},
+        cost_of_debt_all_locs={"USA": {"BF-BOF": 0.05}},
+        cost_of_equity_all_locs={"USA": {"BF-BOF": 0.08}},
+        fopex_all_locs_techs={"USA": {"bf-bof": 50.0}},
+        steel_plant_capacity=100.0,
+        get_bom_from_avg_boms=_get_bom,
+        plant_lifetime=20,
+        construction_time=2,
+        reductant_score_series=_stub_series,
+        iso3_to_region_map={"USA": "Americas"},
+        global_risk_free_rate=0.03,
+        capex_subsidies={},
+        debt_subsidies={},
+        opex_subsidies={},
+        energy_subsidies=energy_subsidies,
+        most_common_reductant={},
+        environment_most_common_reductant={},
+    )
+
+    tech_data = cost_data["steel"][(40.0, -100.0, "USA")]["BF-BOF"]
+
+    # Only the subsidy active at operating start (2032) applies: 0.02 - 0.004 = 0.016.
+    # The one expiring in 2031 (active at target_year 2030) must not.
+    assert tech_data["energy_costs"]["bf_gas"] == pytest.approx(0.016)
+    assert tech_data["output_costs"]["bf_gas"] == pytest.approx(0.024)
+    assert tech_data["no_subsidy_prices"]["bf_gas"] == pytest.approx(0.02)

--- a/tests/unit/test_energy_subsidies.py
+++ b/tests/unit/test_energy_subsidies.py
@@ -766,7 +766,6 @@ def test_prepare_cost_data_normalises_negative_prices_before_subsidy():
     }
     fopex_all_locs_techs = {"USA": {"bf-bof": 50.0}}
     iso3_to_region_map = {"USA": "Americas"}
-    carbon_costs = {"USA": {Year(2030): 50.0}}
 
     # bf_gas subsidy: absolute 0.005 USD/kWh
     bf_gas_subsidy = Subsidy(
@@ -815,7 +814,6 @@ def test_prepare_cost_data_normalises_negative_prices_before_subsidy():
         debt_subsidies={},
         opex_subsidies={},
         energy_subsidies=energy_subsidies,
-        carbon_costs=carbon_costs,
         most_common_reductant={},
         environment_most_common_reductant={},
     )

--- a/tests/unit/test_geo_price_cost_alignment.py
+++ b/tests/unit/test_geo_price_cost_alignment.py
@@ -1,0 +1,306 @@
+"""Regression tests for GEO price/cost year alignment (audit A3).
+
+The opportunity NPV pairs each cost year with the market price of the same calendar
+year: the current-year-anchored price series is re-anchored to the opportunity's
+earliest construction start before ``calculate_npv_full``, whose construction-time
+padding then makes price index i and cost index i the same calendar year. Pre-fix,
+prices were read from the current year while costs came from the target window,
+up to ``consideration_time + 1`` years later.
+"""
+
+import pytest
+
+from steelo.devdata import PointInTime, TimeFrame, get_furnace_group
+from steelo.domain.calculate_costs import (
+    ReductantScoreSeries,
+    calculate_business_opportunity_npvs,
+    calculate_npv_full,
+    calculate_unit_total_opex,
+    calculate_variable_opex,
+    scale_fopex_to_production,
+)
+from steelo.domain.models import Location, PlantGroup
+from steelo.domain.constants import Year
+
+SITE_ID = (40.0, -100.0, "USA")
+
+
+def _flat_score_series(location, tech, output_shares, start, end, **kwargs):
+    """Flat 5.0 score over the requested operating window, recording the window."""
+    n = int(end) - int(start)
+    _score_windows.append((Year(start), Year(end)))
+    return ReductantScoreSeries(scores=[5.0] * n, picks=["scrap"] * n)
+
+
+_score_windows: list[tuple[Year, Year]] = []
+
+
+def _make_cost_data(plant_lifetime: int) -> dict:
+    """Minimal complete cost_data for one steel site with one technology."""
+    return {
+        "steel": {
+            SITE_ID: {
+                "EAF": {
+                    "railway_cost": 10.0,
+                    "energy_costs": {"electricity": 0.05, "hydrogen": 3500.0},
+                    "output_costs": {"electricity": 0.05, "hydrogen": 3500.0},
+                    "no_subsidy_prices": {"electricity": 0.05, "hydrogen": 3500.0},
+                    "capex": 1000.0,
+                    "capex_no_subsidy": 1000.0,
+                    "fopex": 50.0,
+                    "utilization_rate": 0.7,
+                    "reductant": "scrap",
+                    "bom": {"materials": {}},
+                    "output_shares": {"scrap": 1.0},
+                    "all_opex_subsidies": [],
+                    "score_series": [5.0] * plant_lifetime,
+                    "cost_of_debt": 0.05,
+                    "cost_of_debt_no_subsidy": 0.05,
+                    "cost_of_equity": 0.08,
+                }
+            }
+        }
+    }
+
+
+def _expected_npv(price_series: list[float], plant_lifetime: int, construction_time: int) -> float:
+    """The NPV the GEO path must produce for _make_cost_data with the given prices."""
+    unit_vopex = calculate_variable_opex({}, {})
+    unit_fopex = scale_fopex_to_production(50.0, 0.7)
+    opex = [unit_vopex + unit_fopex + 5.0] * plant_lifetime
+    return calculate_npv_full(
+        capex=1000.0,
+        capacity=1000.0,
+        unit_total_opex_list=opex,
+        expected_utilisation_rate=0.7,
+        price_series=price_series,
+        lifetime=plant_lifetime,
+        construction_time=construction_time,
+        cost_of_debt=0.05,
+        cost_of_equity=0.08,
+        equity_share=0.3,
+        infrastructure_costs=10.0,
+    )
+
+
+def _run_identify(monkeypatch, market_price_steel: list[float]) -> dict:
+    """Run identify_new_business_opportunities_4indi and capture the npv_dict it computes."""
+    consideration_time, construction_time, plant_lifetime = 3, 2, 4
+    cost_data = _make_cost_data(plant_lifetime)
+    captured: dict = {}
+
+    monkeypatch.setattr(
+        "steelo.domain.new_plant_opening.prepare_cost_data_for_business_opportunity",
+        lambda *args, **kwargs: cost_data,
+    )
+
+    def _capture_select_top(npv_dict, **kwargs):
+        captured["npv_dict"] = npv_dict
+        return {product: {} for product in npv_dict}
+
+    monkeypatch.setattr(
+        "steelo.domain.new_plant_opening.select_top_opportunities_by_npv",
+        _capture_select_top,
+    )
+
+    plant_group = PlantGroup(plant_group_id="indi", plants=[])
+    plant_group.identify_new_business_opportunities_4indi(
+        current_year=Year(2025),
+        consideration_time=consideration_time,
+        construction_time=construction_time,
+        plant_lifetime=plant_lifetime,
+        input_costs={"USA": {Year(2025): {"electricity": 0.05, "hydrogen": 3500.0}}},
+        locations={"steel": [{"Latitude": 40.0, "Longitude": -100.0, "iso3": "USA"}]},
+        iso3_to_region_map={"USA": "Americas"},
+        market_price={"steel": market_price_steel},
+        capex_dict_all_locs_techs={"Americas": {"EAF": 1000.0}},
+        cost_of_debt_all_locs={"USA": {"EAF": 0.05}},
+        cost_of_equity_all_locs={"USA": {"EAF": 0.08}},
+        steel_plant_capacity=1000.0,
+        all_plant_ids=[],
+        fopex_all_locs_techs={"USA": {"eaf": 50.0}},
+        equity_share=0.3,
+        dynamic_feedstocks={},
+        get_bom_from_avg_boms=lambda *args, **kwargs: (None, 0.7, "scrap", {}),
+        reductant_score_series=_flat_score_series,
+        global_risk_free_rate=0.03,
+        tech_to_product={"EAF": "steel"},
+        allowed_techs={Year(2025): ["EAF"], Year(2029): ["EAF"]},
+        technology_emission_factors=[],
+        chosen_emissions_boundary_for_carbon_costs="scope_1",
+        active_statuses=["operating"],
+        top_n_loctechs_as_business_op=1,
+        probabilistic_agents=False,
+    )
+    return captured["npv_dict"]
+
+
+def test_creation_npv_prices_anchored_at_target_year(monkeypatch):
+    """The creation NPV prices the operating window, not the current year.
+
+    With consideration_time=3 the target year is current + 4, so the first four
+    price entries belong to years before construction can even start. They must
+    not influence the NPV: the result equals a direct calculate_npv_full call on
+    the target-anchored slice, and is invariant to the pre-target entries.
+    """
+    plant_lifetime, construction_time = 4, 2
+    operating_window_prices = [100.0] * (construction_time + plant_lifetime)
+
+    npv_a = _run_identify(monkeypatch, [999.0] * 4 + operating_window_prices)["steel"][SITE_ID]["EAF"]
+    npv_b = _run_identify(monkeypatch, [111.0] * 4 + operating_window_prices)["steel"][SITE_ID]["EAF"]
+
+    expected = _expected_npv(operating_window_prices, plant_lifetime, construction_time)
+    assert npv_a == pytest.approx(expected, rel=1e-12)
+    assert npv_b == pytest.approx(expected, rel=1e-12)
+
+
+def _make_opportunity_fg(plant_lifetime: int):
+    """A considered opportunity FG with everything the real NPV path reads."""
+    fg = get_furnace_group(
+        fg_id="fg_a3",
+        tech_name="EAF",
+        capacity=100,
+        lifetime=PointInTime(
+            current=Year(2030),
+            time_frame=TimeFrame(start=Year(2035), end=Year(2060)),
+            plant_lifetime=plant_lifetime,
+        ),
+        utilization_rate=0.7,
+    )
+    fg.status = "considered"
+    fg.cost_of_debt = 0.05
+    fg.technology.capex = 1000.0
+    fg.tech_unit_fopex = 35.0
+    fg.equity_share = 0.3
+    fg.railway_cost = 10.0
+    fg.chosen_reductant = "scrap"
+    fg.output_shares = {"scrap": 1.0}
+    fg.energy_costs_no_subsidy = {"electricity": 0.05, "hydrogen": 3500.0}
+    return fg
+
+
+def _expected_refresh_npv(fg, price_series: list[float], plant_lifetime: int, construction_time: int) -> float:
+    unit_vopex = calculate_variable_opex(fg.bill_of_materials["materials"], {})
+    unit_fopex = scale_fopex_to_production(fg.tech_unit_fopex, fg.utilization_rate)
+    opex = [unit_vopex + unit_fopex + 5.0] * plant_lifetime
+    return calculate_npv_full(
+        capex=fg.technology.capex,
+        capacity=fg.capacity,
+        unit_total_opex_list=opex,
+        expected_utilisation_rate=fg.utilization_rate,
+        price_series=price_series,
+        lifetime=plant_lifetime,
+        construction_time=construction_time,
+        cost_of_debt=fg.cost_of_debt,
+        cost_of_equity=0.08,
+        equity_share=fg.equity_share,
+        infrastructure_costs=fg.railway_cost,
+    )
+
+
+def test_refresh_npv_prices_anchored_at_opportunity_window():
+    """The yearly re-valuation prices the opportunity's own cost window.
+
+    One year after creation (k=1, consideration_time=3) the window anchors at
+    year + 3, so the first three price entries are pre-window and must not
+    influence the NPV.
+    """
+    plant_lifetime, construction_time, consideration_time = 4, 2, 3
+    fg = _make_opportunity_fg(plant_lifetime)
+    fg.historical_npv_business_opportunities = {Year(2030): 50.0}
+    window_prices = [100.0] * 7
+    market_price = {"steel": [999.0] * 3 + window_prices}
+
+    _score_windows.clear()
+    fg.track_business_opportunities(
+        year=Year(2031),
+        location=Location(lat=40.0, lon=-100.0, country="USA", region="Americas", iso3="USA"),
+        market_price=market_price,
+        cost_of_equity=0.08,
+        plant_lifetime=plant_lifetime,
+        construction_time=construction_time,
+        consideration_time=consideration_time,
+        probability_of_announcement=1.0,
+        all_opex_subsidies=[],
+        reductant_score_series=_flat_score_series,
+    )
+
+    expected = _expected_refresh_npv(fg, window_prices, plant_lifetime, construction_time)
+    assert fg.historical_npv_business_opportunities[Year(2031)] == pytest.approx(expected, rel=1e-12)
+    # Cost window anchored at year + consideration_time + 1 - k + construction_time = 2036
+    assert _score_windows == [(Year(2036), Year(2040))]
+
+
+def test_refresh_straggler_window_floors_at_announcement_plus_construction():
+    """An opportunity older than the consideration window prices the soonest physical path.
+
+    With 6 considered years (k=6 > consideration_time + 1) the raw formula would
+    anchor the window in the past. It must pin at announce-this-year + construction:
+    operations from year + 1 + construction_time, price offset 1.
+    """
+    plant_lifetime, construction_time, consideration_time = 4, 2, 3
+    fg = _make_opportunity_fg(plant_lifetime)
+    # Mixed signs so no announce/discard decision (and no RNG draw) fires
+    fg.historical_npv_business_opportunities = {Year(2025 + i): (100.0 if i % 2 == 0 else -100.0) for i in range(6)}
+    window_prices = [100.0] * 9
+    market_price = {"steel": [999.0] + window_prices}
+
+    _score_windows.clear()
+    fg.track_business_opportunities(
+        year=Year(2031),
+        location=Location(lat=40.0, lon=-100.0, country="USA", region="Americas", iso3="USA"),
+        market_price=market_price,
+        cost_of_equity=0.08,
+        plant_lifetime=plant_lifetime,
+        construction_time=construction_time,
+        consideration_time=consideration_time,
+        probability_of_announcement=1.0,
+        all_opex_subsidies=[],
+        reductant_score_series=_flat_score_series,
+    )
+
+    # Operations can start no earlier than 2031 (announce) + 1 + 2 (construction) = 2034
+    assert _score_windows == [(Year(2034), Year(2038))]
+    expected = _expected_refresh_npv(fg, window_prices, plant_lifetime, construction_time)
+    assert fg.historical_npv_business_opportunities[Year(2031)] == pytest.approx(expected, rel=1e-12)
+
+
+def test_geo_npv_composition_matches_pam_formula():
+    """GEO's opportunity NPV reproduces the PAM opex composition to 1e-9.
+
+    Identical inputs — materials-only VOPEX, production-scaled FOPEX, flat score,
+    flat prices — through calculate_business_opportunity_npvs and through the
+    PAM-side composition (calculate_unit_total_opex + score -> calculate_npv_full)
+    must agree, locking the two valuation paths together.
+    """
+    plant_lifetime, construction_time = 4, 2
+    flat_prices = [100.0] * (construction_time + plant_lifetime)
+
+    npv_dict = calculate_business_opportunity_npvs(
+        cost_data=_make_cost_data(plant_lifetime),
+        target_year=2029,
+        market_price={"steel": flat_prices},
+        steel_plant_capacity=1000.0,
+        plant_lifetime=plant_lifetime,
+        construction_time=construction_time,
+        equity_share=0.3,
+    )
+
+    unit_vopex = calculate_variable_opex({}, {})
+    unit_fopex = scale_fopex_to_production(50.0, 0.7)
+    pam_opex = [calculate_unit_total_opex(unit_vopex, unit_fopex, 0.7) + 5.0] * plant_lifetime
+    pam_npv = calculate_npv_full(
+        capex=1000.0,
+        capacity=1000.0,
+        unit_total_opex_list=pam_opex,
+        expected_utilisation_rate=0.7,
+        price_series=flat_prices,
+        lifetime=plant_lifetime,
+        construction_time=construction_time,
+        cost_of_debt=0.05,
+        cost_of_equity=0.08,
+        equity_share=0.3,
+        infrastructure_costs=10.0,
+    )
+
+    assert npv_dict["steel"][SITE_ID]["EAF"] == pytest.approx(pam_npv, abs=1e-9)

--- a/tests/unit/test_identify_new_business_opportunities_4indi.py
+++ b/tests/unit/test_identify_new_business_opportunities_4indi.py
@@ -341,7 +341,6 @@ class TestPrepareDataForBusinessOpportunity:
         }
         fopex_all_locs_techs = {"USA": {"eaf": 50.0}}  # lowercase tech name
         iso3_to_region_map = {"USA": "Americas"}
-        carbon_costs = {"USA": {Year(2030): 50.0}}
 
         cost_data = prepare_cost_data_for_business_opportunity(
             product_to_tech=product_to_tech,
@@ -364,7 +363,6 @@ class TestPrepareDataForBusinessOpportunity:
             debt_subsidies={},
             opex_subsidies={},
             energy_subsidies={},
-            carbon_costs=carbon_costs,
             most_common_reductant={},
             environment_most_common_reductant={},
         )
@@ -443,7 +441,6 @@ class TestPrepareDataForBusinessOpportunity:
         }
         fopex_all_locs_techs = {"USA": {"eaf": 50.0}}
         iso3_to_region_map = {"USA": "Americas"}
-        carbon_costs = {"USA": {Year(2030): 50.0}}
 
         # When cost_of_debt is missing, ValueError is raised immediately
         with pytest.raises(ValueError, match="Missing critical site-level data"):
@@ -468,7 +465,6 @@ class TestPrepareDataForBusinessOpportunity:
                 debt_subsidies={},
                 opex_subsidies={},
                 energy_subsidies={},
-                carbon_costs=carbon_costs,
                 most_common_reductant={},
                 environment_most_common_reductant={},
             )
@@ -531,7 +527,6 @@ class TestPrepareDataForBusinessOpportunity:
         }
         fopex_all_locs_techs = {"USA": {"eaf": 50.0}}
         iso3_to_region_map = {"USA": "Americas"}
-        carbon_costs = {"USA": {Year(2030): 50.0}}
 
         capex_subsidy = Subsidy(
             scenario_name="test",
@@ -565,7 +560,6 @@ class TestPrepareDataForBusinessOpportunity:
             debt_subsidies={},
             opex_subsidies={},
             energy_subsidies={},
-            carbon_costs=carbon_costs,
             most_common_reductant={},
             environment_most_common_reductant={},
         )
@@ -641,7 +635,6 @@ class TestPrepareDataForBusinessOpportunity:
         }
         fopex_all_locs_techs = {"USA": {"eaf": 50.0}}
         iso3_to_region_map = {"USA": "Americas"}
-        carbon_costs = {"USA": {Year(2030): 50.0}}
 
         h2_subsidy = Subsidy(
             scenario_name="test_h2",
@@ -688,7 +681,6 @@ class TestPrepareDataForBusinessOpportunity:
                 "hydrogen": {"USA": {"EAF": [h2_subsidy]}},
                 "electricity": {"USA": {"EAF": [elec_subsidy]}},
             },
-            carbon_costs=carbon_costs,
             most_common_reductant={},
             environment_most_common_reductant={},
         )
@@ -761,7 +753,6 @@ class TestPrepareDataForBusinessOpportunity:
         }
         fopex_all_locs_techs = {}  # Missing fopex data
         iso3_to_region_map = {"USA": "Americas"}
-        carbon_costs = {"USA": {Year(2030): 50.0}}
 
         # Should raise ValueError immediately due to missing fopex
         with pytest.raises(ValueError, match="Missing critical cost data"):
@@ -786,7 +777,6 @@ class TestPrepareDataForBusinessOpportunity:
                 debt_subsidies={},
                 opex_subsidies={},
                 energy_subsidies={},
-                carbon_costs=carbon_costs,
                 most_common_reductant={},
                 environment_most_common_reductant={},
             )
@@ -960,11 +950,6 @@ class TestPrepareDataForBusinessOpportunity:
             "CHN": {"dri": 70.0},
         }
         iso3_to_region_map = {"USA": "Americas", "DEU": "Europe", "CHN": "Asia"}
-        carbon_costs = {
-            "USA": {Year(2030): 50.0},
-            "DEU": {Year(2030): 60.0},
-            "CHN": {Year(2030): 30.0},
-        }
 
         cost_data = prepare_cost_data_for_business_opportunity(
             product_to_tech=product_to_tech,
@@ -987,7 +972,6 @@ class TestPrepareDataForBusinessOpportunity:
             debt_subsidies={},
             opex_subsidies={},
             energy_subsidies={},
-            carbon_costs=carbon_costs,
             most_common_reductant={},
             environment_most_common_reductant={},
         )
@@ -1217,7 +1201,6 @@ class TestIdentifyNewBusinessOpportunities4indi:
             "allowed_techs": {Year(2025): ["EAF"], Year(2028): ["EAF"]},
             "technology_emission_factors": [],
             "chosen_emissions_boundary_for_carbon_costs": "scope_1",
-            "carbon_costs": {"USA": {Year(2028): 50.0}},
             "top_n_loctechs_as_business_op": 2,
         }
 
@@ -1474,7 +1457,6 @@ def _complete_cost_data_entry():
         "output_costs": {"electricity": 0.05},
         "no_subsidy_prices": {"electricity": 0.05},
         "bom": {"energy": {"electricity": {"unit_cost": 50.0, "demand": 0.5}}},
-        "carbon_cost_series": None,
         "output_shares": {"scrap": 1.0},
     }
 
@@ -1682,7 +1664,6 @@ def test_two_technologies_at_one_site_spawn_two_plants(monkeypatch):
         allowed_techs={Year(2028): ["EAF", "BOF"]},
         technology_emission_factors=[],
         chosen_emissions_boundary_for_carbon_costs="scope_1",
-        carbon_costs={"USA": {Year(2028): 50.0}},
         active_statuses=["operating"],
         top_n_loctechs_as_business_op=2,
     )

--- a/tests/unit/test_priority_kpi.py
+++ b/tests/unit/test_priority_kpi.py
@@ -756,3 +756,41 @@ def test_country_lottery_scales_with_country_size():
     assert sml_count >= 1
     assert big_count >= 3  # 0.5% of 810 cells, not a single token pixel
     assert big_count > sml_count
+
+
+def test_find_top_locations_per_country_deduplicates_global_and_lottery_rows():
+    """A cell in both the global top and its country's lottery appears once in the frame.
+
+    Notes:
+        Guards against the former plain concat, where such a cell occupied two rows
+        and consumed two slots in the downstream 10% NPV sample, double-weighting
+        exactly the sites that were already best.
+    """
+    lat = np.array([10.0, 20.0])
+    lon = np.array([100.0, 110.0])
+    iso3 = np.full((2, 2), "USA", dtype=object)
+    # (10.0, 100.0) is USA's cheapest cell, so the country lottery re-selects it
+    cashflow = np.array([[100.0, 200.0], [300.0, 400.0]])
+
+    ds = xr.Dataset(
+        {
+            "iso3": xr.DataArray(iso3, coords={"lat": lat, "lon": lon}, dims=["lat", "lon"]),
+            "outgoing_cashflow_steel": xr.DataArray(cashflow, coords={"lat": lat, "lon": lon}, dims=["lat", "lon"]),
+            "top10_steel": xr.DataArray(np.zeros((2, 2)), coords={"lat": lat, "lon": lon}, dims=["lat", "lon"]),
+            "feasibility_mask": xr.DataArray(np.ones((2, 2)), coords={"lat": lat, "lon": lon}, dims=["lat", "lon"]),
+        }
+    )
+    ds["top10_steel"].values[0, 0] = 1
+    top_locations = {"steel": pd.DataFrame({"Latitude": [10.0], "Longitude": [100.0]})}
+
+    _, locations_df = find_top_locations_per_country(
+        ds=ds,
+        top_locations=top_locations,
+        product="steel",
+        priority_pct=10,
+        random_seed=42,
+    )
+
+    assert not locations_df.duplicated(subset=["Latitude", "Longitude"]).any()
+    best_cell_rows = ((locations_df["Latitude"] == 10.0) & (locations_df["Longitude"] == 100.0)).sum()
+    assert best_cell_rows == 1

--- a/tests/unit/test_subsidy_geo_key.py
+++ b/tests/unit/test_subsidy_geo_key.py
@@ -293,7 +293,6 @@ def test_candidate_site_collects_country_and_province_capex_subsidies():
         debt_subsidies={},
         opex_subsidies={},
         energy_subsidies={},
-        carbon_costs={"CHN": {Year(2030): 50.0}},
         most_common_reductant={},
         environment_most_common_reductant={},
         derive_geo_unit=derive_geo_unit,
@@ -335,3 +334,66 @@ def test_subsidies_validator_flags_bogus_geo_key():
 
     assert len(errors) == 1
     assert "CHN:CN-XX" in errors[0].message
+
+
+def test_candidate_bom_priced_at_province_energy_costs():
+    """The BOM pick and stored candidate prices use the province energy row when the site
+    falls inside one, falling back to the country row elsewhere — the same resolution the
+    NPV score series applies, so the two sides of the valuation agree (audit B3)."""
+    energy_costs = {
+        "CHN": {Year(2025): {"electricity": 0.05, "hydrogen": 3500.0, "natural_gas": 0.03}},
+        "CHN:CN-HE": {Year(2025): {"electricity": 0.06, "hydrogen": 3600.0, "natural_gas": 0.01}},
+    }
+    sites = [
+        NewPlantLocation(Latitude=39.0, Longitude=114.5, iso3="CHN", power_price=0.05, capped_lcoh=3.0, rail_cost=10.0),
+        NewPlantLocation(Latitude=31.6, Longitude=118.5, iso3="CHN", power_price=0.05, capped_lcoh=3.0, rail_cost=10.0),
+    ]
+
+    def derive_geo_unit(lat, lon, iso3):
+        return "CN-HE" if lat == 39.0 else "CN-AH"
+
+    bom_price_inputs = []
+
+    def _capturing_get_bom(energy_costs_arg, tech, _capacity, _most_common_reductant=None):
+        bom_price_inputs.append(dict(energy_costs_arg))
+        return _mock_get_bom(energy_costs_arg, tech, _capacity, _most_common_reductant)
+
+    cost_data = prepare_cost_data_for_business_opportunity(
+        product_to_tech={"steel": ["EAF"]},
+        best_locations_subset={"steel": sites},
+        current_year=Year(2025),
+        target_year=Year(2030),
+        energy_costs=energy_costs,
+        capex_dict_all_locs_techs={"Asia": {"EAF": 1000.0}},
+        cost_of_debt_all_locs={"CHN": {"EAF": 0.05}},
+        cost_of_equity_all_locs={"CHN": {"EAF": 0.08}},
+        fopex_all_locs_techs={"CHN": {"eaf": 50.0}},
+        steel_plant_capacity=100.0,
+        get_bom_from_avg_boms=_capturing_get_bom,
+        plant_lifetime=20,
+        construction_time=2,
+        reductant_score_series=_stub_series,
+        iso3_to_region_map={"CHN": "Asia"},
+        global_risk_free_rate=0.03,
+        capex_subsidies={},
+        debt_subsidies={},
+        opex_subsidies={},
+        energy_subsidies={},
+        most_common_reductant={},
+        environment_most_common_reductant={},
+        derive_geo_unit=derive_geo_unit,
+    )
+
+    hebei = cost_data["steel"][(39.0, 114.5, "CHN")]["EAF"]
+    anhui = cost_data["steel"][(31.6, 118.5, "CHN")]["EAF"]
+
+    # Non-overridden carrier: province row for the CN-HE site, country row for CN-AH
+    # (no dedicated row -> logged fallback to the country)
+    assert hebei["no_subsidy_prices"]["natural_gas"] == pytest.approx(0.01)
+    assert anhui["no_subsidy_prices"]["natural_gas"] == pytest.approx(0.03)
+    # Pixel overrides still win for electricity and hydrogen at both sites
+    assert hebei["no_subsidy_prices"]["electricity"] == pytest.approx(0.05)
+    assert anhui["no_subsidy_prices"]["electricity"] == pytest.approx(0.05)
+    # The BOM pick itself was priced with the resolved carriers
+    assert bom_price_inputs[0]["natural_gas"] == pytest.approx(0.01)
+    assert bom_price_inputs[1]["natural_gas"] == pytest.approx(0.03)


### PR DESCRIPTION
Five independent fixes to the greenfield opportunity path, one commit each with a regression test.

- **Price/cost year alignment.** The opportunity NPV paired year-*t* market prices with costs from year *t + consideration_time + 1*, and the yearly re-valuation drifted similarly, shrinking as an opportunity aged. Prices are now re-anchored to the opportunity's earliest construction start, so price year *i* and cost year *i* are the same calendar year. The shared GEO price series is extended by `consideration_time + 1` years to cover that window, and the re-valuation window is floored at the soonest physical path — announce now, construct from next year — so long-lived opportunities stop pricing a window that drifts into the past. Includes a parity test locking the GEO NPV composition to the PAM formula.
- **Province energy prices for the candidate BOM.** The BOM and reductant were picked at country carrier prices while the NPV scored the same site at province prices. Both now resolve through the site `Location`, and a spawned furnace group carries province costs from creation rather than being corrected a year later.
- **Candidate deduplication.** A cell appearing in both the global top and its country's lottery occupied two rows, consuming two slots in the 10% NPV sample and double-weighting sites that were already best.
- **Energy-subsidy filter year.** Subsidies for the candidate BOM choice are filtered at the operating start year, matching PAM and the window the score series already prices.
- **Dead `carbon_cost_series` plumbing removed.** Never read — carbon enters through the reductant score series — but load-bearing in a validation gate, so it could silently drop a technology.

The price/cost alignment moves every greenfield NPV.
