### PR TITLE
Filter energy subsidies at the operating start year in the geo cost refresh

### DIFF
--- a/docs/domain_simulation_logic/geospatial_model/baseload_optimization_atlas.md
+++ b/docs/domain_simulation_logic/geospatial_model/baseload_optimization_atlas.md
@@ -97,6 +97,7 @@ run_simulation --baseload-power-sim-dir path-to-baseload-power-simulation-folder
     - Filter out water bodies (oceans and seas).
     - Set a maximum altitude and slope.
     - Exclude grid points with zero potential for both solar and wind.
+    - Note: this is BOA's own eligibility filter, separate from the steelo siting feasibility mask (which additionally allows land at or below sea level).
 
 5. For each eligible grid point
     - Sample many system design candidates

--- a/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
+++ b/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
@@ -156,20 +156,20 @@ Randomly samples a subset of top priority locations to reduce computational burd
 
 **Function:** `prepare_cost_data_for_business_opportunity()`
 
-Gathers all cost inputs needed for NPV calculation for each location-technology pair. Location-technology combinations with missing or invalid critical data are skipped and a warning is logged.
+Gathers all cost inputs needed for NPV calculation for each location-technology pair. Sites missing critical data (energy costs, cost of equity or debt) raise a hard error, as do invalid data types; technologies with an incomplete field set are dropped in validation, so only complete entries reach the NPV.
 
 **Required Inputs:**
 
 | Input Category | Components | Source |
 |----------------|-----------|---------|
-| Energy costs | Electricity, hydrogen, gas, coal prices | Country-level data + site-specific renewable calculations for energy costs |
+| Energy costs | Electricity, hydrogen, gas, coal prices | Geography-resolved data (province row when the site falls in one, else country) + site-specific renewable calculations for electricity and hydrogen |
 | Financial parameters | Cost of debt, cost of equity | Country-level financial data |
 | CAPEX | Capital expenditure per tonne capacity | Regional technology-specific estimates |
 | OPEX | Fixed operating costs per tonne | Country and technology-specific |
 | Infrastructure | Railway buildout cost | From priority location selection |
 | Production | Bill of materials, utilization rate, reductant type | Technology-specific averages |
-| Subsidies | CAPEX, debt, and OPEX subsidies | Country and technology-specific policies |
-| Carbon pricing | Carbon cost time series | Country-level projections |
+| Subsidies | CAPEX, debt, and OPEX subsidies | Geography- and technology-specific policies (country and province rows apply additively) |
+| Carbon pricing | Enters via the per-year reductant score series, not a separate cost field | Country-level projections |
 
 ### Step 4: NPV Calculation
 
@@ -181,6 +181,8 @@ Calculates Net Present Value for each business opportunity using an **adjusted N
 
 Subsidies are often announced years before plants are built. Standard NPV using current-year subsidies would make subsidized technologies appear less attractive until subsidies activate. The adjusted NPV assumes subsidies announced for the target year will be available, preventing artificial delays in subsidized technology adoption. This adjusted NPV is only used for the decision to create a business opportunity. Once a plant is constructed, it uses actual year-by-year costs, not the adjusted values.
 
+**Price/cost alignment:** the market-price series handed to the NPV is anchored at the target (construction-start) year, so after the construction-time lag each revenue year prices the same calendar year as its costs — the NPV values the plant's actual operating window. The yearly re-valuation of existing opportunities re-anchors the same way, floored at the soonest path still open (announce now, construct from next year).
+
 **NPV Components:**
 
 | Component | Composition | Subsidy Timing | Period |
@@ -190,8 +192,8 @@ Subsidies are often announced years before plants are built. Standard NPV using 
 | **Cost of Equity** | Return required by investors | No subsidies | Financing period |
 | **OPEX - Variable** | Materials + energy from bill of materials × unit costs | OPEX subsidies: Operation years | Annual (plant lifetime) |
 | **OPEX - Fixed** | Fixed operating costs per tonne | OPEX subsidies: Operation years | Annual (plant lifetime) |
-| **Energy Costs** | Energy prices for all carriers (electricity, hydrogen, gas, etc.) | Energy subsidies: Target year | Annual (plant lifetime) |
-| **Carbon Costs** | Emissions × carbon price trajectory | No subsidies | Annual (plant lifetime) |
+| **Energy Costs** | Energy prices for all carriers (electricity, hydrogen, gas, etc.) | Energy subsidies: Operating start year | Annual (plant lifetime) |
+| **Carbon Costs** | Emissions × carbon price trajectory (inside the reductant score series) | No subsidies | Annual (plant lifetime) |
 | **Revenue** | Production capacity × utilization rate × market price projections | N/A | Annual (plant lifetime) |
 | **Discount Rate** | Weighted average cost of capital (WACC = debt share × cost of debt + equity share × cost of equity) | Applied to debt portion only | NPV calculation |
 

--- a/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
+++ b/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
@@ -14,7 +14,7 @@ Business opportunities progress through the following stages:
 The system updates the costs and status of business opportunities each simulation year:
 1. **Update Dynamic Costs**
    - Refresh CAPEX, cost of debt, and energy prices for all carriers
-   - Apply subsidies based on earliest construction start year
+   - Apply subsidies (CAPEX and debt at the earliest construction start year; energy carriers at the operating start year that follows it)
    - Update bill of materials with new energy prices
 
 2. **Update Status**
@@ -239,23 +239,24 @@ Updates dynamic costs for all CONSIDERED and ANNOUNCED business opportunities ea
   - `output_energy_costs`: subsidised output prices (increased by subsidy for physical carriers) — used for by-product revenue
   - `energy_costs_no_subsidy`: original unsubsidised prices — used as baseline for yearly refresh
 - Electricity and hydrogen prices sourced from the geospatial layer (custom power mix / capped LCOH); other carriers from the furnace group's existing cost base
+- Energy subsidies are collected for the plant's geography (country and province rows apply additively) and filtered at the operating start year (construction start + construction time), matching opportunity creation and the plant agent model
 - Bill of materials (updated with new subsidised input energy prices)
 
 **Note:** For more information on the electricity and hydrogen prices see related documentation [Priority Location Selection](priority_location_selection.md).
 
 **Target Year Calculation:**
 
-The system uses subsidies from the earliest construction start year, reflecting that subsidies are often announced in advance.
+The system uses CAPEX and debt subsidies from the earliest construction start year, reflecting that subsidies are often announced in advance. Energy subsidies use the operating start year (construction start + construction time), because subsidised carrier prices are what the plant pays once it is running.
 
-| Status | Target Year | Reasoning |
-|--------|-------------|-----------|
-| CONSIDERED | `current + consideration_time + 1 - years_considered` | Earliest construction start based on consideration progress |
+| Status | Target Year (construction start) | Reasoning |
+|--------|---------------------------------|-----------|
+| CONSIDERED | `max(current + consideration_time + 1 - years_considered, current + 1)` | Earliest construction start based on consideration progress, floored at the soonest path still open (announce now, construct from next year) — the same floor the NPV re-valuation applies |
 | ANNOUNCED | `current + 1` | Next year (announcement time = 1) |
 
 **Process:**
 For each business opportunity:
-1. Calculate appropriate target year based on opportunity status
-2. Filter subsidies active in target year and calculate new costs
+1. Calculate the construction start year based on opportunity status
+2. Filter CAPEX and debt subsidies at that year, energy subsidies at construction start + construction time, and calculate new costs
 3. Update bill of materials with new energy prices
 4. Skip updates if costs haven't changed and update modified costs
 

--- a/docs/domain_simulation_logic/geospatial_model/priority_location_selection.md
+++ b/docs/domain_simulation_logic/geospatial_model/priority_location_selection.md
@@ -33,7 +33,7 @@ The pipeline to select the best locations for building new steel and iron plants
 Each grid point is assigned to a country using country boundary shapefiles. This enables country-specific constraints and ensures location data can be mapped to national policies and regulations.
 
 ### Feasibility Mask
-Not all locations are suitable for building steel plants. The feasibility mask filters out locations based on physical constraints: sea points, high altitude locations, steep slopes, and extreme latitudes. The altitude is calculated from geopotential data, and the final mask combines all terrain constraints.
+Not all locations are suitable for building steel plants. The feasibility mask filters out locations based on physical constraints: sea points, high altitude locations, steep slopes, and extreme latitudes. Land at or below sea level is feasible — water is excluded by the land-sea mask, so the altitude constraint is an upper bound only. The altitude is calculated from geopotential data, and the final mask combines all terrain constraints.
 
 **Configuration:**
 - `max_altitude`: Maximum elevation in meters (default: 1'500m)
@@ -127,6 +127,8 @@ Different land cover types and uses are more or less expensive to build on. This
 | Water | 2.0× |
 | Snow and Ice | 2.0× |
 
+Cells without LULC coverage receive the neutral minimum factor 1.0×.
+
 **Purpose:** Accounts for site clearing, grading, and environmental remediation costs.
 **Configuration:** Can be disabled entirely via `include_lulc_cost = False`
 
@@ -175,7 +177,7 @@ To ensure all countries have an opportunity to build new plants (even small coun
 
 **Process:**
 1. For each country (ISO3 code), extract the top X/10% cheapest locations within that country (e.g., if global priority is 5%, select top 0.5% per country)
-2. Add these country-specific locations to the global top locations
+2. Add these country-specific locations to the global top locations (duplicates already present in the global top are dropped)
 3. Number of locations per country is proportional to the country's feasible land area
 4. Uses the same distribution-adaptive selection method as Step 2
 
@@ -201,22 +203,27 @@ The pipeline generates the following plots (saved to `geo_plots_dir`):
 - `altitude_bin.png` - Binary altitude feasibility
 - `slope_bin.png` - Binary slope feasibility
 - `feasibility_mask.png` - Combined binary feasibility mask (land-sea mask, altitude, and slope)
-- `power_price_{year}.png` - Electricity costs by location (grid)
-- `baseload_lcoe_{year}_p{X}.png` - Renewable LCOE (if baseload used)
-- `capped_lcoh_{year}.png` - Hydrogen costs (after regional cap and intraregional trade, if allowed)
-- `distance_to_rail.png` - Distance to nearest railway network
-- `rail_infrastructure_cost.png` - Railway buildout costs
-- `distance_to_demand_{product}_{year}.png` - Distance to nearest demand by product (demand centers for steel, steel plants for iron)
-- `transport_cost_to_demand_{product}_{year}.png` - Per-tonne shipping cost to demand
-- `distance_to_feedstock_{product}_{year}.png` - Distance to nearest feedstock sources by product (iron plants for steel, iron ore mines for iron)
-- `transport_cost_to_feedstock_{product}_{year}.png` - Per-tonne shipping cost from feedstock
+- `grid_power_price_{year}.png` - Grid electricity price by location
+- `power_price_100cov_{year}.png` - Blended power price (baseload LCOE + grid share)
+- `optimal_lcoe_{year}_p{X}.png` - Renewable baseload LCOE (if baseload used)
+- `lcoh_{year}_p{X}.png` - Hydrogen costs (after regional cap and intraregional trade, if allowed)
+- `rail_distance.png` - Distance to nearest railway network
+- `rail_cost.png` - Railway buildout costs
+- `landtype_factor.png` - Land-type CAPEX multiplier map
+- `demand_distance_{product}_{year}.png` - Distance to nearest demand by product (demand centers for steel, steel plants for iron)
+- `demand_transportation_cost_per_ton_{product}_{year}.png` - Per-tonne shipping cost to demand
+- `feedstock_distance_{product}_{year}.png` - Distance to nearest feedstock sources by product (iron plants for steel, iron ore mines for iron)
+- `feedstock_transportation_cost_per_ton_{product}_{year}.png` - Per-tonne shipping cost from feedstock
+- `iron_ore_mines.png` - Iron-ore mine bubble map
 
 ### Priority Calculation Plots (Per Year, Per Product)
-- `outgoing_cashflow_proxy_{product}_{year}_p{X}.png` - Total lifetime costs
+- `lifetime_cost_proxy_{product}_{year}_p{X}.png` - Total lifetime costs
 - `priority_heatmap_{product}_{year}_p{X}.png` - Inverted priority map (higher = better)
-- `top{X}_priority_locations_{product}_{year}.png` - Selected candidate locations
+- `top{priority_pct}_priority_locations_{product}_{year}.png` - Selected candidate locations
 
 Where `{X}` indicates the percentage of grid power vs. baseload (e.g., p5 = 95% baseload + 5% grid).
+
+**Plot cadence:** year-stamped maps are drawn on milestone years only (first and final year, plus every 5th year for price/LCOH layers and every 10th for distance/transport layers). The power-price histogram and the iron-ore mine map are written only in the final simulation year.
 
 ## Code implementation
 
@@ -240,7 +247,7 @@ The wrapper function `get_candidate_locations_for_opening_new_plants()` in `src/
 11. **Extract energy prices** - Stores power and hydrogen costs for downstream NPV calculations
 
 **Timing & Performance:**
-Each step is timed and logged separately. The total pipeline typically takes 30 sec - 5 min depending on:
+Each step is timed and logged separately (`[GEO TIMING]`, DEBUG). After vectorisation of the priority-KPI and lottery loops, a steady-state year takes well under a minute at the default 0.25° resolution; the first year is slower while static layers are built. Runtime depends on:
 - Whether cached layers exist (ISO3, feasibility mask, infrastructure costs) - year 1 vs the rest
 - Available cores for task parallelization
 

--- a/docs/domain_simulation_logic/outputs_and_postprocessing.md
+++ b/docs/domain_simulation_logic/outputs_and_postprocessing.md
@@ -68,7 +68,7 @@ Emissions and cost-curve plots write to top-level sibling folders rather than un
 output/
   plots/
     PAM/        # plant-agent plots (capacity, capex, charges, prices)
-    GEO/        # geospatial / new-plant plots
+    GEO/        # geospatial / new-plant plots (maps on milestone years; power-price histogram and mine map final-year-only)
     TM/         # trade-model plots
     emissions/  # SteelPlotter.plot_emissions_by_technology
     cost_curves/  # SteelPlotter cost-curve methods

--- a/docs/domain_simulation_logic/plant_agent_model/plant_expansions.md
+++ b/docs/domain_simulation_logic/plant_agent_model/plant_expansions.md
@@ -139,9 +139,10 @@ graph TD
 - **Subsidy Types**:
   - Debt subsidies: Reduce cost of borrowing
   - CAPEX subsidies: Reduce upfront investment
+  - Energy carrier subsidies: Reduce the carrier prices used to price the candidate's bill of materials
 - **Actions**:
   - Get all subsidies for location and technology
-  - Filter to only active subsidies for current year using `filter_subsidies_for_year()`
+  - Filter to only active subsidies using `filter_subsidies_for_year()`: CAPEX and debt at the current year (when they are incurred), energy carriers at the operating start year (`current_year + construction_time`, when the expansion starts consuming them)
   - Calculate adjusted cost of debt using `calculate_debt_with_subsidies()`
   - Calculate adjusted CAPEX using `calculate_capex_with_subsidies()`
 - **Key Variables**: `selected_debt_subsidies`, `selected_capex_subsidies`, adjusted `cost_of_debt`, adjusted `capex`
@@ -253,7 +254,7 @@ Returns either:
    - Higher cost/benefit ratio results in lower acceptance probability
 
 4. **Subsidy Application**:
-   - Subsidies are filtered to only include those active in the current year
+   - CAPEX and debt subsidies are filtered to those active in the current year; energy carrier subsidies to those active at the operating start year (`current_year + construction_time`)
    - CAPEX subsidies reduce upfront investment costs
    - Debt subsidies reduce the cost of borrowing
    - Both types are passed to the AddFurnaceGroup command

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -6256,6 +6256,7 @@ class PlantGroup:
         self,
         current_year: Year,
         consideration_time: int,
+        construction_time: int,
         custom_energy_costs: dict,
         capex_dict_all_locs: dict[str, dict[str, float]],
         cost_debt_all_locs: dict[str, dict[str, float]],
@@ -6277,13 +6278,17 @@ class PlantGroup:
         Dynamic costs are updated based on the following logic:
             - Base costs: CAPEX, cost of debt, electricity costs, and hydrogen costs are set to the
               current year.
-            - Subsidies: the subsidies which are applied on top of CAPEX and cost of debt are set to
-              the target year, which is the [current year + consideration time + announcement time -
-              years considered] for considered BOs and [current year + 1] for announced BOs.
+            - CAPEX and debt subsidies: set to the construction start year, which is the [current year
+              + consideration time + announcement time - years considered] for considered BOs and
+              [current year + 1] for announced BOs, floored at [current year + 1].
+            - Energy subsidies: set to the operating start year [construction start + construction
+              time], since subsidised carrier prices are what the plant pays once running. This matches
+              opportunity creation, PAM and the window the score series prices.
 
         Args:
             current_year: Current simulation year
             consideration_time: Number of years to consider before announcement
+            construction_time: Years to build the plant, offsetting construction start to operating start
             custom_energy_costs: Dictionary containing power_price and capped_lcoh data arrays
             capex_dict_all_locs: Dictionary mapping region -> tech -> capex
             cost_debt_all_locs: Dictionary mapping iso3 -> tech -> cost of debt
@@ -6358,9 +6363,12 @@ class PlantGroup:
                             years_already_considered = len(fg.historical_npv_business_opportunities)
                         else:
                             years_already_considered = 0
+                        # Floored at the soonest path still open to a considered opportunity:
+                        # announce now, construct from next year (mirrors track_business_opportunities)
                         year = Year(
-                            current_year + consideration_time + 1 - years_already_considered
+                            max(current_year + consideration_time + 1 - years_already_considered, current_year + 1)
                         )  # announcement_time = 1
+                    operating_start_year = Year(year + construction_time)
 
                     selected_debt_subsidies = filter_subsidies_for_year(all_debt_subsidies, year)
                     selected_capex_subsidies = filter_subsidies_for_year(all_capex_subsidies, year)
@@ -6407,7 +6415,7 @@ class PlantGroup:
                         all_subs = collect_subsidies_for_geo(carrier_subs, plant.location.geo_key).get(
                             fg.technology.name, []
                         )
-                        active = filter_subsidies_for_year(all_subs, year)
+                        active = filter_subsidies_for_year(all_subs, operating_start_year)
                         if active:
                             active_energy_subs[carrier] = active
 
@@ -6424,7 +6432,7 @@ class PlantGroup:
                         )
                         sub_summary = ", ".join(f"{len(s)} {c}" for c, s in active_energy_subs.items())
                         logger.debug(
-                            f"[NEW PLANTS] {iso3}/{fg.technology.name} year={year} Subs: {sub_summary}",
+                            f"[NEW PLANTS] {iso3}/{fg.technology.name} year={operating_start_year} Subs: {sub_summary}",
                         )
                     else:
                         new_energy_costs = dict(base_costs)

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -6013,8 +6013,9 @@ class PlantGroup:
             2. Randomly select a subset of top locations for a more in-depth assessment to reduce runtime.
             3. Prepare all required inputs (input costs with electricity and hydrogen costs from own parc,
                capex and cost of debt with subsidies, cost of equity, fixed OPEX, market price of product,
-               railway costs, average BOM, and utilization rate). If any data is missing, the location-
-               technology pair is skipped (business opportunity not considered) and a warning is logged.
+               railway costs, average BOM, and utilization rate). Sites missing critical data
+               (energy costs, cost of equity or debt) raise a ValueError, as do invalid data types;
+               technologies with an incomplete field set are dropped in validation.
             4. Calculate the NPV for all business opportunities (location-technology pairs) for each product.
             5. Choose top N location-technology combinations with high NPVs and list them as potential
                business opportunities. This step includes some randomness, but is mainly driven by NPV
@@ -6049,11 +6050,13 @@ class PlantGroup:
             chosen_emissions_boundary_for_carbon_costs: Emission boundary for carbon costs
             active_statuses: Status strings whose furnace groups vote in the group's
                 most-common-reductant aggregation
-            top_n_loctechs_as_business_op: Number of top opportunities to select (default: 5)
-            capex_subsidies: Dictionary mapping iso3 -> tech -> list of capex subsidies
-            debt_subsidies: Dictionary mapping iso3 -> tech -> list of debt subsidies
-            opex_subsidies: Dictionary mapping iso3 -> tech -> list of opex subsidies
-            energy_subsidies: Dictionary mapping carrier -> iso3 -> tech -> list of energy subsidies
+            top_n_loctechs_as_business_op: Number of top opportunities to select (signature
+                default 5; the simulation config default is 15)
+            capex_subsidies: Dictionary mapping geo_key -> tech -> list of capex subsidies
+                (geo_key = "ISO3" or "ISO3:unit"; country and sub-national rows merge additively)
+            debt_subsidies: Dictionary mapping geo_key -> tech -> list of debt subsidies
+            opex_subsidies: Dictionary mapping geo_key -> tech -> list of opex subsidies
+            energy_subsidies: Dictionary mapping carrier -> geo_key -> tech -> list of energy subsidies
             derive_geo_unit: Optional ``(lat, lon, iso3) -> geo_unit | None`` derivation (injected
                 from the geospatial adapter) tagging each spawned plant's sub-national unit
             probabilistic_agents: If True (default), step 5 draws a rank-weighted mix of top
@@ -6286,9 +6289,10 @@ class PlantGroup:
             cost_debt_all_locs: Dictionary mapping iso3 -> tech -> cost of debt
             iso3_to_region_map: Dictionary mapping ISO3 country codes to regions
             global_risk_free_rate: Global risk-free interest rate
-            capex_subsidies: Dictionary mapping iso3 -> tech -> list of capex subsidies
-            debt_subsidies: Dictionary mapping iso3 -> tech -> list of debt subsidies
-            energy_subsidies: Dictionary mapping carrier -> iso3 -> tech -> list of energy subsidies
+            capex_subsidies: Dictionary mapping geo_key -> tech -> list of capex subsidies
+                (geo_key = "ISO3" or "ISO3:unit"; country and sub-national rows merge additively)
+            debt_subsidies: Dictionary mapping geo_key -> tech -> list of debt subsidies
+            energy_subsidies: Dictionary mapping carrier -> geo_key -> tech -> list of energy subsidies
 
         Returns:
             List of UpdateDynamicCosts commands for each furnace group that was updated.

--- a/src/steelo/domain/new_plant_opening.py
+++ b/src/steelo/domain/new_plant_opening.py
@@ -142,7 +142,8 @@ def prepare_cost_data_for_business_opportunity(
 ) -> dict[str, dict[tuple[float, float, str], dict[str, dict[str, Any]]]]:
     """
     For each business opportunity (top location-technology pair), prepare all required inputs to calculate the NPV
-    and create a new plant. If inputs are missing, skip the location-technology pair and log a warning.
+    and create a new plant. Sites missing critical data (energy costs, cost of equity or debt) raise a ValueError,
+    as do invalid data types; technologies with an incomplete field set are dropped in validation.
 
     Args:
         product_to_tech: Dictionary mapping products to their allowed technologies (product -> list of techs)
@@ -161,10 +162,11 @@ def prepare_cost_data_for_business_opportunity(
         get_bom_from_avg_boms: Function to retrieve the bill of materials and utilization rate for a given technology and energy costs
         iso3_to_region_map: Mapping from ISO3 country codes to regions for CAPEX lookup
         global_risk_free_rate: Global risk-free rate used in debt subsidy calculations
-        capex_subsidies: Nested dictionary with CAPEX subsidies per country and technology (iso3 -> tech -> list of subsidies)
-        debt_subsidies: Nested dictionary with debt subsidies per country and technology (iso3 -> tech -> list of subsidies)
-        opex_subsidies: Nested dictionary with OPEX subsidies per country and technology (iso3 -> tech -> list of subsidies)
-        energy_subsidies: Nested dictionary with energy carrier subsidies (carrier -> iso3 -> tech -> list of subsidies)
+        capex_subsidies: Nested dictionary with CAPEX subsidies per geography and technology (geo_key -> tech -> list
+            of subsidies; geo_key = "ISO3" or "ISO3:unit", country and sub-national rows merge additively)
+        debt_subsidies: Nested dictionary with debt subsidies per geography and technology (geo_key -> tech -> list of subsidies)
+        opex_subsidies: Nested dictionary with OPEX subsidies per geography and technology (geo_key -> tech -> list of subsidies)
+        energy_subsidies: Nested dictionary with energy carrier subsidies (carrier -> geo_key -> tech -> list of subsidies)
         most_common_reductant: Dictionary mapping technology to most common reductant from plant group (tech -> reductant)
         environment_most_common_reductant: Fallback dict mapping technology to most common reductant from environment (tech -> reductant)
         derive_geo_unit: Optional ``(lat, lon, iso3) -> geo_unit | None`` derivation (injected from

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -207,6 +207,7 @@ class GeospatialModel:
                 pg.update_dynamic_costs_for_business_opportunities(
                     current_year=bus.env.year,
                     consideration_time=bus.env.config.consideration_time,
+                    construction_time=bus.env.config.construction_time,
                     custom_energy_costs=custom_energy_costs,  # type: ignore[arg-type]  # needed to avoid importing xarray into the domain
                     capex_dict_all_locs=bus.env.name_to_capex["greenfield"],
                     cost_debt_all_locs=bus.env.cost_of_debt_by_tech,

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -88,9 +88,10 @@ class GeospatialModel:
             3. Updates dynamic costs (e.g., grid cell-specific power and hydrogen prices, CAPEX, cost of debt, and subsidies) for all
             business opportunities yearly (status: considered and announced).
             4. Updates the NPV of all potential business opportunities each year with new costs (status: considered).
-            5. Business opportunities (status: considered) that remain NPV-positive for the first X years (default=3y) are announced
-            with a certain probability (default=70%; uniformly sampled), changing their status to 'announced'. This reflects that
-            not all opportunities are taken up by investors.
+            5. Business opportunities (status: considered) whose last X (=consideration_time, default=3y) yearly NPVs are all
+            positive (a rolling window, not necessarily the first years) are announced with a certain probability (default=70%;
+            uniformly sampled), changing their status to 'announced'. This reflects that not all opportunities are taken up by
+            investors.
             6. Business opportunities (status: considered) that have a negative NPV for at least X years (default=3y) in a row are
             discarded (status: discarded).
             7. Announced plants, if their technology is still allowed, are constructed after 1 year with a certain probability

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -1187,7 +1187,8 @@ class SimulationRunner:
                 plant.update_furnace_tech_unit_fopex()
                 plant.update_furnace_hydrogen_costs(capped_hydrogen_cost_dict)
 
-                # Apply energy carrier subsidies to energy_costs (after H2 price update)
+                # Apply energy carrier subsidies to energy_costs (after H2 price update); opportunity
+                # FGs are re-priced later this year by the geo refresh at their operating start year
                 for fg in plant.furnace_groups:
                     active_energy_subs: dict[str, list] = {}
                     for carrier, carrier_subs in bus.env.energy_subsidies.items():

--- a/tests/unit/test_dynamic_cost_energy_units.py
+++ b/tests/unit/test_dynamic_cost_energy_units.py
@@ -110,6 +110,7 @@ def test_update_dynamic_costs_uses_geospatial_power_price_without_scaling():
     commands_generated = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=1,
+        construction_time=4,
         custom_energy_costs=custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -254,6 +254,7 @@ def test_update_dynamic_costs_power_price_not_scaled():
     update_cmds = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=1,
+        construction_time=4,
         custom_energy_costs=custom_energy_costs,
         capex_dict_all_locs={"NAM": {"EAF": 100.0}},
         cost_debt_all_locs={

--- a/tests/unit/test_update_dynamic_costs_for_business_opportunities.py
+++ b/tests/unit/test_update_dynamic_costs_for_business_opportunities.py
@@ -160,6 +160,7 @@ def test_update_costs_for_considered_plant_no_subsidies(
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -225,6 +226,7 @@ def test_update_costs_for_announced_plant_no_subsidies(
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -298,6 +300,7 @@ def test_update_costs_with_capex_subsidies(
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -370,6 +373,7 @@ def test_update_costs_with_debt_subsidies(
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -413,6 +417,7 @@ def test_skip_operating_plants(mock_custom_energy_costs, capex_dict_all_locs, co
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -495,6 +500,7 @@ def test_skip_plant_with_missing_cost_of_debt(mock_custom_energy_costs, capex_di
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -542,6 +548,7 @@ def test_skip_furnace_group_with_missing_capex(mock_custom_energy_costs, cost_de
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -599,6 +606,7 @@ def test_skip_furnace_group_with_no_cost_changes(
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -686,6 +694,7 @@ def test_multiple_plants_mixed_statuses(
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -764,6 +773,7 @@ def test_considered_plant_with_historical_npv(
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -819,6 +829,7 @@ def test_furnace_group_without_bill_of_materials(
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -914,6 +925,7 @@ def test_update_costs_with_energy_subsidies(
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -1016,6 +1028,7 @@ def test_update_costs_with_province_scoped_energy_subsidies(
     commands = plant_group.update_dynamic_costs_for_business_opportunities(
         current_year=Year(2025),
         consideration_time=3,
+        construction_time=4,
         custom_energy_costs=mock_custom_energy_costs,
         capex_dict_all_locs=capex_dict_all_locs,
         cost_debt_all_locs=cost_debt_all_locs,
@@ -1032,3 +1045,192 @@ def test_update_costs_with_province_scoped_energy_subsidies(
     assert cmd.new_energy_costs["hydrogen"] == pytest.approx(2.5)
     assert cmd.new_output_energy_costs["hydrogen"] == pytest.approx(4.5)
     assert cmd.new_energy_costs_no_subsidy["hydrogen"] == pytest.approx(3.5)
+
+
+def _dri_opportunity_plant_group(status: str, historical_npvs: dict[int, float] | None = None) -> PlantGroup:
+    """A single USA/DRI opportunity furnace group, for the subsidy-timing tests below."""
+    fg = get_furnace_group(
+        fg_id="fg_timing",
+        tech_name="DRI",
+        capacity=150,
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2030), end=Year(2050)),
+            plant_lifetime=20,
+        ),
+        utilization_rate=0.7,
+    )
+    fg.status = status
+    fg.cost_of_debt = 0.06
+    fg.technology.capex = 3000.0
+    fg.energy_costs = {"electricity": 60.0, "hydrogen": 5.0}
+    fg.energy_costs_no_subsidy = {"electricity": 60.0, "hydrogen": 5.0}
+    fg.output_energy_costs = {"electricity": 60.0, "hydrogen": 5.0}
+    fg.bill_of_materials = {
+        "energy": {
+            "electricity": {"unit_cost": 60.0, "demand": 0.4},
+            "hydrogen": {"unit_cost": 5.0, "demand": 0.8},
+        },
+        "materials": {
+            "iron_ore": {"unit_cost": 100.0, "demand": 1.5},
+        },
+    }
+    if historical_npvs is not None:
+        fg.historical_npv_business_opportunities = historical_npvs
+
+    plant = get_plant(plant_id="plant_timing", furnace_groups=[fg])
+    plant.location = Location(lat=40.0, lon=-100.0, country="USA", region="Americas", iso3="USA")
+    return PlantGroup(plant_group_id="test_group", plants=[plant])
+
+
+def _hydrogen_subsidy(start_year: int, end_year: int) -> dict:
+    return {
+        "hydrogen": {
+            "USA": {
+                "DRI": [
+                    Subsidy(
+                        scenario_name="test",
+                        iso3="USA",
+                        start_year=Year(start_year),
+                        end_year=Year(end_year),
+                        technology_name="DRI",
+                        cost_item="hydrogen",
+                        subsidy_type="absolute",
+                        subsidy_amount=1.0,
+                    )
+                ],
+            },
+        },
+    }
+
+
+def _capex_subsidy(start_year: int, end_year: int) -> dict:
+    return {
+        "USA": {
+            "DRI": [
+                Subsidy(
+                    scenario_name="test",
+                    iso3="USA",
+                    start_year=Year(start_year),
+                    end_year=Year(end_year),
+                    technology_name="DRI",
+                    cost_item="capex",
+                    subsidy_type="relative",
+                    subsidy_amount=0.5,
+                )
+            ],
+        }
+    }
+
+
+def test_energy_subsidies_filtered_at_operating_start_year(
+    mock_custom_energy_costs,
+    capex_dict_all_locs,
+    cost_debt_all_locs,
+    iso3_to_region_map,
+):
+    """Energy subsidies price what the plant pays once running, not at construction start.
+
+    Notes:
+        Announced FG in 2025 with construction_time=4: construction starts 2026, the plant first
+        operates in 2030. A subsidy expiring in 2029 (during construction) must not move the energy
+        costs, while one starting in 2030 must - matching opportunity creation and PAM.
+    """
+    kwargs = dict(
+        current_year=Year(2025),
+        consideration_time=3,
+        construction_time=4,
+        custom_energy_costs=mock_custom_energy_costs,
+        capex_dict_all_locs=capex_dict_all_locs,
+        cost_debt_all_locs=cost_debt_all_locs,
+        iso3_to_region_map=iso3_to_region_map,
+        global_risk_free_rate=0.02,
+    )
+
+    expires_during_construction = _dri_opportunity_plant_group(
+        "announced"
+    ).update_dynamic_costs_for_business_opportunities(energy_subsidies=_hydrogen_subsidy(2026, 2029), **kwargs)
+    assert len(expires_during_construction) == 1
+    # Mock provides hydrogen=3.5; the subsidy is dead by 2030, so the raw price stands
+    assert expires_during_construction[0].new_energy_costs["hydrogen"] == pytest.approx(3.5)
+
+    live_at_operating_start = _dri_opportunity_plant_group("announced").update_dynamic_costs_for_business_opportunities(
+        energy_subsidies=_hydrogen_subsidy(2030, 2035), **kwargs
+    )
+    assert len(live_at_operating_start) == 1
+    # $1.0 absolute subsidy -> input 2.5, output 4.5
+    assert live_at_operating_start[0].new_energy_costs["hydrogen"] == pytest.approx(2.5)
+    assert live_at_operating_start[0].new_output_energy_costs["hydrogen"] == pytest.approx(4.5)
+
+
+def test_capex_subsidies_stay_filtered_at_construction_start_year(
+    mock_custom_energy_costs,
+    capex_dict_all_locs,
+    cost_debt_all_locs,
+    iso3_to_region_map,
+):
+    """CAPEX is incurred at construction start, so its subsidies must not shift to the operating year.
+
+    Notes:
+        Guards the energy-subsidy alignment against over-shifting: same 2026 construction start /
+        2030 operating start as the test above, with the opposite expectations.
+    """
+    kwargs = dict(
+        current_year=Year(2025),
+        consideration_time=3,
+        construction_time=4,
+        custom_energy_costs=mock_custom_energy_costs,
+        capex_dict_all_locs=capex_dict_all_locs,
+        cost_debt_all_locs=cost_debt_all_locs,
+        iso3_to_region_map=iso3_to_region_map,
+        global_risk_free_rate=0.02,
+    )
+
+    live_at_construction_start = _dri_opportunity_plant_group(
+        "announced"
+    ).update_dynamic_costs_for_business_opportunities(capex_subsidies=_capex_subsidy(2026, 2026), **kwargs)
+    assert len(live_at_construction_start) == 1
+    assert live_at_construction_start[0].new_capex_no_subsidy == 2000.0
+    assert live_at_construction_start[0].new_capex == 1000.0  # 50% subsidy applied
+
+    live_only_once_operating = _dri_opportunity_plant_group(
+        "announced"
+    ).update_dynamic_costs_for_business_opportunities(capex_subsidies=_capex_subsidy(2030, 2035), **kwargs)
+    assert len(live_only_once_operating) == 1
+    assert live_only_once_operating[0].new_capex == 2000.0  # unsubsidised
+
+
+def test_considered_target_year_is_floored_at_next_year(
+    mock_custom_energy_costs,
+    capex_dict_all_locs,
+    cost_debt_all_locs,
+    iso3_to_region_map,
+):
+    """A long-considered opportunity must not drift its subsidy year into the past.
+
+    Notes:
+        With consideration_time=3 and 5 years of NPV history, the raw formula
+        [current + consideration_time + 1 - years_considered] gives 2024 - a year already gone.
+        The floor pins it to 2026, the soonest path still open (announce now, construct next year),
+        matching track_business_opportunities. Asserted on CAPEX, which is filtered at that year
+        itself; an energy subsidy would be filtered four years later and could not pin the floor.
+    """
+    plant_group = _dri_opportunity_plant_group(
+        "considered",
+        historical_npvs={2021: 1.0, 2022: 1.0, 2023: 1.0, 2024: 1.0, 2025: 1.0},
+    )
+
+    commands = plant_group.update_dynamic_costs_for_business_opportunities(
+        current_year=Year(2025),
+        consideration_time=3,
+        construction_time=4,
+        custom_energy_costs=mock_custom_energy_costs,
+        capex_dict_all_locs=capex_dict_all_locs,
+        cost_debt_all_locs=cost_debt_all_locs,
+        iso3_to_region_map=iso3_to_region_map,
+        global_risk_free_rate=0.02,
+        capex_subsidies=_capex_subsidy(2026, 2026),
+    )
+
+    assert len(commands) == 1
+    assert commands[0].new_capex == 1000.0  # 50% subsidy live in the floored year 2026


### PR DESCRIPTION
- The yearly refresh of business-opportunity costs filtered energy subsidies at the construction start
  year, while opportunity creation, PAM tech-switch and PAM expansion all filter them at the operating
  start year. An opportunity was created pricing its BOM against one year's subsidies, then re-valued
  every year afterwards against a year `construction_time` earlier — enough to steer the committed
  reductant and flip announce/discard.
- The refresh now takes `construction_time` and filters energy subsidies at construction start +
  construction time. CAPEX and debt stay at construction start, where they are incurred.
- Same block: the CONSIDERED target year had no floor, so an opportunity considered for longer than
  `consideration_time` drifted its subsidy year into the past. Now floored at `current + 1`, matching
  `track_business_opportunities`.
- Three tests added; two are red without the fix, the third guards CAPEX against over-shifting.
- Also included: the geo docs and docstrings refreshed against the code — plot names and cadence,
  geo_key subsidy dicts, hard errors on missing site data, the rolling NPV window.