### PR TITLE
Guard zero utilisation in greenfield technology-switch NPV pricing

### DIFF
--- a/src/steelo/domain/calculate_costs.py
+++ b/src/steelo/domain/calculate_costs.py
@@ -759,6 +759,15 @@ def calculate_unit_total_opex(unit_vopex: float, unit_fopex: float, utilization_
         return 0.0
 
 
+class ZeroUtilisationError(ValueError):
+    """Raised by scale_fopex_to_production when utilisation is non-positive.
+
+    A distinct type (rather than a bare ValueError) so callers can catch this specific,
+    expected condition — an investment candidate with no expected production — without
+    also swallowing unrelated ValueErrors.
+    """
+
+
 def scale_fopex_to_production(tech_unit_fopex: float, expected_utilisation_rate: float) -> float:
     """
     Convert fixed OPEX per tonne of capacity to fixed OPEX per tonne of production.
@@ -775,11 +784,13 @@ def scale_fopex_to_production(tech_unit_fopex: float, expected_utilisation_rate:
         float: Fixed OPEX per tonne of production ($/t).
 
     Raises:
-        ValueError: If expected_utilisation_rate is not positive — an investment candidate
-            with no expected production cannot be priced.
+        ZeroUtilisationError: If expected_utilisation_rate is not positive — an investment
+            candidate with no expected production cannot be priced. Callers evaluating one
+            candidate among several (a technology switch, a new site, a plant expansion)
+            should catch this and skip the candidate rather than let it propagate.
     """
     if expected_utilisation_rate <= 0:
-        raise ValueError(
+        raise ZeroUtilisationError(
             f"Expected utilisation rate must be positive to scale fixed OPEX, got {expected_utilisation_rate}"
         )
     return tech_unit_fopex / expected_utilisation_rate
@@ -1290,7 +1301,15 @@ def calculate_business_opportunity_npvs(
                 raw_fopex = bo_costs["fopex"]
                 assert isinstance(raw_fopex, (int, float)), f"Expected fopex to be numeric, got {type(raw_fopex)}"
                 # Per-capacity fixed OPEX spread over the production the NPV multiplies by
-                unit_fopex = scale_fopex_to_production(raw_fopex, bo_costs["utilization_rate"])  # type: ignore[arg-type]
+                try:
+                    unit_fopex = scale_fopex_to_production(raw_fopex, bo_costs["utilization_rate"])  # type: ignore[arg-type]
+                except ZeroUtilisationError:
+                    logger.warning(
+                        f"Zero utilisation for product {prod} - site {site_id} - technology {tech}. "
+                        "Cannot price fixed OPEX. Returning -inf."
+                    )
+                    npv_dict[prod][site_id][tech] = float("-inf")
+                    continue
                 score_series = bo_costs["score_series"]
                 assert isinstance(score_series, list), f"Expected score_series to be list, got {type(score_series)}"
                 unit_total_opex_list = calculate_opex_list_with_subsidies(

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -22,6 +22,7 @@ from steelo.domain.calculate_costs import (
     calculate_unit_total_opex,
     calculate_variable_opex,
     scale_fopex_to_production,
+    ZeroUtilisationError,
     filter_subsidies_for_year,
     get_subsidised_energy_costs,
     collect_active_subsidies_over_period,
@@ -2530,16 +2531,6 @@ class FurnaceGroup:
                 util_rate = self.utilization_rate
                 reductant = self.chosen_reductant
 
-                # A furnace group the market allocated no production cannot price a
-                # renovation on its realised utilisation; leave the incumbent out of
-                # the candidate set (at an expired boundary this closes the group)
-                if util_rate <= 0:
-                    logger.warning(
-                        f"[OPTIMAL TECH] SKIPPING {tech} - zero utilisation for furnace group "
-                        f"{self.furnace_group_id}, renovation cannot be priced"
-                    )
-                    continue
-
                 # Validate BOM structure before proceeding
                 if not bill_of_materials or "materials" not in bill_of_materials or "energy" not in bill_of_materials:
                     logger.warning(f"[OPTIMAL TECH] SKIPPING {tech} - Invalid or missing BOM structure")
@@ -2601,15 +2592,6 @@ class FurnaceGroup:
                     logger.warning(f"Could not get bill of materials for technology {tech}, skipping")
                     continue
 
-                # A technology the market allocated no fleet-wide production cannot price
-                # a greenfield candidate on its realised utilisation; skip it like Branch A does
-                if util_rate <= 0:
-                    logger.warning(
-                        f"[OPTIMAL TECH] SKIPPING {tech} - zero fleet-wide utilisation, "
-                        f"greenfield candidate cannot be priced"
-                    )
-                    continue
-
                 bill_of_materials = bill_of_materials_opt
 
                 logger.debug(f"[OPTIMAL TECH] Evaluating NEW technology {tech} as greenfield installation")
@@ -2644,13 +2626,26 @@ class FurnaceGroup:
                         raise ValueError(
                             f"BOM rebuild for {tech} with reductant '{committed_reductant}' returned no BOM"
                         )
-                    if util_rate <= 0:
-                        logger.warning(
-                            f"[OPTIMAL TECH] SKIPPING {tech} - zero fleet-wide utilisation after "
-                            f"reductant rebuild, greenfield candidate cannot be priced"
-                        )
-                        continue
                     bill_of_materials = rebuilt_bom
+
+                # Materials-only variable OPEX plus fixed OPEX; energy, carbon and
+                # by-products enter through the per-year score
+                unit_fopex = technology_fopex_dict.get(tech.lower())
+                if unit_fopex is None:
+                    raise ValueError(f"Unit FOPEX for technology {tech} not found")
+
+                # A furnace group (incumbent or candidate) the market allocated no
+                # fleet-wide production for cannot price its fixed OPEX; skip it before
+                # committing it to bom_dict/reductant_dict
+                try:
+                    unit_fopex_scaled = scale_fopex_to_production(unit_fopex, util_rate)
+                except ZeroUtilisationError:
+                    logger.warning(
+                        f"[OPTIMAL TECH] SKIPPING {tech} - zero utilisation for furnace group "
+                        f"{self.furnace_group_id}, cannot price fixed OPEX"
+                    )
+                    continue
+
                 bom_dict[tech] = bill_of_materials
                 reductant_dict[tech] = committed_reductant
 
@@ -2663,14 +2658,8 @@ class FurnaceGroup:
                         summarise_reductant_picks(score_series.picks, operating_start),
                     )
 
-                # Materials-only variable OPEX plus fixed OPEX; energy, carbon and
-                # by-products enter through the per-year score
-                unit_fopex = technology_fopex_dict.get(tech.lower())
-                if unit_fopex is None:
-                    raise ValueError(f"Unit FOPEX for technology {tech} not found")
-
                 unit_base_opex = calculate_unit_total_opex(
-                    unit_fopex=scale_fopex_to_production(unit_fopex, util_rate),
+                    unit_fopex=unit_fopex_scaled,
                     unit_vopex=calculate_variable_opex(bill_of_materials["materials"], {}),
                     utilization_rate=util_rate,
                 )
@@ -3032,6 +3021,14 @@ class FurnaceGroup:
         elif self.output_shares is None:
             logger.warning(
                 f"[NEW PLANTS] Output shares are None for {self.technology.name}. Skipping NPV calculation and returning -inf."
+            )
+            npv_value = float("-inf")
+            if status_stats is not None:
+                status_stats["npv_inputs_missing"] += 1
+        elif self.utilization_rate <= 0:
+            logger.warning(
+                f"[NEW PLANTS] Zero utilisation for {self.technology.name} business opportunity at "
+                f"({location.lat}, {location.lon}) in {location.iso3}. Skipping NPV calculation and returning -inf."
             )
             npv_value = float("-inf")
             if status_stats is not None:
@@ -5525,8 +5522,16 @@ class PlantGroup:
                 tech_unit_fopex_value = technology_unit_fopex.get(tech.lower())
                 if tech_unit_fopex_value is None:
                     raise ValueError(f"No fixed OPEX data for technology: {tech} in country: {plant.location.iso3}")
-                # Per-capacity fixed OPEX spread over the production the NPV multiplies by
-                unit_fopex = cc.scale_fopex_to_production(float(tech_unit_fopex_value), expected_utilisation_rate)
+                # Per-capacity fixed OPEX spread over the production the NPV multiplies by; a
+                # candidate the market allocated no production for cannot be priced this way
+                try:
+                    unit_fopex = cc.scale_fopex_to_production(float(tech_unit_fopex_value), expected_utilisation_rate)
+                except cc.ZeroUtilisationError:
+                    logger.warning(
+                        f"[PG EXPANSION] SKIPPING {tech} for plant {plant.plant_id} - zero expected "
+                        "utilisation, cannot price fixed OPEX"
+                    )
+                    continue
 
                 # Materials-only variable OPEX plus fixed OPEX; energy, carbon and
                 # by-products enter through the per-year score

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -2601,6 +2601,15 @@ class FurnaceGroup:
                     logger.warning(f"Could not get bill of materials for technology {tech}, skipping")
                     continue
 
+                # A technology the market allocated no fleet-wide production cannot price
+                # a greenfield candidate on its realised utilisation; skip it like Branch A does
+                if util_rate <= 0:
+                    logger.warning(
+                        f"[OPTIMAL TECH] SKIPPING {tech} - zero fleet-wide utilisation, "
+                        f"greenfield candidate cannot be priced"
+                    )
+                    continue
+
                 bill_of_materials = bill_of_materials_opt
 
                 logger.debug(f"[OPTIMAL TECH] Evaluating NEW technology {tech} as greenfield installation")
@@ -2635,6 +2644,12 @@ class FurnaceGroup:
                         raise ValueError(
                             f"BOM rebuild for {tech} with reductant '{committed_reductant}' returned no BOM"
                         )
+                    if util_rate <= 0:
+                        logger.warning(
+                            f"[OPTIMAL TECH] SKIPPING {tech} - zero fleet-wide utilisation after "
+                            f"reductant rebuild, greenfield candidate cannot be priced"
+                        )
+                        continue
                     bill_of_materials = rebuilt_bom
                 bom_dict[tech] = bill_of_materials
                 reductant_dict[tech] = committed_reductant

--- a/tests/unit/test_fopex_scaling.py
+++ b/tests/unit/test_fopex_scaling.py
@@ -217,53 +217,6 @@ def test_zero_utilisation_greenfield_candidate_is_skipped_not_fatal(monkeypatch)
     assert "BF" in tech_npv_dict
 
 
-def test_zero_utilisation_after_reductant_rebuild_is_skipped_not_fatal(monkeypatch):
-    """The reductant-rebuild call site must be guarded too.
-
-    The initial BOM fetch commits a reductant other than the score series' pick, which
-    forces a rebuild against the picked reductant; that rebuild is the one returning
-    zero utilisation here, so the guard right after it must be the one that fires.
-    """
-    _capture_npv_full(monkeypatch)
-    fg = _make_fg(utilization_rate=0.8)
-
-    calls = {"n": 0}
-
-    def mock_get_bom(energy_costs, tech, _capacity, _reductant=None):
-        calls["n"] += 1
-        if calls["n"] == 1:
-            # Initial fetch: valid utilisation, but a reductant that differs from the
-            # score series' "hydrogen" pick, forcing a rebuild.
-            return ({"materials": dict(MATERIALS), "energy": {}}, 0.9, "coke", {"iron_ore": 1.0})
-        # Rebuild against the committed "hydrogen" pick comes back with zero utilisation.
-        return ({"materials": dict(MATERIALS), "energy": {}}, 0.0, "hydrogen", {"iron_ore": 1.0})
-
-    tech_npv_dict, _, _, bom_dict, _ = fg.optimal_technology_name(
-        market_price_series={"steel": [500.0] * 30, "iron": [400.0] * 30},
-        cost_of_debt_by_tech={"BF": 0.05, "DRI": 0.05},
-        cost_of_equity_by_tech={"BF": 0.1, "DRI": 0.1},
-        get_bom_from_avg_boms=mock_get_bom,
-        score_series_for_tech=_stub_score_series,
-        capex_dict={"BF": 600.0, "DRI": 500.0},
-        capex_renovation_share={"BF": 0.7},
-        technology_fopex_dict={"bf": 10.0, "dri": 50.0},
-        dynamic_business_cases={},
-        chosen_emissions_boundary_for_carbon_costs="Scope 1",
-        technology_emission_factors=[],
-        tech_to_product={"BF": "iron", "DRI": "iron"},
-        plant_lifetime=20,
-        construction_time=2,
-        current_year=Year(2025),
-        risk_free_rate=0.02,
-        allowed_furnace_transitions={"BF": ["BF", "DRI"]},
-    )
-
-    assert calls["n"] == 2
-    assert "DRI" not in tech_npv_dict
-    assert "DRI" not in bom_dict
-    assert "BF" in tech_npv_dict
-
-
 # ── expansion path ────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_fopex_scaling.py
+++ b/tests/unit/test_fopex_scaling.py
@@ -313,6 +313,42 @@ def test_expansion_candidates_count_full_fixed_cost(monkeypatch):
     assert eaf_call["unit_total_opex_list"][0] == pytest.approx(expected_vopex + 40.0 / 0.9)
 
 
+def test_expansion_zero_utilisation_candidates_are_skipped_not_fatal(monkeypatch):
+    """A candidate technology the market/BOM allocated no production for cannot be priced;
+    evaluate_expansion_options must skip it instead of crashing on scale_fopex_to_production.
+    """
+    captured = _capture_npv_full(monkeypatch)
+    fg = _make_fg(utilization_rate=0.0)
+    pg = PlantGroup(plant_group_id="pg1", plants=[_make_plant(fg)])
+    pg.balance = 1e12
+
+    npv_p = pg.evaluate_expansion_options(
+        price_series={"steel": [500.0] * 30, "iron": [400.0] * 30},
+        capacity=Volumes(1000.0),
+        region_capex={"Region": {"DRI": 500.0, "EAF": 400.0}},
+        cost_of_debt_dict={"NZL": {"DRI": 0.05, "EAF": 0.05}},
+        cost_of_equity_dict={"NZL": {"DRI": 0.1, "EAF": 0.1}},
+        get_bom_from_avg_boms=_mock_get_bom(util_rate=0.0),
+        reductant_score_series=lambda *a, **k: ReductantScoreSeries(scores=[0.0] * 20, picks=["hydrogen"] * 20),
+        dynamic_feedstocks={},
+        fopex_for_iso3={"NZL": {"dri": 50.0, "eaf": 40.0}},
+        iso3_to_region_map={"NZL": "Region"},
+        chosen_emissions_boundary_for_carbon_costs="Scope 1",
+        technology_emission_factors=[],
+        global_risk_free_rate=0.02,
+        equity_share=0.3,
+        tech_to_product={"DRI": "iron", "EAF": "steel"},
+        plant_lifetime=20,
+        construction_time=2,
+        current_year=Year(2025),
+        allowed_techs={Year(2025): ["DRI", "EAF"]},
+        active_statuses=["operating"],
+    )
+
+    assert captured == []
+    assert npv_p == {}
+
+
 # ── creation path ─────────────────────────────────────────────────────────────
 
 
@@ -353,3 +389,42 @@ def test_new_plant_npv_counts_full_fixed_cost(monkeypatch):
     assert call["expected_utilisation_rate"] == pytest.approx(0.8)
     assert call["unit_total_opex_list"][0] == pytest.approx(expected_vopex + 50.0 / 0.8)
     assert npvs["iron"][(0.0, 0.0, "SITE1")]["DRI"] == 0.0
+
+
+def test_new_plant_zero_utilisation_returns_neg_inf_not_fatal(monkeypatch):
+    """A site/tech the averaged fleet data gives zero utilisation for cannot be priced;
+    calculate_business_opportunity_npvs must return -inf for it, matching its documented
+    "if the calculation fails, it returns a very negative NPV instead" contract, rather
+    than crashing on scale_fopex_to_production.
+    """
+    captured = _capture_npv_full(monkeypatch)
+    cost_data = {
+        "iron": {
+            (0.0, 0.0, "SITE1"): {
+                "DRI": {
+                    "bom": {"materials": dict(MATERIALS), "energy": {}},
+                    "fopex": 50.0,
+                    "utilization_rate": 0.0,
+                    "score_series": [0.0] * 20,
+                    "capex": 500.0,
+                    "cost_of_debt": 0.05,
+                    "cost_of_equity": 0.1,
+                    "railway_cost": 0.0,
+                    "all_opex_subsidies": [],
+                },
+            },
+        },
+    }
+
+    npvs = calculate_costs.calculate_business_opportunity_npvs(
+        cost_data=cost_data,
+        target_year=2025,
+        market_price={"iron": [400.0] * 30},
+        steel_plant_capacity=2_500_000.0,
+        plant_lifetime=20,
+        construction_time=2,
+        equity_share=0.3,
+    )
+
+    assert captured == []
+    assert npvs["iron"][(0.0, 0.0, "SITE1")]["DRI"] == float("-inf")

--- a/tests/unit/test_fopex_scaling.py
+++ b/tests/unit/test_fopex_scaling.py
@@ -184,6 +184,86 @@ def test_zero_utilisation_incumbent_is_skipped_not_fatal(monkeypatch):
     assert "DRI" in tech_npv_dict
 
 
+def test_zero_utilisation_greenfield_candidate_is_skipped_not_fatal(monkeypatch):
+    """A greenfield candidate the trade LP allocated no fleet-wide production for
+    cannot price its fixed OPEX either, and must be skipped like the incumbent path
+    rather than raising from scale_fopex_to_production.
+    """
+    _capture_npv_full(monkeypatch)
+    fg = _make_fg(utilization_rate=0.8)
+
+    tech_npv_dict, _, _, bom_dict, _ = fg.optimal_technology_name(
+        market_price_series={"steel": [500.0] * 30, "iron": [400.0] * 30},
+        cost_of_debt_by_tech={"BF": 0.05, "DRI": 0.05},
+        cost_of_equity_by_tech={"BF": 0.1, "DRI": 0.1},
+        get_bom_from_avg_boms=_mock_get_bom(util_rate=0.0),
+        score_series_for_tech=_stub_score_series,
+        capex_dict={"BF": 600.0, "DRI": 500.0},
+        capex_renovation_share={"BF": 0.7},
+        technology_fopex_dict={"bf": 10.0, "dri": 50.0},
+        dynamic_business_cases={},
+        chosen_emissions_boundary_for_carbon_costs="Scope 1",
+        technology_emission_factors=[],
+        tech_to_product={"BF": "iron", "DRI": "iron"},
+        plant_lifetime=20,
+        construction_time=2,
+        current_year=Year(2025),
+        risk_free_rate=0.02,
+        allowed_furnace_transitions={"BF": ["BF", "DRI"]},
+    )
+
+    assert "DRI" not in tech_npv_dict
+    assert "DRI" not in bom_dict
+    assert "BF" in tech_npv_dict
+
+
+def test_zero_utilisation_after_reductant_rebuild_is_skipped_not_fatal(monkeypatch):
+    """The reductant-rebuild call site must be guarded too.
+
+    The initial BOM fetch commits a reductant other than the score series' pick, which
+    forces a rebuild against the picked reductant; that rebuild is the one returning
+    zero utilisation here, so the guard right after it must be the one that fires.
+    """
+    _capture_npv_full(monkeypatch)
+    fg = _make_fg(utilization_rate=0.8)
+
+    calls = {"n": 0}
+
+    def mock_get_bom(energy_costs, tech, _capacity, _reductant=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Initial fetch: valid utilisation, but a reductant that differs from the
+            # score series' "hydrogen" pick, forcing a rebuild.
+            return ({"materials": dict(MATERIALS), "energy": {}}, 0.9, "coke", {"iron_ore": 1.0})
+        # Rebuild against the committed "hydrogen" pick comes back with zero utilisation.
+        return ({"materials": dict(MATERIALS), "energy": {}}, 0.0, "hydrogen", {"iron_ore": 1.0})
+
+    tech_npv_dict, _, _, bom_dict, _ = fg.optimal_technology_name(
+        market_price_series={"steel": [500.0] * 30, "iron": [400.0] * 30},
+        cost_of_debt_by_tech={"BF": 0.05, "DRI": 0.05},
+        cost_of_equity_by_tech={"BF": 0.1, "DRI": 0.1},
+        get_bom_from_avg_boms=mock_get_bom,
+        score_series_for_tech=_stub_score_series,
+        capex_dict={"BF": 600.0, "DRI": 500.0},
+        capex_renovation_share={"BF": 0.7},
+        technology_fopex_dict={"bf": 10.0, "dri": 50.0},
+        dynamic_business_cases={},
+        chosen_emissions_boundary_for_carbon_costs="Scope 1",
+        technology_emission_factors=[],
+        tech_to_product={"BF": "iron", "DRI": "iron"},
+        plant_lifetime=20,
+        construction_time=2,
+        current_year=Year(2025),
+        risk_free_rate=0.02,
+        allowed_furnace_transitions={"BF": ["BF", "DRI"]},
+    )
+
+    assert calls["n"] == 2
+    assert "DRI" not in tech_npv_dict
+    assert "DRI" not in bom_dict
+    assert "BF" in tech_npv_dict
+
+
 # ── expansion path ────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_track_business_opportunities.py
+++ b/tests/unit/test_track_business_opportunities.py
@@ -385,6 +385,60 @@ def test_track_business_opportunity_missing_bom(mock_location, market_price):
     assert fg.historical_npv_business_opportunities[Year(2027)] == float("-inf")
 
 
+def test_track_business_opportunity_zero_utilisation(mock_location, market_price):
+    """Test that NPV is set to -inf when utilization_rate is zero.
+
+    A furnace group the market allocated no fleet-wide production for cannot price its
+    fixed OPEX (scale_fopex_to_production divides by utilization_rate); the opportunity
+    should be re-valued at -inf instead of crashing.
+    """
+    fg = get_furnace_group(
+        fg_id="fg_zero_util",
+        tech_name="EAF",
+        capacity=100,
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2030), end=Year(2060)),
+            plant_lifetime=20,
+        ),
+        utilization_rate=0.0,  # Zero utilisation
+    )
+    fg.status = "considered"
+    fg.cost_of_debt = 0.05
+    fg.technology.capex = 1000.0
+    fg.tech_unit_fopex = 35.0
+    fg.equity_share = 0.3
+    fg.railway_cost = 0.0
+    fg.chosen_reductant = "scrap"
+    fg.output_shares = {"scrap": 1.0}
+    fg.energy_costs_no_subsidy = {"electricity": 0.05, "hydrogen": 3500.0}
+
+    # Initialize with 2 years of data
+    fg.historical_npv_business_opportunities = {
+        Year(2025): float("-inf"),
+        Year(2026): float("-inf"),
+    }
+
+    command = fg.track_business_opportunities(
+        year=Year(2027),
+        location=mock_location,
+        market_price=market_price,
+        cost_of_equity=0.08,
+        plant_lifetime=20,
+        construction_time=2,
+        consideration_time=3,
+        probability_of_announcement=0.8,
+        all_opex_subsidies=[],
+        reductant_score_series=_stub_series,
+    )
+
+    # Verify - should discard due to negative NPVs
+    assert command is not None
+    assert isinstance(command, UpdateFurnaceGroupStatus)
+    assert command.new_status == "discarded"
+    assert fg.historical_npv_business_opportunities[Year(2027)] == float("-inf")
+
+
 def test_track_business_opportunity_nan_npv(mock_location, market_price):
     """Test that NaN NPV is converted to -inf."""
     fg = get_furnace_group(


### PR DESCRIPTION
Branch B of optimal_technology_name (evaluating a new technology as a greenfield candidate) called scale_fopex_to_production with a fleet-wide utilisation rate from get_bom_from_avg_boms without checking for zero, unlike the sibling brownfield-renovation branch which already [skips zero-utilisation candidates](https://github.com/systemiqofficial/steel-iq/blob/develop/src/steelo/domain/models.py#L2533-L2541). When the trade LP allocates a technology zero production in a given year, that 0.0 is legitimate and previously crashed the whole optimal_technology_name call with ValueError instead of just skipping that one candidate.

Add the same "skip with a warning" guard after both get_bom_from_avg_boms call sites in Branch B (the initial fetch and the post-score-series reductant rebuild).