### PR TITLE
Refresh considered opportunities' utilisation yearly from the fleet average

### DIFF
--- a/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
+++ b/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
@@ -16,6 +16,7 @@ The system updates the costs and status of business opportunities each simulatio
    - Refresh CAPEX, cost of debt, and energy prices for all carriers
    - Apply subsidies (CAPEX and debt at the earliest construction start year; energy carriers at the operating start year that follows it)
    - Update bill of materials with new energy prices
+   - Refresh the expected utilisation of CONSIDERED opportunities from the current fleet average for the technology (ANNOUNCED ones keep their value)
 
 2. **Update Status**
    - For CONSIDERED: Recalculate NPV and check for status change
@@ -241,6 +242,7 @@ Updates dynamic costs for all CONSIDERED and ANNOUNCED business opportunities ea
 - Electricity and hydrogen prices sourced from the geospatial layer (custom power mix / capped LCOH); other carriers from the furnace group's existing cost base
 - Energy subsidies are collected for the plant's geography (country and province rows apply additively) and filtered at the operating start year (construction start + construction time), matching opportunity creation and the plant agent model
 - Bill of materials (updated with new subsidised input energy prices)
+- Expected utilisation, refreshed from `Environment.avg_utilization` (the operating fleet's average for the technology, with the same 0.6 fallback as opportunity creation) — CONSIDERED opportunities only. ANNOUNCED ones keep their value: the build decision is already taken, and utilisation is reset to 0 at construction start. A fleet average of zero flows into the zero-utilisation guard in the NPV re-valuation (−inf → discard).
 
 **Note:** For more information on the electricity and hydrogen prices see related documentation [Priority Location Selection](priority_location_selection.md).
 

--- a/docs/domain_simulation_logic/plant_agent_model/trade_model_connector.md
+++ b/docs/domain_simulation_logic/plant_agent_model/trade_model_connector.md
@@ -149,10 +149,10 @@ After cost propagation, the connector updates furnace group attributes:
 
 ```python
 allocated_volumes = sum(outgoing_edge_volumes)
-utilization_rate = allocated_volumes / capacity
+utilization_rate = min(1.0, allocated_volumes / capacity)
 ```
 
-Sets `fg.utilization_rate` based on actual production assigned by Trade Module.
+Sets `fg.utilization_rate` based on actual production assigned by Trade Module. The ratio is clamped at 1.0; an allocation above capacity is a solver anomaly and is logged as a warning.
 
 #### 4b. Update Bill of Materials
 

--- a/src/steelo/domain/commands.py
+++ b/src/steelo/domain/commands.py
@@ -110,6 +110,7 @@ class UpdateDynamicCosts(Command):
         - Cost of debt (with subsidies, if applicable)
         - CAPEX (with subsidies, if applicable)
         - Energy costs for all carriers (subsidised input, output, and unsubsidised)
+        - Expected utilisation (fleet average for the technology at emission time)
     """
 
     plant_id: str
@@ -121,6 +122,7 @@ class UpdateDynamicCosts(Command):
     new_energy_costs: dict[str, float]
     new_output_energy_costs: dict[str, float]
     new_energy_costs_no_subsidy: dict[str, float]
+    new_utilization_rate: float
 
 
 # @dataclass

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -5141,8 +5141,9 @@ class PlantGroup:
 
         Note: The status is set to considered and the plant id is set to the next available id in the
         plant group. The utilization rate is set to the average utilization rate for the technology to
-        calculate realistic NPVs for business opportunities and reset to 0 when the plant is made
-        operational by PAM.
+        calculate realistic NPVs for business opportunities, refreshed yearly from the fleet average
+        while considered (update_dynamic_costs_for_business_opportunities), and reset to 0 when the
+        plant is made operational by PAM.
         """
         # Create new plant
         location = Location(

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -6282,6 +6282,7 @@ class PlantGroup:
         cost_debt_all_locs: dict[str, dict[str, float]],
         iso3_to_region_map: dict[str, str],
         global_risk_free_rate: float,
+        avg_utilization: dict[str, dict[str, float]],
         capex_subsidies: dict[str, dict[str, list[Subsidy]]] = {},
         debt_subsidies: dict[str, dict[str, list[Subsidy]]] = {},
         energy_subsidies: dict[str, dict[str, dict[str, list[Subsidy]]]] = {},
@@ -6294,6 +6295,9 @@ class PlantGroup:
             - CAPEX with subsidies
             - Cost of debt with subsidies
             - Energy costs from custom energy model (with subsidies)
+            - Expected utilisation, refreshed from the current fleet average for the
+              technology (considered opportunities only — announced ones keep their value,
+              which is reset to 0 at construction anyway)
 
         Dynamic costs are updated based on the following logic:
             - Base costs: CAPEX, cost of debt, electricity costs, and hydrogen costs are set to the
@@ -6314,6 +6318,8 @@ class PlantGroup:
             cost_debt_all_locs: Dictionary mapping iso3 -> tech -> cost of debt
             iso3_to_region_map: Dictionary mapping ISO3 country codes to regions
             global_risk_free_rate: Global risk-free interest rate
+            avg_utilization: Fleet-average utilisation per technology
+                (``Environment.avg_utilization``: tech -> {"utilization_rate": rate})
             capex_subsidies: Dictionary mapping geo_key -> tech -> list of capex subsidies
                 (geo_key = "ISO3" or "ISO3:unit"; country and sub-national rows merge additively)
             debt_subsidies: Dictionary mapping geo_key -> tech -> list of debt subsidies
@@ -6459,18 +6465,26 @@ class PlantGroup:
                         new_output_energy_costs = dict(base_costs)
                         new_energy_costs_no_subsidy = dict(base_costs)
 
+                    # Refresh the expected utilisation from the current fleet average
+                    if fg.status == "considered":
+                        new_utilization_rate = avg_utilization.get(fg.technology.name, {}).get("utilization_rate", 0.6)
+                    else:
+                        new_utilization_rate = fg.utilization_rate
+
                     # Check if costs have actually changed
                     old_costs_cmp = {
                         "cost_of_debt": fg.cost_of_debt,
                         "capex": fg.technology.capex,
                         "energy_costs": fg.energy_costs,
                         "output_energy_costs": fg.output_energy_costs,
+                        "utilization_rate": fg.utilization_rate,
                     }
                     new_costs_cmp = {
                         "cost_of_debt": new_costs["cost_of_debt"],
                         "capex": new_costs["capex"],
                         "energy_costs": new_energy_costs,
                         "output_energy_costs": new_output_energy_costs,
+                        "utilization_rate": new_utilization_rate,
                     }
                     if old_costs_cmp == new_costs_cmp:
                         continue  # Skip if no changes
@@ -6489,6 +6503,7 @@ class PlantGroup:
                             new_energy_costs=new_energy_costs,
                             new_output_energy_costs=new_output_energy_costs,
                             new_energy_costs_no_subsidy=new_energy_costs_no_subsidy,
+                            new_utilization_rate=new_utilization_rate,
                         )
                     )
         return update_commands

--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -876,13 +876,20 @@ class TM_PAM_connector:
             - Logs debug warning if capacity is 0.
 
         Notes:
-            - Utilization rate is capped between 0.0 and capacity (no explicit cap applied).
+            - Utilization rate is clamped to at most 1.0; an allocation above capacity is a
+              solver anomaly and is logged as a warning.
             - Zero-capacity furnaces get utilization_rate = 0.
         """
         logger = logging.getLogger(f"{__name__}.update_furnace_group_utilisation")
         self.update_exported_volumes(furnace_groups=furnace_groups, volume_attribute=volume_attribute)
         for fg in furnace_groups:
-            fg.utilization_rate = fg.allocated_volumes / fg.capacity if fg.capacity > 0 else 0
+            raw_rate = fg.allocated_volumes / fg.capacity if fg.capacity > 0 else 0
+            if raw_rate > 1.0:
+                logger.warning(
+                    f"LP allocated {fg.allocated_volumes:,.0f} t to furnace group {fg.furnace_group_id} "
+                    f"with capacity {fg.capacity:,.0f} t (utilisation {raw_rate:.3f}); clamping to 1.0"
+                )
+            fg.utilization_rate = min(1.0, raw_rate)
             if fg.capacity <= 0:
                 # raise Warning(f"Furnace group capacity is 0 for {fg.furnace_group_id}")
                 logger.debug(

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -213,6 +213,7 @@ class GeospatialModel:
                     cost_debt_all_locs=bus.env.cost_of_debt_by_tech,
                     iso3_to_region_map=bus.env.country_mappings.iso3_to_region(),
                     global_risk_free_rate=bus.env.config.global_risk_free_rate,
+                    avg_utilization=bus.env.avg_utilization,
                     capex_subsidies=bus.env.capex_subsidies,
                     debt_subsidies=bus.env.debt_subsidies,
                     energy_subsidies=bus.env.energy_subsidies,

--- a/src/steelo/service_layer/handlers.py
+++ b/src/steelo/service_layer/handlers.py
@@ -745,6 +745,7 @@ def update_dynamic_costs(cmd: commands.UpdateDynamicCosts, uow: UnitOfWork, env:
         - Cost of debt (with subsidies, if applicable)
         - CAPEX (with subsidies, if applicable)
         - Energy costs for all carriers (subsidised input, output, and unsubsidised)
+        - Expected utilisation (fleet average for the technology)
     """
     logger = logging.getLogger(f"{__name__}.update_dynamic_costs")
     with uow:
@@ -758,6 +759,7 @@ def update_dynamic_costs(cmd: commands.UpdateDynamicCosts, uow: UnitOfWork, env:
                 fg.energy_costs = cmd.new_energy_costs
                 fg.output_energy_costs = cmd.new_output_energy_costs
                 fg.energy_costs_no_subsidy = cmd.new_energy_costs_no_subsidy
+                fg.utilization_rate = cmd.new_utilization_rate
                 logger.debug(
                     "[HANDLER] UpdateDynamicCosts %s/%s: energy_costs=%s output=%s no_sub=%s",
                     cmd.plant_id,

--- a/src/steelo/service_layer/handlers.py
+++ b/src/steelo/service_layer/handlers.py
@@ -282,7 +282,10 @@ def update_cost_curve(_event: events.Event, uow: UnitOfWork, env: Environment):
     with uow:
         env.update_cost_curve(
             world_furnace_groups=[
-                fg for p in uow.plants.list() for fg in p.furnace_groups if (fg.status in env.config.active_statuses)
+                fg
+                for p in uow.plants.list()
+                for fg in p.furnace_groups
+                if (fg.status.lower() in env.config.active_statuses)
             ],
             lag=0,
         )
@@ -303,7 +306,12 @@ def update_furnace_utilization_rates(event: events.SteelAllocationsCalculated, u
         raise ValueError("SimulationConfig is required for update_furnace_utilization_rates")
 
     with uow:
-        fgs = [fg for p in uow.plants.list() for fg in p.furnace_groups if (fg.status in env.config.active_statuses)]
+        fgs = [
+            fg
+            for p in uow.plants.list()
+            for fg in p.furnace_groups
+            if (fg.status.lower() in env.config.active_statuses)
+        ]
         active_bof_count = sum(1 for fg in fgs if fg.technology.name.upper() == "BOF")
 
         tmpc = TM_PAM_connector(
@@ -359,7 +367,7 @@ def update_furnace_utilization_rates(event: events.SteelAllocationsCalculated, u
         iron_demand_from_production = 0.0
         for plant in uow.plants.list():
             for fg in plant.furnace_groups:
-                if fg.status in env.config.active_statuses and fg.technology.product.lower() == "iron":
+                if fg.status.lower() in env.config.active_statuses and fg.technology.product.lower() == "iron":
                     iron_demand_from_production += fg.production
 
         print(f"Iron demand based on production in year {env.year} is {iron_demand_from_production * T_TO_KT:,.0f} kt")
@@ -639,7 +647,7 @@ def finalise_iteration(
 
     print(f"Demand for year {env.year}: is {env.current_demand * T_TO_KT:,.0f} kt")
     print(
-        f"Steel capacity for year {env.year}: is {sum([fg.capacity for p in uow.plants.list() for fg in p.furnace_groups if fg.status in env.config.active_statuses and fg.technology.product == 'steel']) * T_TO_KT:,.0f} kt"
+        f"Steel capacity for year {env.year}: is {sum([fg.capacity for p in uow.plants.list() for fg in p.furnace_groups if fg.status.lower() in env.config.active_statuses and fg.technology.product == 'steel']) * T_TO_KT:,.0f} kt"
     )
     logger.debug(f"finalising iteration. time: {datetime.now()}")
 

--- a/tests/unit/test_dynamic_cost_energy_units.py
+++ b/tests/unit/test_dynamic_cost_energy_units.py
@@ -116,6 +116,7 @@ def test_update_dynamic_costs_uses_geospatial_power_price_without_scaling():
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.01,
+        avg_utilization={},
         capex_subsidies={},
         debt_subsidies={},
     )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -281,6 +281,7 @@ def test_update_dynamic_costs_power_price_not_scaled():
         },
         iso3_to_region_map={"USA": "NAM"},
         global_risk_free_rate=0.03,
+        avg_utilization={},
     )
 
     assert update_cmds, "Expected an UpdateDynamicCosts command to be enqueued."

--- a/tests/unit/test_tm_pam_connector_utilisation_clamp.py
+++ b/tests/unit/test_tm_pam_connector_utilisation_clamp.py
@@ -1,0 +1,71 @@
+"""Tests for the utilisation clamp in TM_PAM_connector.update_furnace_group_utilisation.
+
+The LP should never allocate above capacity, but if it does (solver anomaly), the
+resulting utilisation must be clamped to 1.0 with a warning rather than propagating
+a >1 expectation into avg_utilization and greenfield NPVs.
+"""
+
+import logging
+from contextlib import contextmanager
+
+from steelo.adapters.repositories.in_memory_repository import PlantInMemoryRepository
+from steelo.devdata import get_furnace_group, get_plant
+from steelo.domain.trade_modelling import TM_PAM_connector as connector_module
+from steelo.domain.trade_modelling.TM_PAM_connector import TM_PAM_connector
+
+
+def _connector_with(fg):
+    plants_repo = PlantInMemoryRepository()
+    plants_repo.add(get_plant(plant_id="plant_clamp", furnace_groups=[fg]))
+    connector = TM_PAM_connector(dynamic_feedstocks_classes={}, plants=plants_repo)
+    # The allocation is set directly on the FG; skip the graph-edge extraction
+    connector.update_exported_volumes = lambda furnace_groups, volume_attribute="volume": None
+    return connector
+
+
+@contextmanager
+def _capture_warnings():
+    """Capture records on the function logger itself.
+
+    A handler attached directly to the logger is immune to the propagate/level
+    reconfiguration other tests apply to the steelo logger tree, which defeats caplog.
+    """
+    logger = logging.getLogger(f"{connector_module.__name__}.update_furnace_group_utilisation")
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler(level=logging.WARNING)
+    handler.emit = records.append  # type: ignore[method-assign]
+    old_level, old_propagate = logger.level, logger.propagate
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(old_level)
+        logger.propagate = old_propagate
+
+
+def test_over_capacity_allocation_is_clamped_to_one():
+    """An allocation above capacity yields utilisation 1.0 and logs a warning."""
+    fg = get_furnace_group(fg_id="fg_clamp", tech_name="EAF", capacity=100)
+    fg.allocated_volumes = 130.0
+
+    connector = _connector_with(fg)
+    with _capture_warnings() as records:
+        connector.update_furnace_group_utilisation([fg])
+
+    assert fg.utilization_rate == 1.0
+    assert any("clamping to 1.0" in record.getMessage() for record in records)
+
+
+def test_within_capacity_allocation_is_not_clamped():
+    """A normal allocation keeps its exact ratio and logs no warning."""
+    fg = get_furnace_group(fg_id="fg_no_clamp", tech_name="EAF", capacity=100)
+    fg.allocated_volumes = 80.0
+
+    connector = _connector_with(fg)
+    with _capture_warnings() as records:
+        connector.update_furnace_group_utilisation([fg])
+
+    assert fg.utilization_rate == 0.8
+    assert not any("clamping" in record.getMessage() for record in records)

--- a/tests/unit/test_update_dynamic_costs_for_business_opportunities.py
+++ b/tests/unit/test_update_dynamic_costs_for_business_opportunities.py
@@ -6,6 +6,14 @@ from steelo.domain.models import PlantGroup, Subsidy, Location
 from steelo.domain.commands import UpdateDynamicCosts
 from steelo.devdata import get_furnace_group, get_plant, PointInTime, TimeFrame, Year
 
+# Matches the utilisation each test bakes into its furnace groups, so the yearly
+# refresh is a no-op unless a test overrides it deliberately
+AVG_UTILIZATION = {
+    "EAF": {"utilization_rate": 0.7},
+    "BOF": {"utilization_rate": 0.75},
+    "DRI": {"utilization_rate": 0.7},
+}
+
 
 @pytest.fixture
 def mock_custom_energy_costs():
@@ -166,6 +174,7 @@ def test_update_costs_for_considered_plant_no_subsidies(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
         capex_subsidies={},
         debt_subsidies={},
     )
@@ -232,6 +241,7 @@ def test_update_costs_for_announced_plant_no_subsidies(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
         capex_subsidies={},
         debt_subsidies={},
     )
@@ -306,6 +316,7 @@ def test_update_costs_with_capex_subsidies(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
         capex_subsidies=capex_subsidies,
         debt_subsidies={},
     )
@@ -379,6 +390,7 @@ def test_update_costs_with_debt_subsidies(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
         capex_subsidies={},
         debt_subsidies=debt_subsidies,
     )
@@ -423,6 +435,7 @@ def test_skip_operating_plants(mock_custom_energy_costs, capex_dict_all_locs, co
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
     )
 
     # Verify - should return empty list
@@ -506,6 +519,7 @@ def test_skip_plant_with_missing_cost_of_debt(mock_custom_energy_costs, capex_di
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
     )
 
     # Verify - should skip this plant
@@ -554,6 +568,7 @@ def test_skip_furnace_group_with_missing_capex(mock_custom_energy_costs, cost_de
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
     )
 
     # Verify - should skip this furnace group
@@ -612,6 +627,7 @@ def test_skip_furnace_group_with_no_cost_changes(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
     )
 
     # Verify - no command emitted because all costs match
@@ -700,6 +716,7 @@ def test_multiple_plants_mixed_statuses(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
     )
 
     # Verify - should only process plants 1 and 2
@@ -779,6 +796,7 @@ def test_considered_plant_with_historical_npv(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
         capex_subsidies=capex_subsidies,
         debt_subsidies={},
     )
@@ -835,6 +853,7 @@ def test_furnace_group_without_bill_of_materials(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
     )
 
     # Verify - the cost refresh does not depend on a BOM being present
@@ -931,6 +950,7 @@ def test_update_costs_with_energy_subsidies(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
         capex_subsidies={},
         debt_subsidies={},
         energy_subsidies=energy_subsidies,
@@ -1034,6 +1054,7 @@ def test_update_costs_with_province_scoped_energy_subsidies(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
         capex_subsidies={},
         debt_subsidies={},
         energy_subsidies=energy_subsidies,
@@ -1145,6 +1166,7 @@ def test_energy_subsidies_filtered_at_operating_start_year(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
     )
 
     expires_during_construction = _dri_opportunity_plant_group(
@@ -1184,6 +1206,7 @@ def test_capex_subsidies_stay_filtered_at_construction_start_year(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
     )
 
     live_at_construction_start = _dri_opportunity_plant_group(
@@ -1229,8 +1252,214 @@ def test_considered_target_year_is_floored_at_next_year(
         cost_debt_all_locs=cost_debt_all_locs,
         iso3_to_region_map=iso3_to_region_map,
         global_risk_free_rate=0.02,
+        avg_utilization=AVG_UTILIZATION,
         capex_subsidies=_capex_subsidy(2026, 2026),
     )
 
     assert len(commands) == 1
     assert commands[0].new_capex == 1000.0  # 50% subsidy live in the floored year 2026
+
+
+def test_considered_utilisation_refreshed_from_fleet_average(
+    mock_custom_energy_costs,
+    capex_dict_all_locs,
+    cost_debt_all_locs,
+    iso3_to_region_map,
+):
+    """A considered opportunity's utilisation is refreshed from the current fleet average.
+
+    The value baked in at creation must not survive a change in the fleet statistic:
+    the emitted command carries the fresh value even when no other cost moved.
+    """
+    energy = {"electricity": 50.0, "hydrogen": 3.5}
+    fg = get_furnace_group(
+        fg_id="fg_util_refresh",
+        tech_name="EAF",
+        capacity=100,
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2027), end=Year(2047)),
+            plant_lifetime=20,
+        ),
+        utilization_rate=0.7,
+    )
+    fg.status = "considered"
+    # All costs match what the refresh will compute, so only utilisation changes
+    fg.cost_of_debt = 0.05
+    fg.technology.capex = 1000.0
+    fg.energy_costs = dict(energy)
+    fg.output_energy_costs = dict(energy)
+    fg.energy_costs_no_subsidy = dict(energy)
+
+    plant = get_plant(plant_id="plant_util_refresh", furnace_groups=[fg])
+    plant.location = Location(lat=40.0, lon=-100.0, country="USA", region="Americas", iso3="USA")
+
+    plant_group = PlantGroup(plant_group_id="test_group", plants=[plant])
+
+    commands = plant_group.update_dynamic_costs_for_business_opportunities(
+        current_year=Year(2025),
+        consideration_time=3,
+        construction_time=4,
+        custom_energy_costs=mock_custom_energy_costs,
+        capex_dict_all_locs=capex_dict_all_locs,
+        cost_debt_all_locs=cost_debt_all_locs,
+        iso3_to_region_map=iso3_to_region_map,
+        global_risk_free_rate=0.02,
+        avg_utilization={"EAF": {"utilization_rate": 0.9}},
+    )
+
+    # A utilisation-only change must not be swallowed by the no-change skip
+    assert len(commands) == 1
+    assert commands[0].new_utilization_rate == 0.9
+
+
+def test_considered_utilisation_refreshed_to_zero(
+    mock_custom_energy_costs,
+    capex_dict_all_locs,
+    cost_debt_all_locs,
+    iso3_to_region_map,
+):
+    """A fleet average of exactly 0.0 is a real value, not a missing key.
+
+    The refresh must carry it through (feeding the zero-utilisation guard in
+    track_business_opportunities) rather than falling back to the 0.6 default.
+    """
+    energy = {"electricity": 50.0, "hydrogen": 3.5}
+    fg = get_furnace_group(
+        fg_id="fg_util_zero",
+        tech_name="EAF",
+        capacity=100,
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2027), end=Year(2047)),
+            plant_lifetime=20,
+        ),
+        utilization_rate=0.7,
+    )
+    fg.status = "considered"
+    fg.cost_of_debt = 0.05
+    fg.technology.capex = 1000.0
+    fg.energy_costs = dict(energy)
+    fg.output_energy_costs = dict(energy)
+    fg.energy_costs_no_subsidy = dict(energy)
+
+    plant = get_plant(plant_id="plant_util_zero", furnace_groups=[fg])
+    plant.location = Location(lat=40.0, lon=-100.0, country="USA", region="Americas", iso3="USA")
+
+    plant_group = PlantGroup(plant_group_id="test_group", plants=[plant])
+
+    commands = plant_group.update_dynamic_costs_for_business_opportunities(
+        current_year=Year(2025),
+        consideration_time=3,
+        construction_time=4,
+        custom_energy_costs=mock_custom_energy_costs,
+        capex_dict_all_locs=capex_dict_all_locs,
+        cost_debt_all_locs=cost_debt_all_locs,
+        iso3_to_region_map=iso3_to_region_map,
+        global_risk_free_rate=0.02,
+        avg_utilization={"EAF": {"utilization_rate": 0.0}},
+    )
+
+    assert len(commands) == 1
+    assert commands[0].new_utilization_rate == 0.0
+
+
+def test_considered_utilisation_missing_tech_falls_back_to_default(
+    mock_custom_energy_costs,
+    capex_dict_all_locs,
+    cost_debt_all_locs,
+    iso3_to_region_map,
+):
+    """A tech absent from avg_utilization gets the 0.6 default, mirroring creation.
+
+    Mirrors the lookup in get_bom_from_avg_boms so refresh and opportunity creation
+    can never disagree on the fallback.
+    """
+    energy = {"electricity": 50.0, "hydrogen": 3.5}
+    fg = get_furnace_group(
+        fg_id="fg_util_fallback",
+        tech_name="EAF",
+        capacity=100,
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2027), end=Year(2047)),
+            plant_lifetime=20,
+        ),
+        utilization_rate=0.7,
+    )
+    fg.status = "considered"
+    fg.cost_of_debt = 0.05
+    fg.technology.capex = 1000.0
+    fg.energy_costs = dict(energy)
+    fg.output_energy_costs = dict(energy)
+    fg.energy_costs_no_subsidy = dict(energy)
+
+    plant = get_plant(plant_id="plant_util_fallback", furnace_groups=[fg])
+    plant.location = Location(lat=40.0, lon=-100.0, country="USA", region="Americas", iso3="USA")
+
+    plant_group = PlantGroup(plant_group_id="test_group", plants=[plant])
+
+    commands = plant_group.update_dynamic_costs_for_business_opportunities(
+        current_year=Year(2025),
+        consideration_time=3,
+        construction_time=4,
+        custom_energy_costs=mock_custom_energy_costs,
+        capex_dict_all_locs=capex_dict_all_locs,
+        cost_debt_all_locs=cost_debt_all_locs,
+        iso3_to_region_map=iso3_to_region_map,
+        global_risk_free_rate=0.02,
+        avg_utilization={},
+    )
+
+    assert len(commands) == 1
+    assert commands[0].new_utilization_rate == 0.6
+
+
+def test_announced_utilisation_not_refreshed(
+    mock_custom_energy_costs,
+    capex_dict_all_locs,
+    cost_debt_all_locs,
+    iso3_to_region_map,
+):
+    """An announced opportunity keeps its utilisation regardless of the fleet average.
+
+    The build decision is already taken; the value is reset to 0 at construction start,
+    so refreshing it would only perturb unrelated readers.
+    """
+    fg = get_furnace_group(
+        fg_id="fg_announced_util",
+        tech_name="BOF",
+        capacity=200,
+        lifetime=PointInTime(
+            current=Year(2025),
+            time_frame=TimeFrame(start=Year(2026), end=Year(2046)),
+            plant_lifetime=20,
+        ),
+        utilization_rate=0.75,
+    )
+    fg.status = "announced"
+    fg.cost_of_debt = 0.07
+    fg.technology.capex = 1700.0
+    fg.energy_costs = {"electricity": 55.0, "hydrogen": 3.8}
+
+    plant = get_plant(plant_id="plant_announced_util", furnace_groups=[fg])
+    plant.location = Location(lat=51.0, lon=9.0, country="DEU", region="Europe", iso3="DEU")
+
+    plant_group = PlantGroup(plant_group_id="test_group", plants=[plant])
+
+    commands = plant_group.update_dynamic_costs_for_business_opportunities(
+        current_year=Year(2025),
+        consideration_time=3,
+        construction_time=4,
+        custom_energy_costs=mock_custom_energy_costs,
+        capex_dict_all_locs=capex_dict_all_locs,
+        cost_debt_all_locs=cost_debt_all_locs,
+        iso3_to_region_map=iso3_to_region_map,
+        global_risk_free_rate=0.02,
+        avg_utilization={"BOF": {"utilization_rate": 0.2}},
+    )
+
+    # Costs changed (debt 0.07->0.04, capex 1700->1600) so a command is emitted,
+    # but it carries the FG's own utilisation, not the fleet average
+    assert len(commands) == 1
+    assert commands[0].new_utilization_rate == 0.75

--- a/tests/unit/test_update_dynamic_costs_handler.py
+++ b/tests/unit/test_update_dynamic_costs_handler.py
@@ -1,0 +1,60 @@
+"""Tests that the UpdateDynamicCosts handler applies every field of the command.
+
+The yearly business-opportunity refresh emits UpdateDynamicCosts commands; the handler
+must land all of them on the furnace group, including the expected utilisation added
+alongside the cost fields.
+"""
+
+from unittest.mock import MagicMock
+
+from steelo.devdata import get_furnace_group, get_plant
+from steelo.domain.commands import UpdateDynamicCosts
+from steelo.service_layer.handlers import update_dynamic_costs
+
+
+class _FakeUnitOfWork:
+    def __init__(self, plant):
+        self.plants = MagicMock()
+        self.plants.get.return_value = plant
+        self.committed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def commit(self):
+        self.committed = True
+
+
+def test_handler_applies_all_command_fields_to_furnace_group():
+    """Costs, energy dicts and utilisation all land on the targeted furnace group."""
+    fg = get_furnace_group(fg_id="fg_dyn", tech_name="EAF", capacity=100, utilization_rate=0.7)
+    plant = get_plant(plant_id="plant_dyn", furnace_groups=[fg])
+    uow = _FakeUnitOfWork(plant)
+
+    cmd = UpdateDynamicCosts(
+        plant_id="plant_dyn",
+        furnace_group_id="fg_dyn",
+        new_cost_of_debt=0.04,
+        new_cost_of_debt_no_subsidy=0.05,
+        new_capex=900.0,
+        new_capex_no_subsidy=1000.0,
+        new_energy_costs={"electricity": 45.0},
+        new_output_energy_costs={"electricity": 46.0},
+        new_energy_costs_no_subsidy={"electricity": 50.0},
+        new_utilization_rate=0.85,
+    )
+
+    update_dynamic_costs(cmd, uow, env=MagicMock())
+
+    assert fg.cost_of_debt == 0.04
+    assert fg.cost_of_debt_no_subsidy == 0.05
+    assert fg.technology.capex == 900.0
+    assert fg.technology.capex_no_subsidy == 1000.0
+    assert fg.energy_costs == {"electricity": 45.0}
+    assert fg.output_energy_costs == {"electricity": 46.0}
+    assert fg.energy_costs_no_subsidy == {"electricity": 50.0}
+    assert fg.utilization_rate == 0.85
+    assert uow.committed


### PR DESCRIPTION
An opportunity FG bakes in the fleet-average utilisation of its technology at creation and never updates it, while capex, cost of debt and energy costs are refreshed yearly — so it could be announced on a stale utilisation expectation.

- `update_dynamic_costs_for_business_opportunities` now refreshes `utilization_rate` on considered FGs from `env.avg_utilization` each year (same lookup and 0.6 fallback as creation). announced FGs keep their value — the build decision is taken and it is reset to 0 at construction anyway. A refresh to zero flows into the guard (−inf → discard).
- Hardening, behaviour-neutral on current data: LP-written utilisation clamped at 1.0 (warning on over-allocation), and the four exact-case `fg.status` active-status filters in handlers.py now compare `.lower()`, matching `generate_average_boms`.
