### PR TITLE
Union-trim the new-plant opportunity draw; make calculate_npv_pct configurable

### DIFF
--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -6010,7 +6010,9 @@ class PlantGroup:
         technology_emission_factors: list[TechnologyEmissionFactors],
         chosen_emissions_boundary_for_carbon_costs: str,
         active_statuses: list[str],
-        top_n_loctechs_as_business_op: int = 5,
+        top_n_loctechs_as_business_op: int,
+        opportunity_pool_depth: int,
+        calculate_npv_pct: float,
         capex_subsidies: dict[str, dict[str, list[Subsidy]]] = {},  # iso3 -> tech -> list of subsidies
         debt_subsidies: dict[str, dict[str, list[Subsidy]]] = {},  # iso3 -> tech -> list of subsidies
         opex_subsidies: dict[str, dict[str, list[Subsidy]]] = {},  # iso3 -> tech -> list of subsidies
@@ -6068,8 +6070,13 @@ class PlantGroup:
             chosen_emissions_boundary_for_carbon_costs: Emission boundary for carbon costs
             active_statuses: Status strings whose furnace groups vote in the group's
                 most-common-reductant aggregation
-            top_n_loctechs_as_business_op: Number of top opportunities to select (signature
-                default 5; the simulation config default is 15)
+            top_n_loctechs_as_business_op: Number of top opportunities to select per product
+                (single source of truth: SimulationConfig, default 15)
+            opportunity_pool_depth: Depth of the probabilistic draw's eligible pool: global
+                head of (depth * top_n) candidates by NPV unioned with each allowed
+                technology's best `depth` sites (see select_top_opportunities_by_npv)
+            calculate_npv_pct: Fraction (0.0-1.0) of the priority-location subset that is
+                randomly sampled for full NPV evaluation each year
             capex_subsidies: Dictionary mapping geo_key -> tech -> list of capex subsidies
                 (geo_key = "ISO3" or "ISO3:unit"; country and sub-national rows merge additively)
             debt_subsidies: Dictionary mapping geo_key -> tech -> list of debt subsidies
@@ -6141,7 +6148,7 @@ class PlantGroup:
         # Step 2: Select a subset of locations
         best_locations_subset = select_location_subset(
             locations=locations,
-            calculate_npv_pct=0.1,  # 10%; TODO: set as tuneable parameter
+            calculate_npv_pct=calculate_npv_pct,
         )
         subset_counts, subset_total = _count_entries(best_locations_subset)
         candidate_stats["subset_sites_total"] = subset_total
@@ -6237,6 +6244,7 @@ class PlantGroup:
             npv_dict=npv_dict,
             top_n_loctechs_as_business_op=top_n_loctechs_as_business_op,
             probabilistic_agents=probabilistic_agents,
+            opportunity_pool_depth=opportunity_pool_depth,
         )
         selected_counts, selected_total = _count_entries(top_business_opportunities)
         candidate_stats["selected_pairs_total"] = selected_total

--- a/src/steelo/domain/new_plant_opening.py
+++ b/src/steelo/domain/new_plant_opening.py
@@ -616,10 +616,97 @@ def validate_and_clean_cost_data(
     return cost_data
 
 
+def build_eligible_pool(
+    valid_pairs: list[tuple[Any, str]],
+    ranked_indices: np.ndarray,
+    head_count: int,
+    sites_per_tech: int,
+) -> list[int]:
+    """
+    Build the eligible candidate pool for the rank-weighted draw: the global NPV head unioned
+    with each technology's best sites.
+
+    Args:
+        valid_pairs: All valid (site_id, technology) candidates for one product
+        ranked_indices: Indices into valid_pairs, sorted by NPV descending
+        head_count: Number of top-ranked candidates that are always eligible (the global head)
+        sites_per_tech: Guaranteed seats per technology; head members count toward the quota
+
+    Returns:
+        Indices into valid_pairs, in descending NPV order, without duplicates
+
+    Notes:
+        - Guarantees every technology keeps min(sites_per_tech, available) eligible candidates
+          even when a single technology occupies the entire head, so a souring head technology
+          can never erase the standing of every alternative
+        - Single ranked pass: a technology's first occurrences are its best sites, so head
+          membership and per-technology seats dedupe naturally
+    """
+    eligible: list[int] = []
+    seen_per_tech: dict[str, int] = {}
+    for rank, idx in enumerate(ranked_indices):
+        tech = valid_pairs[idx][1]
+        seen = seen_per_tech.get(tech, 0)
+        seen_per_tech[tech] = seen + 1
+        if rank < head_count or seen < sites_per_tech:
+            eligible.append(int(idx))
+    return eligible
+
+
+def summarise_opportunity_pool(
+    valid_pairs: list[tuple[Any, str]],
+    valid_npvs: list[float],
+    eligible_indices: list[int],
+    selected_pairs: list[tuple[Any, str]],
+) -> dict[str, Any]:
+    """
+    Aggregate creation-time pool-quality statistics for one product.
+
+    Args:
+        valid_pairs: All valid (site_id, technology) candidates
+        valid_npvs: NPVs aligned with valid_pairs
+        eligible_indices: Indices into valid_pairs that entered the draw
+        selected_pairs: The (site_id, technology) pairs actually drawn
+
+    Returns:
+        Dict with the valid-pool size, eligible-pool median/min/max NPV and negative fraction,
+        technology counts for the eligible and drawn sets, and per-technology best NPV over the
+        full valid pool
+
+    Notes:
+        Pure aggregation for the pool_summary log line - an all-negative pool becomes visible
+        in the year it occurs instead of three years later in the status chart
+    """
+    tech_best: dict[str, float] = {}
+    for (_, tech), npv in zip(valid_pairs, valid_npvs):
+        if tech not in tech_best or npv > tech_best[tech]:
+            tech_best[tech] = npv
+    eligible_npvs = [valid_npvs[i] for i in eligible_indices]
+    eligible_techs: dict[str, int] = {}
+    for i in eligible_indices:
+        tech = valid_pairs[i][1]
+        eligible_techs[tech] = eligible_techs.get(tech, 0) + 1
+    drawn_techs: dict[str, int] = {}
+    for _, tech in selected_pairs:
+        drawn_techs[tech] = drawn_techs.get(tech, 0) + 1
+    return {
+        "valid": len(valid_pairs),
+        "eligible": len(eligible_npvs),
+        "median": float(np.median(eligible_npvs)),
+        "min": float(min(eligible_npvs)),
+        "max": float(max(eligible_npvs)),
+        "frac_negative": sum(1 for v in eligible_npvs if v < 0) / len(eligible_npvs),
+        "eligible_techs": eligible_techs,
+        "drawn_techs": drawn_techs,
+        "tech_best": tech_best,
+    }
+
+
 def select_top_opportunities_by_npv(
     npv_dict: dict[str, dict[Any, dict[str, float]]],
     top_n_loctechs_as_business_op: int,
     probabilistic_agents: bool,
+    opportunity_pool_depth: int,
 ) -> dict[str, dict[tuple[float, float, str], dict[str, float]]]:
     """
     Select top location-technology combinations with high NPVs. When probabilistic_agents is True,
@@ -629,8 +716,12 @@ def select_top_opportunities_by_npv(
     Args:
         npv_dict: Nested dictionary with NPV values (product -> site_id -> tech -> NPV)
         top_n_loctechs_as_business_op: Number of top location-technology combinations to select per product
-        probabilistic_agents: If True, rank-weighted random draw over the top 3N candidates (deliberate
+        probabilistic_agents: If True, rank-weighted random draw over the eligible pool (deliberate
             realism - a mix of high and medium NPV options). If False, deterministic top-N by NPV.
+        opportunity_pool_depth: Depth of the probabilistic draw's eligible pool, in two coupled
+            senses: the global head is the top (depth * N) candidates by NPV, and every allowed
+            technology additionally keeps its best `depth` sites eligible. Higher = more
+            exploration; 1 = near-pure exploitation. Ignored when probabilistic_agents is False.
 
     Returns:
         Dictionary mapping products to site IDs to technologies with their NPVs (product -> site_id (lat, lon, iso3) -> tech -> NPV)
@@ -644,17 +735,21 @@ def select_top_opportunities_by_npv(
 
     Notes:
         - Invalid NPV values (NaN, -inf) are removed before processing
-        - When probabilistic_agents: candidates are ranked by NPV and only the best 3N enter a
-          weighted draw with linearly decreasing rank weights - a mix of high and medium NPV
-          options rather than only the highest, while implausible sites can never be selected
+        - When probabilistic_agents: the eligible pool is the global top (depth * N) by NPV
+          unioned with each technology's best `depth` sites, then a weighted draw with linearly
+          decreasing rank weights - a mix of high and medium NPV options, while every allowed
+          technology keeps standing even when one technology dominates the head
         - Rank weights are scale-free: the draw behaves identically for all-negative,
           mixed and all-positive pools
+        - Logs one pool_summary line per product with pool size, eligible-pool NPV statistics
+          and per-technology best NPV over the full pool
     """
     logger = logging.getLogger(f"{__name__}.select_top_opportunities_by_npv")
     if probabilistic_agents:
         logger.info(
             f"[NEW PLANTS] Drawing {top_n_loctechs_as_business_op} location-technology combinations per product from the "
-            f"top {3 * top_n_loctechs_as_business_op} by NPV (rank-weighted, without replacement)."
+            f"top {opportunity_pool_depth * top_n_loctechs_as_business_op} by NPV unioned with the top "
+            f"{opportunity_pool_depth} sites per technology (rank-weighted, without replacement)."
         )
     else:
         logger.info(
@@ -695,30 +790,43 @@ def select_top_opportunities_by_npv(
         ranked_indices = np.argsort(npvs_array)[::-1]
 
         if probabilistic_agents:
-            # Trim to the plausible head of the pool, then draw with rank weights (best gets
-            # weight `trim`, worst weight 1). The former shift-by-min weighting degenerated
-            # to a near-uniform draw whenever the whole pool was negative.
-            trim = min(len(ranked_indices), 3 * top_n_loctechs_as_business_op)
-            pool_indices = ranked_indices[:trim]
+            # Union trim: the global head keeps its rank-weight dominance in healthy years,
+            # while the per-technology seats stop a monocultural head from erasing every other
+            # technology's standing (rank weights: best gets `trim`, worst 1; the former
+            # shift-by-min weighting degenerated to near-uniform on all-negative pools)
+            head_count = min(len(ranked_indices), opportunity_pool_depth * top_n_loctechs_as_business_op)
+            eligible = build_eligible_pool(valid_pairs, ranked_indices, head_count, opportunity_pool_depth)
+            trim = len(eligible)
 
             if trim > top_n_loctechs_as_business_op:
                 rank_weights = np.arange(trim, 0, -1, dtype=float)
                 probabilities = rank_weights / rank_weights.sum()
                 drawn = np.random.choice(trim, size=top_n_loctechs_as_business_op, replace=False, p=probabilities)
-                selected_pairs = [valid_pairs[pool_indices[i]] for i in drawn]
+                selected_pairs = [valid_pairs[eligible[i]] for i in drawn]
             else:
-                selected_pairs = [valid_pairs[i] for i in pool_indices]
+                selected_pairs = [valid_pairs[i] for i in eligible]
             logger.info(
                 f"[NEW PLANTS] {product}: drew {len(selected_pairs)} of {len(valid_pairs)} valid candidates "
-                f"(rank-weighted over the top {trim})."
+                f"(rank-weighted over {trim} eligible: global top {head_count} + top {opportunity_pool_depth} per technology)."
             )
         else:
-            top_indices = ranked_indices[:top_n_loctechs_as_business_op]
-            selected_pairs = [valid_pairs[i] for i in top_indices]
+            eligible = [int(i) for i in ranked_indices[:top_n_loctechs_as_business_op]]
+            selected_pairs = [valid_pairs[i] for i in eligible]
             logger.info(
                 f"[NEW PLANTS] {product}: selected top {len(selected_pairs)} of {len(valid_pairs)} valid candidates "
                 "by NPV (deterministic)."
             )
+
+        summary = summarise_opportunity_pool(valid_pairs, valid_npvs, eligible, selected_pairs)
+        eligible_techs_str = ",".join(f"{t}:{n}" for t, n in sorted(summary["eligible_techs"].items()))
+        drawn_techs_str = ",".join(f"{t}:{n}" for t, n in sorted(summary["drawn_techs"].items()))
+        tech_best_str = ",".join(f"{t}:{v:.4e}" for t, v in sorted(summary["tech_best"].items(), key=lambda kv: -kv[1]))
+        logger.info(
+            f"[NEW PLANTS] pool_summary product={product} valid={summary['valid']} eligible={summary['eligible']} "
+            f"median={summary['median']:.4e} min={summary['min']:.4e} max={summary['max']:.4e} "
+            f"frac_negative={summary['frac_negative']:.2f} eligible_techs=[{eligible_techs_str}] "
+            f"drawn_techs=[{drawn_techs_str}] tech_best=[{tech_best_str}]"
+        )
 
         # Format selected (site, tech) pairs into business opportunities dict
         top_business_opportunities[product] = {}

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -290,6 +290,8 @@ class GeospatialModel:
                 tech_to_product=bus.env.technology_to_product,
                 allowed_techs=bus.env.allowed_techs,
                 top_n_loctechs_as_business_op=bus.env.config.top_n_loctechs_as_business_op,
+                opportunity_pool_depth=bus.env.config.opportunity_pool_depth,
+                calculate_npv_pct=bus.env.config.calculate_npv_pct,
                 technology_emission_factors=bus.env.technology_emission_factors,
                 chosen_emissions_boundary_for_carbon_costs=bus.env.config.chosen_emissions_boundary_for_carbon_costs,
                 capex_subsidies=bus.env.capex_subsidies,

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -389,6 +389,10 @@ class SimulationConfig:
     probability_of_announcement: float = 0.7  # Probability of a plant being announced after being considered - given a history of positive NPVs of at least `consideration_time` years
     top_n_loctechs_as_business_op: int = 15  # Number of top location-technology combinations to consider as business
     # opportunities per product per year (e.g., 5 for steel and 5 for iron = 10 total)
+    opportunity_pool_depth: int = 3  # Probabilistic draw eligibility: global top (depth * top_n) by NPV plus each
+    # allowed technology's best `depth` sites, so no technology loses standing to a monoculture head
+    calculate_npv_pct: float = 0.1  # Fraction of priority locations sampled each year for full NPV evaluation;
+    # 0.1 is chosen purely to save computational time, not for model reasons
     co2_storage_reserved_discount_factor: float = (
         0.9  # Fraction of an announced CCS plant's CO2 need that counts toward the reserved storage bucket
     )

--- a/src/steeloweb/forms.py
+++ b/src/steeloweb/forms.py
@@ -359,6 +359,19 @@ class ModelRunCreateForm(forms.ModelForm):
         widget=forms.NumberInput(attrs={"class": "form-control field-connected"}),
     )
 
+    opportunity_pool_depth = forms.IntegerField(
+        label="Opportunity pool depth",
+        initial=3,
+        min_value=1,
+        max_value=10,
+        required=False,
+        help_text=(
+            "Draw eligibility: global top (depth × top N) by NPV plus each technology's best 'depth' sites, "
+            "so every technology stays drawable"
+        ),
+        widget=forms.NumberInput(attrs={"class": "form-control field-connected"}),
+    )
+
     priority_pct = forms.IntegerField(
         label="Percentage of considered opportunities",
         initial=5,
@@ -367,6 +380,21 @@ class ModelRunCreateForm(forms.ModelForm):
         required=False,
         help_text="Percentage of global grid points selected as priority locations for business opportunities",
         widget=forms.NumberInput(attrs={"class": "form-control field-connected"}),
+    )
+
+    calculate_npv_pct = forms.DecimalField(
+        label="NPV sample fraction",
+        initial=0.1,
+        min_value=0.0,
+        max_value=1.0,
+        max_digits=3,
+        decimal_places=2,
+        required=False,
+        help_text=(
+            "Fraction (0.0-1.0) of priority locations sampled each year for full NPV evaluation; "
+            "the 0.1 default only saves computational time"
+        ),
+        widget=forms.NumberInput(attrs={"class": "form-control field-connected", "step": "0.01"}),
     )
 
     # Plant capacity parameters
@@ -776,7 +804,9 @@ class ModelRunCreateForm(forms.ModelForm):
             "probability_of_announcement",
             "probability_of_construction",
             "top_n_loctechs_as_business_op",
+            "opportunity_pool_depth",
             "priority_pct",
+            "calculate_npv_pct",
             "expanded_capacity",
             "capacity_limit_iron",
             "capacity_limit_steel",

--- a/src/steeloweb/models.py
+++ b/src/steeloweb/models.py
@@ -717,6 +717,8 @@ class ModelRun(models.Model):
             "probability_of_construction",
             "probability_of_announcement",
             "top_n_loctechs_as_business_op",
+            "opportunity_pool_depth",
+            "calculate_npv_pct",
             # Plant capacity parameters
             "expanded_capacity",
             "capacity_limit_iron",

--- a/src/steeloweb/views.py
+++ b/src/steeloweb/views.py
@@ -744,7 +744,9 @@ def create_modelrun(request):
                 "probability_of_announcement": float(form.cleaned_data.get("probability_of_announcement") or 0.7),
                 "probability_of_construction": float(form.cleaned_data.get("probability_of_construction") or 0.9),
                 "top_n_loctechs_as_business_op": form.cleaned_data.get("top_n_loctechs_as_business_op", 15),
+                "opportunity_pool_depth": int(form.cleaned_data.get("opportunity_pool_depth") or 3),
                 "priority_pct": int(form.cleaned_data.get("priority_pct") or 5),
+                "calculate_npv_pct": float(form.cleaned_data.get("calculate_npv_pct") or 0.1),
                 # Plant capacity parameters (convert Mt to t)
                 "expanded_capacity": float(form.cleaned_data.get("expanded_capacity") or 2.5) * 1000000,
                 "capacity_limit_iron": float(form.cleaned_data.get("capacity_limit_iron") or 100) * 1000000,

--- a/tests/unit/test_geo_price_cost_alignment.py
+++ b/tests/unit/test_geo_price_cost_alignment.py
@@ -130,6 +130,8 @@ def _run_identify(monkeypatch, market_price_steel: list[float]) -> dict:
         chosen_emissions_boundary_for_carbon_costs="scope_1",
         active_statuses=["operating"],
         top_n_loctechs_as_business_op=1,
+        opportunity_pool_depth=3,
+        calculate_npv_pct=0.1,
         probabilistic_agents=False,
     )
     return captured["npv_dict"]

--- a/tests/unit/test_identify_new_business_opportunities_4indi.py
+++ b/tests/unit/test_identify_new_business_opportunities_4indi.py
@@ -7,6 +7,8 @@ from steelo.domain.new_plant_opening import (
     get_list_of_allowed_techs_for_target_year,
     prepare_cost_data_for_business_opportunity,
     select_top_opportunities_by_npv,
+    build_eligible_pool,
+    summarise_opportunity_pool,
     NewPlantLocation,
 )
 from steelo.domain.models import Subsidy, PlantGroup
@@ -1013,7 +1015,7 @@ class TestSelectTopOpportunitiesByNpv:
             ]
 
             top_opportunities = select_top_opportunities_by_npv(
-                npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+                npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True, opportunity_pool_depth=3
             )
 
             # Verify top opportunities were selected
@@ -1043,7 +1045,7 @@ class TestSelectTopOpportunitiesByNpv:
         # The function uses np.random.choice which will filter out invalid NPVs
         # Just verify it runs without error and returns valid results
         top_opportunities = select_top_opportunities_by_npv(
-            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True, opportunity_pool_depth=3
         )
 
         # Should have selected 1 opportunity from the 3 valid ones
@@ -1072,7 +1074,7 @@ class TestSelectTopOpportunitiesByNpv:
             mock_choice.return_value = [0]  # Select first item
 
             select_top_opportunities_by_npv(
-                npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+                npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True, opportunity_pool_depth=3
             )
 
             # Verify np.random.choice was called with probabilities
@@ -1097,6 +1099,7 @@ class TestSelectTopOpportunitiesByNpv:
             npv_dict=npv_dict,
             top_n_loctechs_as_business_op=5,  # Request 5 but only 2 available
             probabilistic_agents=True,
+            opportunity_pool_depth=3,
         )
 
         # Should return all available opportunities (2 location-tech pairs)
@@ -1110,7 +1113,7 @@ class TestSelectTopOpportunitiesByNpv:
         # Function raises ValueError when there are no valid NPVs
         with pytest.raises(ValueError, match="No valid NPVs found"):
             select_top_opportunities_by_npv(
-                npv_dict=npv_dict, top_n_loctechs_as_business_op=5, probabilistic_agents=True
+                npv_dict=npv_dict, top_n_loctechs_as_business_op=5, probabilistic_agents=True, opportunity_pool_depth=3
             )
 
     def test_all_negative_npvs(self):
@@ -1123,7 +1126,7 @@ class TestSelectTopOpportunitiesByNpv:
         }
 
         top_opportunities = select_top_opportunities_by_npv(
-            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True, opportunity_pool_depth=3
         )
 
         # Rank weights are scale-free, so an all-negative pool still draws normally
@@ -1139,7 +1142,7 @@ class TestSelectTopOpportunitiesByNpv:
         }
 
         top_opportunities = select_top_opportunities_by_npv(
-            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True, opportunity_pool_depth=3
         )
 
         # Verify structure: product -> site_id -> tech -> NPV
@@ -1522,7 +1525,9 @@ def test_selection_rank_weights_decrease_with_npv_rank():
 
     with patch("numpy.random.choice") as mock_choice:
         mock_choice.return_value = [0]
-        select_top_opportunities_by_npv(npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True)
+        select_top_opportunities_by_npv(
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True, opportunity_pool_depth=3
+        )
 
     (pool_size,), kwargs = mock_choice.call_args
     assert pool_size == 3
@@ -1544,7 +1549,7 @@ def test_selection_never_draws_beyond_the_trimmed_pool():
     np.random.seed(42)
     for _ in range(25):
         selected = select_top_opportunities_by_npv(
-            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True, opportunity_pool_depth=3
         )
         (npv,) = [npv for techs in selected["steel"].values() for npv in techs.values()]
         assert npv >= -3.0
@@ -1558,11 +1563,11 @@ def test_selection_is_deterministic_under_a_seed():
 
     np.random.seed(123)
     first = select_top_opportunities_by_npv(
-        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=True
+        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=True, opportunity_pool_depth=3
     )
     np.random.seed(123)
     second = select_top_opportunities_by_npv(
-        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=True
+        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=True, opportunity_pool_depth=3
     )
 
     assert first == second
@@ -1574,7 +1579,7 @@ def test_deterministic_mode_selects_top_n_by_npv():
 
     with patch("numpy.random.choice") as mock_choice:
         selected = select_top_opportunities_by_npv(
-            npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=False
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=False, opportunity_pool_depth=3
         )
         # Deterministic mode must not touch the random draw at all
         assert not mock_choice.called
@@ -1588,10 +1593,10 @@ def test_deterministic_mode_is_reproducible_without_seeding():
     npv_dict = _npv_dict_from_values([-600.0, -100.0, -400.0, -200.0, -500.0, -300.0])
 
     first = select_top_opportunities_by_npv(
-        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=False
+        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=False, opportunity_pool_depth=3
     )
     second = select_top_opportunities_by_npv(
-        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=False
+        npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=False, opportunity_pool_depth=3
     )
 
     assert first == second
@@ -1666,9 +1671,202 @@ def test_two_technologies_at_one_site_spawn_two_plants(monkeypatch):
         chosen_emissions_boundary_for_carbon_costs="scope_1",
         active_statuses=["operating"],
         top_n_loctechs_as_business_op=2,
+        opportunity_pool_depth=3,
+        calculate_npv_pct=0.1,
     )
 
     new_plants = command.new_plants
     assert len(new_plants) == 2
     assert len({plant.plant_id for plant in new_plants}) == 2
     assert {plant.furnace_groups[0].technology.name for plant in new_plants} == {"EAF", "BOF"}
+
+
+def _ranked_pool(tech_npvs):
+    """Build (valid_pairs, valid_npvs, ranked_indices) from {tech: [npvs]}, one site per NPV.
+
+    Sites are synthetic and unique; ranking is by NPV descending, as in the selection function.
+    """
+    import numpy as np
+
+    valid_pairs = []
+    valid_npvs = []
+    for tech, npvs in tech_npvs.items():
+        for i, npv in enumerate(npvs):
+            valid_pairs.append(((40.0 + i, -100.0 - i, "USA"), tech))
+            valid_npvs.append(npv)
+    ranked_indices = np.argsort(np.array(valid_npvs))[::-1]
+    return valid_pairs, valid_npvs, ranked_indices
+
+
+def test_eligible_pool_keeps_every_technology_standing_when_head_is_monocultural():
+    """A head fully occupied by one technology still leaves min(3, available) seats per tech.
+
+    Notes:
+        Guards the union trim: 50 A-sites monopolise a 45-slot head, yet B keeps its top-3
+        and C keeps both of its sites eligible, in descending NPV order without duplicates.
+    """
+    valid_pairs, valid_npvs, ranked_indices = _ranked_pool(
+        {
+            "A": [1000.0 - i for i in range(50)],
+            "B": [10.0, 9.0, 8.0, 7.0, 6.0],
+            "C": [5.0, 4.0],
+        },
+    )
+
+    eligible = build_eligible_pool(valid_pairs, ranked_indices, head_count=45, sites_per_tech=3)
+
+    per_tech = {}
+    for i in eligible:
+        per_tech[valid_pairs[i][1]] = per_tech.get(valid_pairs[i][1], 0) + 1
+    assert per_tech == {"A": 45, "B": 3, "C": 2}
+    assert len(eligible) == len(set(eligible))
+    eligible_npvs = [valid_npvs[i] for i in eligible]
+    assert eligible_npvs == sorted(eligible_npvs, reverse=True)
+
+
+def test_eligible_pool_adds_no_seats_for_technologies_already_covered_by_the_head():
+    """A technology with at least sites_per_tech candidates inside the head gets no extra seats."""
+    valid_pairs, valid_npvs, ranked_indices = _ranked_pool(
+        {
+            "A": [100.0, 99.0, 98.0, 97.0, 96.0],
+            "B": [95.0, 94.0, 93.0, 92.0, 91.0],
+        },
+    )
+
+    # Head of 8 holds A:5 and B:3 - both technologies already covered, union adds nothing
+    eligible = build_eligible_pool(valid_pairs, ranked_indices, head_count=8, sites_per_tech=3)
+
+    assert len(eligible) == 8
+    assert [valid_npvs[i] for i in eligible] == [100.0, 99.0, 98.0, 97.0, 96.0, 95.0, 94.0, 93.0]
+
+
+def test_union_trim_draw_reaches_per_tech_seats_but_never_beyond_them():
+    """The draw can select a guaranteed per-technology seat, yet never a candidate outside the union.
+
+    Notes:
+        With top_n=1 the head is the best 3 (all A). B's top-3 seats join the pool through the
+        union, so B is drawable; A's 4th site and B's 4th site stay ineligible forever.
+    """
+    import numpy as np
+
+    npv_dict = {
+        "steel": {
+            (40.0, -100.0, "USA"): {"A": -1.0},
+            (41.0, -101.0, "USA"): {"A": -2.0},
+            (42.0, -102.0, "USA"): {"A": -3.0},
+            (43.0, -103.0, "USA"): {"A": -4.0},
+            (44.0, -104.0, "USA"): {"B": -100.0},
+            (45.0, -105.0, "USA"): {"B": -101.0},
+            (46.0, -106.0, "USA"): {"B": -102.0},
+            (47.0, -107.0, "USA"): {"B": -200.0},
+        },
+    }
+
+    np.random.seed(7)
+    drawn_npvs = set()
+    for _ in range(300):
+        selected = select_top_opportunities_by_npv(
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True, opportunity_pool_depth=3
+        )
+        (npv,) = [npv for techs in selected["steel"].values() for npv in techs.values()]
+        drawn_npvs.add(npv)
+
+    assert drawn_npvs & {-100.0, -101.0, -102.0}, "per-technology seats were never drawn"
+    assert -4.0 not in drawn_npvs, "drew A's 4th site, outside head and per-tech seats"
+    assert -200.0 not in drawn_npvs, "drew B's 4th site, beyond its guaranteed seats"
+
+
+def test_pool_summary_reports_per_tech_best_over_the_full_pool():
+    """tech_best covers every technology in the valid pool, not only the eligible head."""
+    valid_pairs, valid_npvs, ranked_indices = _ranked_pool(
+        {
+            "A": [100.0, 50.0],
+            "B": [-10.0, -20.0],
+        },
+    )
+
+    eligible = [int(i) for i in ranked_indices[:2]]  # A only
+    selected_pairs = [valid_pairs[eligible[0]]]
+    summary = summarise_opportunity_pool(valid_pairs, valid_npvs, eligible, selected_pairs)
+
+    assert summary["valid"] == 4
+    assert summary["eligible"] == 2
+    assert summary["tech_best"] == {"A": 100.0, "B": -10.0}
+    assert summary["eligible_techs"] == {"A": 2}
+    assert summary["drawn_techs"] == {"A": 1}
+    assert summary["median"] == 75.0
+    assert summary["min"] == 50.0
+    assert summary["max"] == 100.0
+    assert summary["frac_negative"] == 0.0
+
+
+def test_pool_summary_flags_an_all_negative_eligible_pool():
+    """frac_negative reaches 1.0 when every eligible candidate is underwater."""
+    valid_pairs, valid_npvs, ranked_indices = _ranked_pool(
+        {
+            "A": [-200.0, -300.0, -400.0],
+        },
+    )
+
+    eligible = [int(i) for i in ranked_indices]
+    summary = summarise_opportunity_pool(valid_pairs, valid_npvs, eligible, [valid_pairs[eligible[0]]])
+
+    assert summary["frac_negative"] == 1.0
+    assert summary["max"] == -200.0
+
+
+def test_selection_logs_a_pool_summary_line(caplog):
+    """Every selection call emits one parsable pool_summary line per product."""
+    import logging
+
+    npv_dict = {
+        "steel": {
+            (40.0, -100.0, "USA"): {"EAF": 1000.0, "BOF": -500.0},
+            (41.0, -101.0, "USA"): {"EAF": 800.0},
+        },
+    }
+
+    with caplog.at_level(logging.INFO):
+        select_top_opportunities_by_npv(
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=1, probabilistic_agents=True, opportunity_pool_depth=3
+        )
+
+    summary_lines = [r.getMessage() for r in caplog.records if "pool_summary product=steel" in r.getMessage()]
+    assert len(summary_lines) == 1
+    assert "valid=3" in summary_lines[0]
+    assert "tech_best=[EAF:1.0000e+03,BOF:-5.0000e+02]" in summary_lines[0]
+
+
+def test_opportunity_pool_depth_drives_head_and_per_tech_seats():
+    """One depth value sets both the global head (depth * N) and each technology's seats.
+
+    Notes:
+        With 6 A-sites, 4 B-sites, top_n=2 and depth=2: the head is the best 4 (all A) and B
+        keeps its top-2 through the union, so the draw runs over exactly 6 eligible candidates.
+        At the default depth 3 the same pool widens to head 6 + B's top-3 = 9.
+    """
+    import numpy as np
+
+    npv_dict = {
+        "steel": {
+            **{(40.0 + i, -100.0 - i, "USA"): {"A": 100.0 - i} for i in range(6)},
+            **{(50.0 + i, -110.0 - i, "USA"): {"B": 50.0 - i} for i in range(4)},
+        },
+    }
+
+    with patch("numpy.random.choice") as mock_choice:
+        mock_choice.return_value = [0, 1]
+        select_top_opportunities_by_npv(
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=True, opportunity_pool_depth=2
+        )
+    (pool_size,), kwargs = mock_choice.call_args
+    assert pool_size == 6
+    assert list(kwargs["p"]) == pytest.approx(list(np.arange(6, 0, -1) / 21.0))
+
+    with patch("numpy.random.choice") as mock_choice:
+        mock_choice.return_value = [0, 1]
+        select_top_opportunities_by_npv(
+            npv_dict=npv_dict, top_n_loctechs_as_business_op=2, probabilistic_agents=True, opportunity_pool_depth=3
+        )
+    (pool_size,), _ = mock_choice.call_args
+    assert pool_size == 9


### PR DESCRIPTION
- `select_top_opportunities_by_npv` now draws from the global top (depth × N) by NPV unioned
  with each allowed technology's best `depth` sites — a monoculture head can no longer erase
  every alternative technology's standing. Rank-weighted draw and deterministic mode unchanged.
- New `pool_summary` log line per product per year: pool size, eligible NPV stats, technology
  mixes, per-technology best NPV over the full pool.
- New `opportunity_pool_depth` config variable (default 3, web form) sets both head width and
  per-technology seats.
- `calculate_npv_pct` promoted from hardcoded 0.1 to config; 0.1 only saves compute.
- Signature defaults removed (`top_n_loctechs_as_business_op`, new params) — SimulationConfig
  is the single source of truth.