### PR TITLE
Gate calculate_npv_pct and geo_config.priority_pct on probabilistic_a…

### DIFF
--- a/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
+++ b/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
@@ -5,7 +5,7 @@
 The new plant opening system transforms candidate locations into actual steel and iron plants through a multi-year business opportunity lifecycle. Companies identify promising locations, track their economic viability over time, announce viable projects, and eventually construct new facilities -all while accounting for uncertainty, capacity constraints, and changing market conditions.
 
 Business opportunities progress through the following stages:
-- **CONSIDERED**: Top location-technology pairs are identified based on NPV calculations and selected using weighted random sampling (or, when `probabilistic_agents` is disabled, deterministically by highest NPV — see [Business Opportunity Identification](#business-opportunity-identification)). Its NPV is recalculated annually with updated costs for several years; opportunities with consistently positive NPV advance to announcement (subject to probability filter), while consistently negative NPV leads to discard.
+- **CONSIDERED**: Top location-technology pairs are identified based on NPV calculations and selected using weighted random sampling (or, when `probabilistic_agents` is disabled, deterministically by highest NPV, evaluated over every candidate location instead of a random sample — see [Business Opportunity Identification](#business-opportunity-identification)). Its NPV is recalculated annually with updated costs for several years; opportunities with consistently positive NPV advance to announcement (subject to probability filter), while consistently negative NPV leads to discard.
 - **ANNOUNCED**: Project waits for construction start; dynamic costs continue to be updated annually; advancement to construction depends on technology remaining allowed, capacity limits, and probability filter.
 - **CONSTRUCTION**: Plant is being built over several years (handled by the plant agent model).
 - **OPERATING**: Plant is operational and removed from business opportunity tracking (fully handled by the plant agent model).
@@ -149,9 +149,9 @@ Filters technologies based on what will be allowed at the earliest possible cons
 Randomly samples a subset of top priority locations to reduce computational burden, since NPV calculations are resource-intensive.
 
 **Configuration:**
-- `calculate_npv_pct`: Percentage of locations to evaluate (default: 10%) out of the top X% extracted by the location priority selection (default: 5% of the world; see related documentation in [Priority Location Selection](priority_location_selection.md)).
+- `calculate_npv_pct`: Percentage of locations to evaluate (default: 10%) out of the top `geo_config.priority_pct`% extracted by the location priority selection (default: 5% of the world; see related documentation in [Priority Location Selection](priority_location_selection.md)).
 
-**Purpose:** Balance computational efficiency with coverage of good opportunities. Sampling 10% of 1000 candidate locations means evaluating 100 instead of all 1000. This step keeps its non-deterministic behavior for runtime efficiency — evaluating every candidate measured ~7x slower — since it is not thematically related to `probabilistic_agents`, which governs assessment of already-identified opportunities, not candidate selection.
+**Purpose:** Balance computational efficiency with coverage of good opportunities. Sampling 10% of 1000 candidate locations means evaluating 100 instead of all 1000. When `probabilistic_agents` is False, `calculate_npv_pct` is forced to 1.0 (evaluate every candidate) and `geo_config.priority_pct` is forced to 0.5 (narrowing the candidate pool the 100% sampling runs over) — full sampling alone measured ~7x slower, but combined with the narrower pool the runtime cost is negligible.
 
 ### Step 3: Cost Data Preparation
 
@@ -311,15 +311,16 @@ Models real-world risk factors: financing may fall through, permits may be denie
 | `plant_lifetime` | int | 20 years | Expected operational lifetime of plant |
 | `expanded_capacity` | float | 2.5 Mt/year | Standard capacity for new plants (same than for plant expansion) |
 | `top_n_loctechs_as_business_op` | int | 5 | Number of opportunities to track per product per year |
-| `calculate_npv_pct` | float | 0.1 | Percentage of priority locations to sample for NPV calculation (fixed; not gated by `probabilistic_agents` — evaluating all measured ~7x slower) |
 
 ### Probability Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `probabilistic_agents` | bool | True | When True, Step 5 draws a rank-weighted mix of top opportunities; when False, Step 5 picks the top N by NPV deterministically. Does not affect Step 2's `calculate_npv_pct` sampling (kept probabilistic for runtime — see above) |
+| `probabilistic_agents` | bool | True | When True, Step 5 draws a rank-weighted mix of top opportunities; when False, Step 5 picks the top N by NPV deterministically. Also gates Step 2's `calculate_npv_pct` sampling and `geo_config.priority_pct` — see below |
 | `probability_of_announcement` | float | 0.7 | Chance viable opportunity is announced. Forced to 1.0 when `probabilistic_agents` is False |
 | `probability_of_construction` | float | 0.9 | Chance announced project starts construction. Forced to 1.0 when `probabilistic_agents` is False |
+| `calculate_npv_pct` | float | 0.1 | Fraction of priority locations sampled for NPV calculation. Forced to 1.0 when `probabilistic_agents` is False |
+| `geo_config.priority_pct` | float | 5 | Percentage of global grid points selected as priority locations (see [Priority Location Selection](priority_location_selection.md)). Forced to 0.5 when `probabilistic_agents` is False, to keep the cost of full `calculate_npv_pct` sampling low |
 
 ### Capacity Limits
 

--- a/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
+++ b/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
@@ -149,9 +149,9 @@ Filters technologies based on what will be allowed at the earliest possible cons
 Randomly samples a subset of top priority locations to reduce computational burden, since NPV calculations are resource-intensive.
 
 **Configuration:**
-- `calculate_npv_pct`: Percentage of locations to evaluate (default: 10%) out of the top `geo_config.priority_pct`% extracted by the location priority selection (default: 5% of the world; see related documentation in [Priority Location Selection](priority_location_selection.md)).
+- `calculate_npv_sites_share`: Fraction of locations to evaluate (default: 0.1, i.e. 10%) out of the top `geo_config.pick_priority_sites_share` fraction extracted by the location priority selection (default: 0.05, i.e. 5% of the world; see related documentation in [Priority Location Selection](priority_location_selection.md)).
 
-**Purpose:** Balance computational efficiency with coverage of good opportunities. Sampling 10% of 1000 candidate locations means evaluating 100 instead of all 1000. When `probabilistic_agents` is False, `calculate_npv_pct` is forced to 1.0 (evaluate every candidate) and `geo_config.priority_pct` is forced to 0.5 (narrowing the candidate pool the 100% sampling runs over) — full sampling alone measured ~7x slower, but combined with the narrower pool the runtime cost is negligible.
+**Purpose:** Balance computational efficiency with coverage of good opportunities. Sampling 10% of 1000 candidate locations means evaluating 100 instead of all 1000. When `probabilistic_agents` is False, `calculate_npv_sites_share` is forced to 1.0 (evaluate every candidate) and `geo_config.pick_priority_sites_share` is forced to 0.005 (narrowing the candidate pool the 100% sampling runs over) — full sampling alone measured ~7x slower, but combined with the narrower pool the runtime cost is negligible.
 
 ### Step 3: Cost Data Preparation
 
@@ -316,11 +316,11 @@ Models real-world risk factors: financing may fall through, permits may be denie
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `probabilistic_agents` | bool | True | When True, Step 5 draws a rank-weighted mix of top opportunities; when False, Step 5 picks the top N by NPV deterministically. Also gates Step 2's `calculate_npv_pct` sampling and `geo_config.priority_pct` — see below |
+| `probabilistic_agents` | bool | True | When True, Step 5 draws a rank-weighted mix of top opportunities; when False, Step 5 picks the top N by NPV deterministically. Also gates Step 2's `calculate_npv_sites_share` sampling and `geo_config.pick_priority_sites_share` — see below |
 | `probability_of_announcement` | float | 0.7 | Chance viable opportunity is announced. Forced to 1.0 when `probabilistic_agents` is False |
 | `probability_of_construction` | float | 0.9 | Chance announced project starts construction. Forced to 1.0 when `probabilistic_agents` is False |
-| `calculate_npv_pct` | float | 0.1 | Fraction of priority locations sampled for NPV calculation. Forced to 1.0 when `probabilistic_agents` is False |
-| `geo_config.priority_pct` | float | 5 | Percentage of global grid points selected as priority locations (see [Priority Location Selection](priority_location_selection.md)). Forced to 0.5 when `probabilistic_agents` is False, to keep the cost of full `calculate_npv_pct` sampling low |
+| `calculate_npv_sites_share` | float | 0.1 | Fraction of priority locations sampled for NPV calculation. Forced to 1.0 when `probabilistic_agents` is False |
+| `geo_config.pick_priority_sites_share` | float | 0.05 | Fraction of global grid points selected as priority locations (see [Priority Location Selection](priority_location_selection.md)). Forced to 0.005 when `probabilistic_agents` is False, to keep the cost of full `calculate_npv_sites_share` sampling low |
 
 ### Capacity Limits
 

--- a/docs/domain_simulation_logic/geospatial_model/priority_location_selection.md
+++ b/docs/domain_simulation_logic/geospatial_model/priority_location_selection.md
@@ -165,7 +165,7 @@ Iron and steel are calculated separately, each receiving a share of CAPEX and en
 
 ### Step 2: Global Priority Location Extraction
 
-After calculating outgoing cashflow for all feasible locations, the system extracts the top X% cheapest locations globally (where X is defined by `priority_pct`, default 5%) by flattening the 2D cost grid, removing infeasible locations, sorting by cost, and applying a distribution-adaptive selection method:
+After calculating outgoing cashflow for all feasible locations, the system extracts the top X% cheapest locations globally (where X% is `geo_config.pick_priority_sites_share`, a fraction 0.0-1.0, default 0.05 i.e. 5%) by flattening the 2D cost grid, removing infeasible locations, sorting by cost, and applying a distribution-adaptive selection method:
 
 1. **Continuous Distribution** (≥ 20 unique values): Uses quantile threshold to select all locations below the Xth percentile (most common case)
 2. **Low-Variance Distribution** (< 20 unique values): Samples from cost-ranked chunks with random selection within chunks to prevent systematic geographic bias
@@ -219,7 +219,7 @@ The pipeline generates the following plots (saved to `geo_plots_dir`):
 ### Priority Calculation Plots (Per Year, Per Product)
 - `lifetime_cost_proxy_{product}_{year}_p{X}.png` - Total lifetime costs
 - `priority_heatmap_{product}_{year}_p{X}.png` - Inverted priority map (higher = better)
-- `top{priority_pct}_priority_locations_{product}_{year}.png` - Selected candidate locations
+- `top{P}_priority_locations_{product}_{year}.png` - Selected candidate locations, where `{P}` is `pick_priority_sites_share` expressed as a percentage (e.g. `top5` for the 0.05 default; not the same `{X}` as the grid-power-mix plots below)
 
 Where `{X}` indicates the percentage of grid power vs. baseload (e.g., p5 = 95% baseload + 5% grid).
 
@@ -259,7 +259,7 @@ Key parameters affecting priority location selection:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `priority_pct` | 5 | Percentage of global top locations to extract as priority locations |
+| `pick_priority_sites_share` | 0.05 | Fraction of global top locations to extract as priority locations |
 | `included_power_mix` | 85% baseload + 15% grid | Power source for new plants |
 | `include_transport_cost` | True | Whether to include shipping costs |
 | `include_infrastructure_cost` | True | Whether to include railway buildout |

--- a/src/steelo/adapters/geospatial/priority_kpi.py
+++ b/src/steelo/adapters/geospatial/priority_kpi.py
@@ -255,7 +255,11 @@ def extract_priority_locations(
 
 
 def find_top_locations_per_country(
-    ds: xr.Dataset, top_locations: dict[str, pd.DataFrame], product: str, priority_pct: float, random_seed: int
+    ds: xr.Dataset,
+    top_locations: dict[str, pd.DataFrame],
+    product: str,
+    priority_sites_share: float,
+    random_seed: int,
 ) -> tuple[xr.DataArray, pd.DataFrame]:
     """
     Add the top X/10% locations for each country to ensure all countries have representation.
@@ -266,15 +270,16 @@ def find_top_locations_per_country(
         ds: Dataset containing outgoing cashflow data and ISO3 codes
         top_locations: Dictionary mapping product types to DataFrames of global top locations
         product: Product type ("iron" or "steel")
-        priority_pct: Global priority percentage (the per-country percentage is priority_pct/10)
+        priority_sites_share: Global priority fraction (0.0-1.0); the per-country fraction is
+            priority_sites_share/10
         random_seed: Random seed for reproducible sampling
 
     Returns:
         top_values: DataArray with binary values (1 for top locations including country lottery, 0 otherwise)
         top_locations_wlottery: DataFrame containing all top locations including country-specific additions
     """
-
-    top_wlottery = ds[f"top{str(priority_pct)}_{product}"].copy().astype(float)
+    priority_pct_label = f"{priority_sites_share * 100:g}"
+    top_wlottery = ds[f"top{priority_pct_label}_{product}"].copy().astype(float)
     top_locations_wlottery = top_locations[product].copy()
 
     # List of unique ISO3 codes
@@ -290,7 +295,7 @@ def find_top_locations_per_country(
             top_values_iso3, top_locations_iso3 = extract_priority_locations(
                 ds_iso3,
                 f"outgoing_cashflow_{product}",
-                top_pct=priority_pct / 10,
+                top_pct=(priority_sites_share / 10) * 100,  # extract_priority_locations expects 0-100
                 random_seed=random_seed,
                 invert=True,
             )
@@ -357,7 +362,8 @@ def calculate_priority_location_kpi(
         Generates and saves plots of outgoing cashflow and priority heatmaps (decadal
         milestones), and top location maps (5-year milestones).
     """
-    logger.info(f"Identifying the top {geo_config.priority_pct}% priority locations.")
+    priority_pct_label = f"{geo_config.pick_priority_sites_share * 100:g}"
+    logger.info(f"Identifying the top {priority_pct_label}% priority locations.")
 
     # Mask all variables with the feasibility mask and remove NaN values
     ds_masked = ds.where(ds["feasibility_mask"] > 0)
@@ -388,28 +394,28 @@ def calculate_priority_location_kpi(
         )
 
         # Get the top X% locations (bottom X% of the price distribution)
-        ds_masked[f"top{str(geo_config.priority_pct)}_{product}"], top_locations[product] = extract_priority_locations(
+        ds_masked[f"top{priority_pct_label}_{product}"], top_locations[product] = extract_priority_locations(
             ds_masked,
             f"outgoing_cashflow_{product}",
-            top_pct=geo_config.priority_pct,
+            top_pct=geo_config.pick_priority_sites_share * 100,  # extract_priority_locations expects 0-100
             random_seed=geo_config.random_seed,
             invert=True,
         )
 
         # Add the top X/10 % locations for each country to "give everyone a chance". The "chance" is proportional to the size of the country.
-        ds_masked[f"top{str(geo_config.priority_pct)}_{product}_wlottery"], top_locations_wlottery[product] = (
+        ds_masked[f"top{priority_pct_label}_{product}_wlottery"], top_locations_wlottery[product] = (
             find_top_locations_per_country(
-                ds_masked, top_locations, product, geo_config.priority_pct, geo_config.random_seed
+                ds_masked, top_locations, product, geo_config.pick_priority_sites_share, geo_config.random_seed
             )
         )
 
         if is_top_locations_milestone_year:
             plot_paths_obj = PlotPaths(geo_plots_dir=geo_paths.geo_plots_dir)
             plot_screenshot(
-                ds_masked[f"top{str(geo_config.priority_pct)}_{product}_wlottery"],
+                ds_masked[f"top{priority_pct_label}_{product}_wlottery"],
                 var_type="binary",
-                title=f"Top {geo_config.priority_pct}% locations for {product} production in {year}",
-                save_name=f"top{str(geo_config.priority_pct)}_priority_locations_{product}_{str(year)}",
+                title=f"Top {priority_pct_label}% locations for {product} production in {year}",
+                save_name=f"top{priority_pct_label}_priority_locations_{product}_{str(year)}",
                 plot_paths=plot_paths_obj,
             )
 

--- a/src/steelo/adapters/geospatial/priority_kpi.py
+++ b/src/steelo/adapters/geospatial/priority_kpi.py
@@ -255,7 +255,7 @@ def extract_priority_locations(
 
 
 def find_top_locations_per_country(
-    ds: xr.Dataset, top_locations: dict[str, pd.DataFrame], product: str, priority_pct: int, random_seed: int
+    ds: xr.Dataset, top_locations: dict[str, pd.DataFrame], product: str, priority_pct: float, random_seed: int
 ) -> tuple[xr.DataArray, pd.DataFrame]:
     """
     Add the top X/10% locations for each country to ensure all countries have representation.
@@ -391,7 +391,7 @@ def calculate_priority_location_kpi(
         ds_masked[f"top{str(geo_config.priority_pct)}_{product}"], top_locations[product] = extract_priority_locations(
             ds_masked,
             f"outgoing_cashflow_{product}",
-            top_pct=int(geo_config.priority_pct),
+            top_pct=geo_config.priority_pct,
             random_seed=geo_config.random_seed,
             invert=True,
         )

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -6012,7 +6012,7 @@ class PlantGroup:
         active_statuses: list[str],
         top_n_loctechs_as_business_op: int,
         opportunity_pool_depth: int,
-        calculate_npv_pct: float,
+        calculate_npv_sites_share: float,
         capex_subsidies: dict[str, dict[str, list[Subsidy]]] = {},  # iso3 -> tech -> list of subsidies
         debt_subsidies: dict[str, dict[str, list[Subsidy]]] = {},  # iso3 -> tech -> list of subsidies
         opex_subsidies: dict[str, dict[str, list[Subsidy]]] = {},  # iso3 -> tech -> list of subsidies
@@ -6075,8 +6075,9 @@ class PlantGroup:
             opportunity_pool_depth: Depth of the probabilistic draw's eligible pool: global
                 head of (depth * top_n) candidates by NPV unioned with each allowed
                 technology's best `depth` sites (see select_top_opportunities_by_npv)
-            calculate_npv_pct: Fraction (0.0-1.0) of the priority-location subset that is
-                randomly sampled for full NPV evaluation each year
+            calculate_npv_sites_share: Fraction (0.0-1.0) of the priority-location subset that is
+                randomly sampled for full NPV evaluation each year. Forced to 1.0 when
+                probabilistic_agents is False (see SimulationConfig.__post_init__)
             capex_subsidies: Dictionary mapping geo_key -> tech -> list of capex subsidies
                 (geo_key = "ISO3" or "ISO3:unit"; country and sub-national rows merge additively)
             debt_subsidies: Dictionary mapping geo_key -> tech -> list of debt subsidies
@@ -6085,10 +6086,10 @@ class PlantGroup:
             derive_geo_unit: Optional ``(lat, lon, iso3) -> geo_unit | None`` derivation (injected
                 from the geospatial adapter) tagging each spawned plant's sub-national unit
             probabilistic_agents: If True (default), step 5 draws a rank-weighted mix of top
-                opportunities. If False, step 5 deterministically picks the top N by NPV. Step 2's
-                location sampling is unaffected by this flag (measured ~7x runtime cost to evaluate
-                all candidates deterministically was judged not worth it — see
-                docs/domain_simulation_logic/geospatial_model/new_plant_opening.md).
+                opportunities. If False, step 5 deterministically picks the top N by NPV, and
+                calculate_npv_sites_share is forced to 1.0 by SimulationConfig.__post_init__ so
+                step 2 evaluates every candidate location instead of a random sample — see
+                docs/domain_simulation_logic/geospatial_model/new_plant_opening.md.
 
         Returns:
             Command to add new Plant and FurnaceGroup objects for the identified business opportunities
@@ -6148,7 +6149,7 @@ class PlantGroup:
         # Step 2: Select a subset of locations
         best_locations_subset = select_location_subset(
             locations=locations,
-            calculate_npv_pct=calculate_npv_pct,
+            calculate_npv_sites_share=calculate_npv_sites_share,
         )
         subset_counts, subset_total = _count_entries(best_locations_subset)
         candidate_stats["subset_sites_total"] = subset_total

--- a/src/steelo/domain/new_plant_opening.py
+++ b/src/steelo/domain/new_plant_opening.py
@@ -21,14 +21,14 @@ class NewPlantLocation(TypedDict):
 
 def select_location_subset(
     locations: dict,
-    calculate_npv_pct: float,
+    calculate_npv_sites_share: float,
 ) -> dict:
     """
     Randomly select a subset of top locations for detailed NPV assessment (potential business opportunities).
 
     Args:
         locations: Dictionary mapping products to lists of location dictionaries
-        calculate_npv_pct: Percentage of locations to sample (0.0 to 1.0)
+        calculate_npv_sites_share: Fraction of locations to sample (0.0 to 1.0)
 
     Returns:
         Dictionary mapping products to sampled location lists
@@ -37,10 +37,10 @@ def select_location_subset(
         Logs sampling information and sample locations
     """
     logger = logging.getLogger(f"{__name__}.select_location_subset")
-    logger.info(f"[NEW PLANTS] Sampling {calculate_npv_pct * 100}% of top locations for NPV calculation.")
+    logger.info(f"[NEW PLANTS] Sampling {calculate_npv_sites_share * 100}% of top locations for NPV calculation.")
     best_locations_subset = {}
     for product in ["iron", "steel"]:
-        n = int(len(locations.get(product, [])) * calculate_npv_pct)
+        n = int(len(locations.get(product, [])) * calculate_npv_sites_share)
         best_locations_subset[product] = random.sample(locations[product], n) if n > 0 else []
         logger.info(
             f"[NEW PLANTS] For {product}: Sampling n = {n} out of total locations = {len(locations.get(product, []))} for NPV calculation."

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -291,7 +291,7 @@ class GeospatialModel:
                 allowed_techs=bus.env.allowed_techs,
                 top_n_loctechs_as_business_op=bus.env.config.top_n_loctechs_as_business_op,
                 opportunity_pool_depth=bus.env.config.opportunity_pool_depth,
-                calculate_npv_pct=bus.env.config.calculate_npv_pct,
+                calculate_npv_sites_share=bus.env.config.calculate_npv_sites_share,
                 technology_emission_factors=bus.env.technology_emission_factors,
                 chosen_emissions_boundary_for_carbon_costs=bus.env.config.chosen_emissions_boundary_for_carbon_costs,
                 capex_subsidies=bus.env.capex_subsidies,

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -245,8 +245,8 @@ class GeoConfig:
     )
 
     # === Outgoing cashflow estimate (to build a new plant at a certain location) ===
-    priority_pct: float = (
-        5  # Percentage of global grid points selected as priority locations for business opportunities
+    pick_priority_sites_share: float = (
+        0.05  # Fraction of global grid points selected as priority locations for business opportunities
     )
     iron_ore_steel_ratio: float = 1.6  # Amount of iron ore needed to produce 1 unit of steel
     share_iron_vs_steel: dict[str, dict[str, float]] = field(
@@ -386,16 +386,16 @@ class SimulationConfig:
         3  # Minimum number of years a considered business opportunity needs to be NPV-positive before being announced
     )
     construction_time: int = 4  # Years it takes to construct a plant after it has been announced
-    # probability_of_construction, probability_of_announcement, calculate_npv_pct, and
-    # geo_config.priority_pct are all forced to deterministic values in __post_init__ when
-    # probabilistic_agents is False.
+    # probability_of_construction, probability_of_announcement, calculate_npv_sites_share, and
+    # geo_config.pick_priority_sites_share are all forced to deterministic values in
+    # __post_init__ when probabilistic_agents is False.
     probability_of_construction: float = 0.9  # Probability of a plant being constructed after being announced
     probability_of_announcement: float = 0.7  # Probability of a plant being announced after being considered - given a history of positive NPVs of at least `consideration_time` years
     top_n_loctechs_as_business_op: int = 15  # Number of top location-technology combinations to consider as business
     # opportunities per product per year (e.g., 5 for steel and 5 for iron = 10 total)
     opportunity_pool_depth: int = 3  # Probabilistic draw eligibility: global top (depth * top_n) by NPV plus each
     # allowed technology's best `depth` sites, so no technology loses standing to a monoculture head
-    calculate_npv_pct: float = 0.1  # Fraction of priority locations sampled each year for full NPV evaluation;
+    calculate_npv_sites_share: float = 0.1  # Fraction of priority locations sampled each year for full NPV evaluation;
     # 0.1 is chosen purely to save computational time, not for model reasons
     co2_storage_reserved_discount_factor: float = (
         0.9  # Fraction of an announced CCS plant's CO2 need that counts toward the reserved storage bucket
@@ -547,12 +547,13 @@ class SimulationConfig:
 
         # Deterministic agents: the announcement/construction draws must always pass, and
         # new-plant siting must evaluate NPV for every candidate location rather than a
-        # random sample (with priority_pct narrowed to keep the full-sampling cost low).
+        # random sample (with pick_priority_sites_share narrowed to keep the full-sampling
+        # cost low).
         if not self.probabilistic_agents:
             self.probability_of_construction = 1.0
             self.probability_of_announcement = 1.0
-            self.calculate_npv_pct = 1.0
-            self.geo_config.priority_pct = 0.5
+            self.calculate_npv_sites_share = 1.0
+            self.geo_config.pick_priority_sites_share = 0.005
 
         # Handle deprecated parameter - preserve semantics by translating to technology_settings
         if global_bf_ban is not None:

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -245,7 +245,9 @@ class GeoConfig:
     )
 
     # === Outgoing cashflow estimate (to build a new plant at a certain location) ===
-    priority_pct: int = 5  # Percentage of global grid points selected as priority locations for business opportunities
+    priority_pct: float = (
+        5  # Percentage of global grid points selected as priority locations for business opportunities
+    )
     iron_ore_steel_ratio: float = 1.6  # Amount of iron ore needed to produce 1 unit of steel
     share_iron_vs_steel: dict[str, dict[str, float]] = field(
         default_factory=lambda: {
@@ -384,7 +386,9 @@ class SimulationConfig:
         3  # Minimum number of years a considered business opportunity needs to be NPV-positive before being announced
     )
     construction_time: int = 4  # Years it takes to construct a plant after it has been announced
-    # Both probabilities are forced to 1 in __post_init__ when probabilistic_agents is False
+    # probability_of_construction, probability_of_announcement, calculate_npv_pct, and
+    # geo_config.priority_pct are all forced to deterministic values in __post_init__ when
+    # probabilistic_agents is False.
     probability_of_construction: float = 0.9  # Probability of a plant being constructed after being announced
     probability_of_announcement: float = 0.7  # Probability of a plant being announced after being considered - given a history of positive NPVs of at least `consideration_time` years
     top_n_loctechs_as_business_op: int = 15  # Number of top location-technology combinations to consider as business
@@ -541,10 +545,14 @@ class SimulationConfig:
         # Single source of truth: propagate top-level seed into nested GeoConfig.
         self.geo_config.random_seed = self.random_seed
 
-        # Deterministic agents: the announcement/construction draws must always pass
+        # Deterministic agents: the announcement/construction draws must always pass, and
+        # new-plant siting must evaluate NPV for every candidate location rather than a
+        # random sample (with priority_pct narrowed to keep the full-sampling cost low).
         if not self.probabilistic_agents:
             self.probability_of_construction = 1.0
             self.probability_of_announcement = 1.0
+            self.calculate_npv_pct = 1.0
+            self.geo_config.priority_pct = 0.5
 
         # Handle deprecated parameter - preserve semantics by translating to technology_settings
         if global_bf_ban is not None:

--- a/src/steeloweb/forms.py
+++ b/src/steeloweb/forms.py
@@ -372,17 +372,19 @@ class ModelRunCreateForm(forms.ModelForm):
         widget=forms.NumberInput(attrs={"class": "form-control field-connected"}),
     )
 
-    priority_pct = forms.IntegerField(
-        label="Percentage of considered opportunities",
-        initial=5,
-        min_value=1,
-        max_value=100,
+    pick_priority_sites_share = forms.DecimalField(
+        label="Priority sites fraction",
+        initial=0.05,
+        min_value=0.001,
+        max_value=1.0,
+        max_digits=4,
+        decimal_places=3,
         required=False,
-        help_text="Percentage of global grid points selected as priority locations for business opportunities",
-        widget=forms.NumberInput(attrs={"class": "form-control field-connected"}),
+        help_text="Fraction (0.0-1.0) of global grid points selected as priority locations for business opportunities",
+        widget=forms.NumberInput(attrs={"class": "form-control field-connected", "step": "0.001"}),
     )
 
-    calculate_npv_pct = forms.DecimalField(
+    calculate_npv_sites_share = forms.DecimalField(
         label="NPV sample fraction",
         initial=0.1,
         min_value=0.0,
@@ -805,8 +807,8 @@ class ModelRunCreateForm(forms.ModelForm):
             "probability_of_construction",
             "top_n_loctechs_as_business_op",
             "opportunity_pool_depth",
-            "priority_pct",
-            "calculate_npv_pct",
+            "pick_priority_sites_share",
+            "calculate_npv_sites_share",
             "expanded_capacity",
             "capacity_limit_iron",
             "capacity_limit_steel",

--- a/src/steeloweb/models.py
+++ b/src/steeloweb/models.py
@@ -718,13 +718,13 @@ class ModelRun(models.Model):
             "probability_of_announcement",
             "top_n_loctechs_as_business_op",
             "opportunity_pool_depth",
-            "calculate_npv_pct",
+            "calculate_npv_sites_share",
             # Plant capacity parameters
             "expanded_capacity",
             "capacity_limit_iron",
             "capacity_limit_steel",
             "new_capacity_share_from_new_plants",
-            "priority_pct",
+            "pick_priority_sites_share",
             "hydrogen_ceiling_percentile",
             "intraregional_trade_allowed",
             "long_dist_pipeline_transport_cost",
@@ -931,7 +931,7 @@ class ModelRun(models.Model):
                 "include_transport_cost",
                 "include_lulc_cost",
                 "transportation_cost_per_km_per_ton",
-                "priority_pct",
+                "pick_priority_sites_share",
             ]
             # Only include geo parameters that are not None to avoid overriding defaults
             # Apply defensive type casting for specific fields
@@ -951,8 +951,8 @@ class ModelRun(models.Model):
                         val = float(_pick(filtered_config, k, 20.0))
                     elif k == "long_dist_pipeline_transport_cost":
                         val = float(_pick(filtered_config, k, 1.0))
-                    elif k == "priority_pct":
-                        val = int(_pick(filtered_config, k, 5))
+                    elif k == "pick_priority_sites_share":
+                        val = float(_pick(filtered_config, k, 0.05))
                     elif k == "transportation_cost_per_km_per_ton":
                         val = {route: float(v) for route, v in filtered_config[k].items() if v not in (None, "")}
                     geo_config_data[k] = val
@@ -995,7 +995,7 @@ class ModelRun(models.Model):
                 "include_transport_cost",
                 "include_lulc_cost",
                 "transportation_cost_per_km_per_ton",
-                "priority_pct",
+                "pick_priority_sites_share",
             ]
             # Only include geo parameters that are not None to avoid overriding defaults
             # Apply defensive type casting for specific fields
@@ -1015,8 +1015,8 @@ class ModelRun(models.Model):
                         val = float(_pick(filtered_config, k, 20.0))
                     elif k == "long_dist_pipeline_transport_cost":
                         val = float(_pick(filtered_config, k, 1.0))
-                    elif k == "priority_pct":
-                        val = int(_pick(filtered_config, k, 5))
+                    elif k == "pick_priority_sites_share":
+                        val = float(_pick(filtered_config, k, 0.05))
                     elif k == "transportation_cost_per_km_per_ton":
                         val = {route: float(v) for route, v in filtered_config[k].items() if v not in (None, "")}
                     geo_config_data[k] = val

--- a/src/steeloweb/templates/steeloweb/create_modelrun.html
+++ b/src/steeloweb/templates/steeloweb/create_modelrun.html
@@ -55,7 +55,7 @@ function resetConstructionSettings() {
     document.getElementById('id_probabilistic_agents').checked = true;
     document.getElementById('id_probability_of_announcement').value = '0.7';
     document.getElementById('id_probability_of_construction').value = '0.9';
-    resetField('id_priority_pct') || (document.getElementById('id_priority_pct').value = '5');
+    resetField('id_pick_priority_sites_share') || (document.getElementById('id_pick_priority_sites_share').value = '0.05');
     document.getElementById('id_top_n_loctechs_as_business_op').value = '15';
     document.getElementById('id_expanded_capacity').value = '2.5';
     document.getElementById('id_capacity_limit_iron').value = '100.0';
@@ -849,15 +849,15 @@ document.head.appendChild(style);
                                 <h6 class="mb-3 fw-bold">Selection of New Business Opportunities</h6>
 
                                 <div class="mb-3 row">
-                                    <label for="{{ form.priority_pct.id_for_label }}" class="col-sm-3 col-form-label">{{ form.priority_pct.label }}:</label>
+                                    <label for="{{ form.pick_priority_sites_share.id_for_label }}" class="col-sm-3 col-form-label">{{ form.pick_priority_sites_share.label }}:</label>
                                     <div class="col-sm-9">
-                                        {{ form.priority_pct }}
-                                        {% if form.priority_pct.errors %}
+                                        {{ form.pick_priority_sites_share }}
+                                        {% if form.pick_priority_sites_share.errors %}
                                         <div class="invalid-feedback d-block">
-                                            {{ form.priority_pct.errors }}
+                                            {{ form.pick_priority_sites_share.errors }}
                                         </div>
                                         {% endif %}
-                                        <small class="form-text text-muted">{{ form.priority_pct.help_text }}</small>
+                                        <small class="form-text text-muted">{{ form.pick_priority_sites_share.help_text }}</small>
                                     </div>
                                 </div>
 

--- a/src/steeloweb/views.py
+++ b/src/steeloweb/views.py
@@ -745,8 +745,8 @@ def create_modelrun(request):
                 "probability_of_construction": float(form.cleaned_data.get("probability_of_construction") or 0.9),
                 "top_n_loctechs_as_business_op": form.cleaned_data.get("top_n_loctechs_as_business_op", 15),
                 "opportunity_pool_depth": int(form.cleaned_data.get("opportunity_pool_depth") or 3),
-                "priority_pct": int(form.cleaned_data.get("priority_pct") or 5),
-                "calculate_npv_pct": float(form.cleaned_data.get("calculate_npv_pct") or 0.1),
+                "pick_priority_sites_share": float(form.cleaned_data.get("pick_priority_sites_share") or 0.05),
+                "calculate_npv_sites_share": float(form.cleaned_data.get("calculate_npv_sites_share") or 0.1),
                 # Plant capacity parameters (convert Mt to t)
                 "expanded_capacity": float(form.cleaned_data.get("expanded_capacity") or 2.5) * 1000000,
                 "capacity_limit_iron": float(form.cleaned_data.get("capacity_limit_iron") or 100) * 1000000,

--- a/tests/unit/test_geo_price_cost_alignment.py
+++ b/tests/unit/test_geo_price_cost_alignment.py
@@ -131,7 +131,7 @@ def _run_identify(monkeypatch, market_price_steel: list[float]) -> dict:
         active_statuses=["operating"],
         top_n_loctechs_as_business_op=1,
         opportunity_pool_depth=3,
-        calculate_npv_pct=0.1,
+        calculate_npv_sites_share=0.1,
         probabilistic_agents=False,
     )
     return captured["npv_dict"]

--- a/tests/unit/test_identify_new_business_opportunities_4indi.py
+++ b/tests/unit/test_identify_new_business_opportunities_4indi.py
@@ -78,7 +78,7 @@ class TestSelectLocationSubset:
             ],
         }
 
-        subset = select_location_subset(locations=locations, calculate_npv_pct=0.1)
+        subset = select_location_subset(locations=locations, calculate_npv_sites_share=0.1)
 
         # Verify structure
         assert "steel" in subset
@@ -119,7 +119,7 @@ class TestSelectLocationSubset:
             ],
         }
 
-        subset = select_location_subset(locations=locations, calculate_npv_pct=0.5)
+        subset = select_location_subset(locations=locations, calculate_npv_sites_share=0.5)
 
         assert len(subset["steel"]) == 5  # 50% of 10
         assert len(subset["iron"]) == 3  # 50% of 6
@@ -128,7 +128,7 @@ class TestSelectLocationSubset:
         """Empty location lists yield empty subsets without raising."""
         locations = {"steel": [], "iron": []}
 
-        subset = select_location_subset(locations=locations, calculate_npv_pct=0.1)
+        subset = select_location_subset(locations=locations, calculate_npv_sites_share=0.1)
 
         assert subset == {"steel": [], "iron": []}
 
@@ -147,14 +147,14 @@ class TestSelectLocationSubset:
             ],
         }
 
-        subset = select_location_subset(locations=locations, calculate_npv_pct=0.1)
+        subset = select_location_subset(locations=locations, calculate_npv_sites_share=0.1)
 
         # 10% of 1 = 0.1, rounds to 0
         assert len(subset["steel"]) == 0
         assert len(subset["iron"]) == 0
 
     def test_full_percentage_selects_every_candidate(self):
-        """calculate_npv_pct=1.0 includes every candidate (just reordered, none dropped)."""
+        """calculate_npv_sites_share=1.0 includes every candidate (just reordered, none dropped)."""
         locations = {
             "steel": [
                 NewPlantLocation(
@@ -180,7 +180,7 @@ class TestSelectLocationSubset:
             ],
         }
 
-        subset = select_location_subset(locations=locations, calculate_npv_pct=1.0)
+        subset = select_location_subset(locations=locations, calculate_npv_sites_share=1.0)
 
         # Every candidate is present (random.sample with n == population size drops nothing,
         # just reorders), regardless of list order.
@@ -1672,7 +1672,7 @@ def test_two_technologies_at_one_site_spawn_two_plants(monkeypatch):
         active_statuses=["operating"],
         top_n_loctechs_as_business_op=2,
         opportunity_pool_depth=3,
-        calculate_npv_pct=0.1,
+        calculate_npv_sites_share=0.1,
     )
 
     new_plants = command.new_plants

--- a/tests/unit/test_priority_kpi.py
+++ b/tests/unit/test_priority_kpi.py
@@ -462,12 +462,12 @@ class TestFindTopLocationsPerCountry:
         }
 
         # Find top locations per country for steel
-        # priority_pct=10 means top 1% per country (10/10)
+        # priority_sites_share=0.10 means top 1% per country (0.10/10)
         top_values, locations_df = find_top_locations_per_country(
             ds=mock_dataset_with_countries,
             top_locations=top_locations,
             product="steel",
-            priority_pct=10,
+            priority_sites_share=0.10,
             random_seed=42,
         )
 
@@ -516,7 +516,7 @@ class TestFindTopLocationsPerCountry:
             ds=mock_dataset_with_countries,
             top_locations=top_locations,
             product="steel",
-            priority_pct=10,
+            priority_sites_share=0.10,
             random_seed=42,
         )
 
@@ -544,7 +544,7 @@ class TestFindTopLocationsPerCountry:
             ds=mock_dataset_with_countries,
             top_locations=top_locations,
             product="steel",
-            priority_pct=10,
+            priority_sites_share=0.10,
             random_seed=42,
         )
 
@@ -594,7 +594,7 @@ class TestCalculatePriorityLocationKpi:
     def mock_geo_config(self):
         """Create a mock GeoConfig object."""
         config = Mock()
-        config.priority_pct = 25
+        config.pick_priority_sites_share = 0.25
         config.random_seed = 42
         config.share_iron_vs_steel = {
             "iron": {"capex_share": 0.4, "energy_consumption_per_t": 3.0},  # MWh/t for iron
@@ -678,7 +678,7 @@ class TestCalculatePriorityLocationKpi:
     ):
         """Test with different priority percentages."""
         # Test with 50% selection
-        mock_geo_config.priority_pct = 50
+        mock_geo_config.pick_priority_sites_share = 0.50
 
         result = calculate_priority_location_kpi(
             ds=mock_full_dataset,
@@ -696,7 +696,7 @@ class TestCalculatePriorityLocationKpi:
         assert "steel" in result
 
         # With 50% selection, should have more locations than with 25%
-        mock_geo_config.priority_pct = 10
+        mock_geo_config.pick_priority_sites_share = 0.10
         result_small = calculate_priority_location_kpi(
             ds=mock_full_dataset,
             capex=1000000,
@@ -714,12 +714,12 @@ class TestCalculatePriorityLocationKpi:
 
 
 def test_country_lottery_scales_with_country_size():
-    """The per-country lottery selects ~priority_pct/10 % of each country's cells.
+    """The per-country lottery selects ~priority_sites_share/10 % of each country's cells.
 
     Notes:
         Guards against the former ``int(priority_pct / 10)`` truncation, which
         collapsed the lottery to a single pixel per country regardless of size.
-        With priority_pct=5 the per-country share is 0.5%, so a country with 810
+        With priority_sites_share=0.05 the per-country share is 0.5%, so a country with 810
         cells must contribute several locations while a 90-cell country gets one.
     """
     n = 30
@@ -745,7 +745,7 @@ def test_country_lottery_scales_with_country_size():
         ds=ds,
         top_locations=top_locations,
         product="steel",
-        priority_pct=5,
+        priority_sites_share=0.05,
         random_seed=42,
     )
 
@@ -787,7 +787,7 @@ def test_find_top_locations_per_country_deduplicates_global_and_lottery_rows():
         ds=ds,
         top_locations=top_locations,
         product="steel",
-        priority_pct=10,
+        priority_sites_share=0.10,
         random_seed=42,
     )
 

--- a/tests/unit/test_simulation_config.py
+++ b/tests/unit/test_simulation_config.py
@@ -109,6 +109,25 @@ def test_deterministic_agents_force_announcement_and_construction_probabilities_
     assert config.probability_of_announcement == 1.0
 
 
+def test_deterministic_agents_force_full_npv_sampling_with_narrowed_priority_pct():
+    """
+    Tests that probabilistic_agents=False forces full NPV sampling of candidate
+    locations (calculate_npv_pct=1.0) while narrowing geo_config.priority_pct to 0.5
+    to keep the cost of full sampling low, regardless of defaults or overrides.
+    """
+    config = SimulationConfig(
+        start_year=Year(2025),
+        end_year=Year(2060),
+        master_excel_path=Path("test.xlsx"),
+        output_dir=Path("/tmp/output"),
+        probabilistic_agents=False,
+        calculate_npv_pct=0.3,
+    )
+
+    assert config.calculate_npv_pct == 1.0
+    assert config.geo_config.priority_pct == 0.5
+
+
 def test_probabilistic_agents_keep_default_announcement_and_construction_probabilities():
     """
     Tests that probabilistic_agents=True (the default) preserves the stochastic
@@ -124,3 +143,20 @@ def test_probabilistic_agents_keep_default_announcement_and_construction_probabi
     assert config.probabilistic_agents is True
     assert config.probability_of_construction == 0.9
     assert config.probability_of_announcement == 0.7
+
+
+def test_probabilistic_agents_keep_default_npv_sampling_and_priority_pct():
+    """
+    Tests that probabilistic_agents=True (the default) preserves the default
+    calculate_npv_pct and geo_config.priority_pct values.
+    """
+    config = SimulationConfig(
+        start_year=Year(2025),
+        end_year=Year(2060),
+        master_excel_path=Path("test.xlsx"),
+        output_dir=Path("/tmp/output"),
+    )
+
+    assert config.probabilistic_agents is True
+    assert config.calculate_npv_pct == 0.1
+    assert config.geo_config.priority_pct == 5

--- a/tests/unit/test_simulation_config.py
+++ b/tests/unit/test_simulation_config.py
@@ -109,11 +109,12 @@ def test_deterministic_agents_force_announcement_and_construction_probabilities_
     assert config.probability_of_announcement == 1.0
 
 
-def test_deterministic_agents_force_full_npv_sampling_with_narrowed_priority_pct():
+def test_deterministic_agents_force_full_npv_sampling_with_narrowed_priority_share():
     """
     Tests that probabilistic_agents=False forces full NPV sampling of candidate
-    locations (calculate_npv_pct=1.0) while narrowing geo_config.priority_pct to 0.5
-    to keep the cost of full sampling low, regardless of defaults or overrides.
+    locations (calculate_npv_sites_share=1.0) while narrowing
+    geo_config.pick_priority_sites_share to 0.005 to keep the cost of full sampling
+    low, regardless of defaults or overrides.
     """
     config = SimulationConfig(
         start_year=Year(2025),
@@ -121,11 +122,11 @@ def test_deterministic_agents_force_full_npv_sampling_with_narrowed_priority_pct
         master_excel_path=Path("test.xlsx"),
         output_dir=Path("/tmp/output"),
         probabilistic_agents=False,
-        calculate_npv_pct=0.3,
+        calculate_npv_sites_share=0.3,
     )
 
-    assert config.calculate_npv_pct == 1.0
-    assert config.geo_config.priority_pct == 0.5
+    assert config.calculate_npv_sites_share == 1.0
+    assert config.geo_config.pick_priority_sites_share == 0.005
 
 
 def test_probabilistic_agents_keep_default_announcement_and_construction_probabilities():
@@ -145,10 +146,10 @@ def test_probabilistic_agents_keep_default_announcement_and_construction_probabi
     assert config.probability_of_announcement == 0.7
 
 
-def test_probabilistic_agents_keep_default_npv_sampling_and_priority_pct():
+def test_probabilistic_agents_keep_default_npv_sampling_and_priority_share():
     """
     Tests that probabilistic_agents=True (the default) preserves the default
-    calculate_npv_pct and geo_config.priority_pct values.
+    calculate_npv_sites_share and geo_config.pick_priority_sites_share values.
     """
     config = SimulationConfig(
         start_year=Year(2025),
@@ -158,5 +159,5 @@ def test_probabilistic_agents_keep_default_npv_sampling_and_priority_pct():
     )
 
     assert config.probabilistic_agents is True
-    assert config.calculate_npv_pct == 0.1
-    assert config.geo_config.priority_pct == 5
+    assert config.calculate_npv_sites_share == 0.1
+    assert config.geo_config.pick_priority_sites_share == 0.05

--- a/tests/web/test_geo_config_fields.py
+++ b/tests/web/test_geo_config_fields.py
@@ -598,10 +598,10 @@ def test_max_slope_propagation(db, base_form_data):
     assert modelrun.config["max_slope"] == 5.5
 
 
-def test_priority_pct_propagation(db, base_form_data):
-    """Test that priority_pct is correctly passed to model config."""
+def test_pick_priority_sites_share_propagation(db, base_form_data):
+    """Test that pick_priority_sites_share is correctly passed to model config."""
     form_data = base_form_data.copy()
-    form_data["priority_pct"] = 15
+    form_data["pick_priority_sites_share"] = 0.15
 
     form = ModelRunCreateForm(data=form_data)
     assert form.is_valid(), f"Form errors: {form.errors}"
@@ -610,13 +610,13 @@ def test_priority_pct_propagation(db, base_form_data):
     modelrun.config = build_config_from_form(form)
     modelrun.save()
 
-    assert modelrun.config["priority_pct"] == 15
+    assert modelrun.config["pick_priority_sites_share"] == 0.15
 
 
-def test_priority_pct_default_propagation(db, base_form_data):
-    """Test that priority_pct defaults to 5 when not specified."""
+def test_pick_priority_sites_share_default_propagation(db, base_form_data):
+    """Test that pick_priority_sites_share defaults to 0.05 when not specified."""
     form_data = base_form_data.copy()
-    # Don't set priority_pct
+    # Don't set pick_priority_sites_share
 
     form = ModelRunCreateForm(data=form_data)
     assert form.is_valid(), f"Form errors: {form.errors}"
@@ -625,8 +625,8 @@ def test_priority_pct_default_propagation(db, base_form_data):
     modelrun.config = build_config_from_form(form)
     modelrun.save()
 
-    # Default value should be 5
-    assert modelrun.config.get("priority_pct", 5) == 5
+    # Default value should be 0.05
+    assert modelrun.config.get("pick_priority_sites_share", 0.05) == 0.05
 
 
 # === Default Value Propagation Tests ===


### PR DESCRIPTION
Gate calculate_npv_pct and geo_config.priority_pct on probabilistic_agents=False

New-plant siting samples only calculate_npv_pct (10%) of candidate locations for NPV evaluation: the one stochastic decision point in the annual cycle never gated by probabilistic_agents, unlike the announcement/construction probability draws. Full sampling alone measured ~7x slower and was previously judged not worth it, but a re-benchmark on 12 runs shows that narrowing geo_config.priority_pct (5% → 0.5%) at the same time brings full sampling down to ~1.03x baseline runtime while also reducing seed-to-seed variance noticeable in tech/location/emissions shares.