### PR TITLE
Impute start years for undated furnace units

### DIFF
--- a/src/steelo/adapters/dataprocessing/master_excel_reader.py
+++ b/src/steelo/adapters/dataprocessing/master_excel_reader.py
@@ -8,6 +8,7 @@ expected by the simulation system. Uses MasterExcelValidator for validation.
 import pandas as pd
 from pathlib import Path
 import logging
+import random
 from typing import Any, Optional, cast
 import tempfile
 from dataclasses import dataclass
@@ -20,7 +21,26 @@ from steelo.adapters.dataprocessing.master_excel_validator import (
     ValidationReport,
     check_furnace_units_geography,
 )
-from steelo.domain.constants import KT_TO_T, PLANT_LIFETIME
+from steelo.domain.constants import KT_TO_T, PLANT_LIFETIME, RANDOM_SEED_DEFAULT
+
+# Inclusive start-year ranges for 'Furnace units' rows with no start_year, by country.
+IMPUTED_START_YEAR_RANGE_CHN = (2000, 2013)
+IMPUTED_START_YEAR_RANGE_DEFAULT = (2005, 2025)
+
+
+def impute_start_year(iso3: str, rng: random.Random) -> int:
+    """Draw a start year for a furnace unit whose start_year is missing.
+
+    Args:
+        iso3: Country of the unit; China gets the older vintage band.
+        rng: Generator seeded with the global RANDOM_SEED_DEFAULT, so the draw is reproducible for a given sheet.
+
+    Returns:
+        A uniformly drawn integer year, inclusive of both range bounds.
+    """
+    lo, hi = IMPUTED_START_YEAR_RANGE_CHN if iso3 == "CHN" else IMPUTED_START_YEAR_RANGE_DEFAULT
+    return rng.randint(lo, hi)
+
 
 logger = logging.getLogger(__name__)
 
@@ -1035,6 +1055,11 @@ class MasterExcelReader:
             ValueError: If the 'Furnace units' sheet is not found in the Excel file, or
                 if its geography is invalid (an iso3 that is not a real ISO-3 code, or a
                 geo_unit_or_province that does not compose to a geo_hierarchy key).
+
+        Notes:
+            Rows with no start_year get one drawn uniformly from a country band
+            (see ``impute_start_year``) with a fixed seed, so the renovation cycles of
+            undated units are spread across vintages instead of all expiring at once.
         """
         from ...domain.models import Location, Technology, FurnaceGroup, PointInTime, TimeFrame, Year, Volumes
         from ..dataprocessing.excel_reader import read_dynamic_business_cases
@@ -1087,6 +1112,8 @@ class MasterExcelReader:
         raw_canonical_metadata: dict[str, FurnaceGroupMetadata] = {}
         furnace_groups_by_plant: dict[str, list] = {}
         plant_first_row: dict[str, Any] = {}
+        start_year_rng = random.Random(RANDOM_SEED_DEFAULT)
+        imputed_start_years = 0
 
         for row_idx, row in df.iterrows():
             if pd.isna(row.get("plant_id")):
@@ -1110,8 +1137,15 @@ class MasterExcelReader:
                 dynamic_business_case=tech_business_cases,
             )
 
+            status = str(row.get("status", "operating"))
             start_year_val = row.get("start_year")
-            start_year = Year(int(start_year_val)) if pd.notna(start_year_val) else Year(2020)
+            vintage_imputed = False
+            if pd.notna(start_year_val):
+                start_year = Year(int(start_year_val))
+            else:
+                start_year = Year(impute_start_year(str(row.get("iso3")), start_year_rng))
+                vintage_imputed = True
+                imputed_start_years += 1
             start_date = date(int(start_year), 1, 1)
 
             last_renovation_year_val = row.get("last_renovation_year")
@@ -1127,7 +1161,7 @@ class MasterExcelReader:
             furnace_group = FurnaceGroup(
                 furnace_group_id=furnace_group_id,
                 capacity=Volumes(KT_TO_T * float(capacity)),
-                status=str(row.get("status", "operating")),
+                status=status,
                 last_renovation_date=last_renovation_date,
                 technology=technology,
                 historical_production={},
@@ -1143,11 +1177,13 @@ class MasterExcelReader:
             if plant_id not in plant_first_row:
                 plant_first_row[plant_id] = row
 
-            commissioning_year = Year(int(start_year_val)) if pd.notna(start_year_val) else None
-            age_at_reference = None
-            if commissioning_year is None:
-                plant_age = simulation_start_year - int(start_year)
-                age_at_reference = plant_age if plant_age > 0 else 0
+            # The repository rebuilds each group's lifetime from this metadata, not from the stored lifetime.
+            if vintage_imputed:
+                commissioning_year: Year | None = None
+                age_at_reference = max(simulation_start_year - int(start_year), 0)
+            else:
+                commissioning_year = start_year
+                age_at_reference = None
 
             warnings = validate_commissioning_year(commissioning_year, furnace_group_id)
             warnings.extend(validate_age_at_reference(age_at_reference, simulation_start_year, furnace_group_id))
@@ -1158,7 +1194,7 @@ class MasterExcelReader:
                 last_renovation_year=(
                     Year(int(last_renovation_year_val)) if pd.notna(last_renovation_year_val) else None
                 ),
-                age_source="exact" if commissioning_year else "imputed",
+                age_source="imputed" if vintage_imputed else "exact",
                 source_sheet=str(row.get("source_sheet", sheet_name)),
                 source_row=excel_row,
                 validation_warnings=warnings,
@@ -1198,6 +1234,11 @@ class MasterExcelReader:
             f"Successfully created {len(plants)} plants from 'Furnace units' sheet "
             f"(from {len(raw_plants)} raw records) with metadata for {len(final_canonical_metadata)} furnace groups"
         )
+        if imputed_start_years:
+            logger.info(
+                f"Imputed a random start_year for {imputed_start_years} furnace units with none in the sheet "
+                f"(CHN {IMPUTED_START_YEAR_RANGE_CHN}, elsewhere {IMPUTED_START_YEAR_RANGE_DEFAULT})"
+            )
         aggregated_constraints_to_return: list[Any] = (
             aggregated_constraints if aggregated_constraints is not None else []
         )

--- a/src/steelo/adapters/dataprocessing/master_excel_reader.py
+++ b/src/steelo/adapters/dataprocessing/master_excel_reader.py
@@ -21,11 +21,19 @@ from steelo.adapters.dataprocessing.master_excel_validator import (
     ValidationReport,
     check_furnace_units_geography,
 )
-from steelo.domain.constants import KT_TO_T, PLANT_LIFETIME, RANDOM_SEED_DEFAULT
+from steelo.domain.constants import (
+    ANNOUNCEMENT_TIME,
+    CONSTRUCTION_TIME_DEFAULT,
+    KT_TO_T,
+    PLANT_LIFETIME,
+    RANDOM_SEED_DEFAULT,
+)
 
 # Inclusive start-year ranges for 'Furnace units' rows with no start_year, by country.
 IMPUTED_START_YEAR_RANGE_CHN = (2000, 2013)
 IMPUTED_START_YEAR_RANGE_DEFAULT = (2005, 2025)
+# Statuses of units not built yet; undated ones are dated forward from the reference year.
+PIPELINE_STATUSES = ("announced", "construction")
 
 
 def impute_start_year(iso3: str, rng: random.Random) -> int:
@@ -40,6 +48,25 @@ def impute_start_year(iso3: str, rng: random.Random) -> int:
     """
     lo, hi = IMPUTED_START_YEAR_RANGE_CHN if iso3 == "CHN" else IMPUTED_START_YEAR_RANGE_DEFAULT
     return rng.randint(lo, hi)
+
+
+def impute_pipeline_start_year(status: str, reference_year: int, rng: random.Random) -> int:
+    """Draw the year an announced or under-construction unit comes online.
+
+    Args:
+        status: One of PIPELINE_STATUSES (lower-case).
+        reference_year: Year the sheet describes (the simulation start year); the unit is dated forward from it.
+        rng: Seeded generator shared with ``impute_start_year``, so the draw is reproducible for a given sheet.
+
+    Returns:
+        construction: uniform in [reference_year, reference_year + CONSTRUCTION_TIME_DEFAULT] — the unit is
+        somewhere in its construction phase. announced: construction has not started yet, so its start is
+        drawn uniformly in [reference_year, reference_year + ANNOUNCEMENT_TIME] and the unit comes online a
+        fixed CONSTRUCTION_TIME_DEFAULT years after that.
+    """
+    if status == "construction":
+        return reference_year + rng.randint(0, CONSTRUCTION_TIME_DEFAULT)
+    return reference_year + rng.randint(0, ANNOUNCEMENT_TIME) + CONSTRUCTION_TIME_DEFAULT
 
 
 logger = logging.getLogger(__name__)
@@ -1060,6 +1087,10 @@ class MasterExcelReader:
             Rows with no start_year get one drawn uniformly from a country band
             (see ``impute_start_year``) with a fixed seed, so the renovation cycles of
             undated units are spread across vintages instead of all expiring at once.
+            Announced / under-construction rows with no start_year, or one before
+            simulation_start_year, are instead dated forward from simulation_start_year
+            (see ``impute_pipeline_start_year``): the simulation only switches such units on
+            in the year equal to their start year, so a past one would strand them forever.
         """
         from ...domain.models import Location, Technology, FurnaceGroup, PointInTime, TimeFrame, Year, Volumes
         from ..dataprocessing.excel_reader import read_dynamic_business_cases
@@ -1114,6 +1145,7 @@ class MasterExcelReader:
         plant_first_row: dict[str, Any] = {}
         start_year_rng = random.Random(RANDOM_SEED_DEFAULT)
         imputed_start_years = 0
+        imputed_pipeline_start_years = 0
 
         for row_idx, row in df.iterrows():
             if pd.isna(row.get("plant_id")):
@@ -1139,9 +1171,15 @@ class MasterExcelReader:
 
             status = str(row.get("status", "operating"))
             start_year_val = row.get("start_year")
+            in_pipeline = status.lower() in PIPELINE_STATUSES
+            pipeline_start_imputed = False
             vintage_imputed = False
-            if pd.notna(start_year_val):
+            if pd.notna(start_year_val) and not (in_pipeline and int(start_year_val) < simulation_start_year):
                 start_year = Year(int(start_year_val))
+            elif in_pipeline:
+                start_year = Year(impute_pipeline_start_year(status.lower(), simulation_start_year, start_year_rng))
+                pipeline_start_imputed = True
+                imputed_pipeline_start_years += 1
             else:
                 start_year = Year(impute_start_year(str(row.get("iso3")), start_year_rng))
                 vintage_imputed = True
@@ -1194,7 +1232,7 @@ class MasterExcelReader:
                 last_renovation_year=(
                     Year(int(last_renovation_year_val)) if pd.notna(last_renovation_year_val) else None
                 ),
-                age_source="imputed" if vintage_imputed else "exact",
+                age_source="imputed" if pipeline_start_imputed or vintage_imputed else "exact",
                 source_sheet=str(row.get("source_sheet", sheet_name)),
                 source_row=excel_row,
                 validation_warnings=warnings,
@@ -1238,6 +1276,13 @@ class MasterExcelReader:
             logger.info(
                 f"Imputed a random start_year for {imputed_start_years} furnace units with none in the sheet "
                 f"(CHN {IMPUTED_START_YEAR_RANGE_CHN}, elsewhere {IMPUTED_START_YEAR_RANGE_DEFAULT})"
+            )
+        if imputed_pipeline_start_years:
+            logger.info(
+                f"Dated {imputed_pipeline_start_years} announced/construction furnace units with no start_year or "
+                f"one before {simulation_start_year} forward from {simulation_start_year} "
+                f"(construction +0..{CONSTRUCTION_TIME_DEFAULT}, announced +{CONSTRUCTION_TIME_DEFAULT}.."
+                f"{ANNOUNCEMENT_TIME + CONSTRUCTION_TIME_DEFAULT} years)"
             )
         aggregated_constraints_to_return: list[Any] = (
             aggregated_constraints if aggregated_constraints is not None else []

--- a/src/steelo/data/cache_manager.py
+++ b/src/steelo/data/cache_manager.py
@@ -51,7 +51,7 @@ class CacheMetadata:
 class DataPreparationCache:
     """Manages cached data preparations based on content hashing."""
 
-    CACHE_VERSION = "1.6"  # Bump to invalidate all caches (year columns read through to 2060)
+    CACHE_VERSION = "1.7"  # Bump to invalidate all caches (imputed start years for undated furnace units)
 
     def __init__(self, cache_root: Optional[Path] = None):
         """Initialize cache manager.

--- a/src/steelo/domain/constants.py
+++ b/src/steelo/domain/constants.py
@@ -45,6 +45,7 @@ PLANT_LIFETIME = 20  # years; default lifetime of a plant (used for data prepara
 # called before the SimulationConfig is created. For the actual simulation, the lifetime in the
 # SimulationConfig is used. The data preparation lifetime is only used to determine the renovation
 # cycle position of existing plants.
+RANDOM_SEED_DEFAULT = 42  # single seed shared by PAM, geospatial, trade LP and data preparation
 MIN_CAPACITY_FOR_DISTANCE_CALCULATION = 1 * MT_TO_T  # t; minimum capacity for plants to be considered
 # in the distance to closest location calculation in the geospatial analysis. This is to speed up the
 # calculation - locations with a capacity below this threshold are ignored.

--- a/src/steelo/domain/constants.py
+++ b/src/steelo/domain/constants.py
@@ -46,6 +46,8 @@ PLANT_LIFETIME = 20  # years; default lifetime of a plant (used for data prepara
 # SimulationConfig is used. The data preparation lifetime is only used to determine the renovation
 # cycle position of existing plants.
 RANDOM_SEED_DEFAULT = 42  # single seed shared by PAM, geospatial, trade LP and data preparation
+CONSTRUCTION_TIME_DEFAULT = 4  # years from the start of construction to operation
+ANNOUNCEMENT_TIME = 1  # max years between a unit's announcement and the start of its construction
 MIN_CAPACITY_FOR_DISTANCE_CALCULATION = 1 * MT_TO_T  # t; minimum capacity for plants to be considered
 # in the distance to closest location calculation in the geospatial analysis. This is to speed up the
 # calculation - locations with a capacity below this threshold are ignored.

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -20,6 +20,7 @@ from steelo.simulation_types import TechSettingsMap, get_default_technology_sett
 from steelo.utilities.memory_profiling import MemoryTracker
 
 from .domain import Year, PlantGroup
+from .domain.constants import RANDOM_SEED_DEFAULT
 from .service_layer.message_bus import MessageBus
 from .economic_models import EconomicModel, PlantAgentsModel, AllocationModel, GeospatialModel
 from .domain.events import IterationOver
@@ -263,7 +264,7 @@ class GeoConfig:
     )
 
     # === Other ===
-    random_seed: int = 42  # Seed for random number generation to ensure reproducibility
+    random_seed: int = RANDOM_SEED_DEFAULT  # Seed for random number generation to ensure reproducibility
 
 
 @dataclass
@@ -447,7 +448,7 @@ class SimulationConfig:
     # === Randomness ===
     # Single seed shared by Plant Agent, Geospatial, and Trade LP modules.
     # Propagated to geo_config.random_seed in __post_init__.
-    random_seed: int = 42
+    random_seed: int = RANDOM_SEED_DEFAULT
 
     # === Other ===
     # Verbosity

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -20,7 +20,7 @@ from steelo.simulation_types import TechSettingsMap, get_default_technology_sett
 from steelo.utilities.memory_profiling import MemoryTracker
 
 from .domain import Year, PlantGroup
-from .domain.constants import RANDOM_SEED_DEFAULT
+from .domain.constants import CONSTRUCTION_TIME_DEFAULT, RANDOM_SEED_DEFAULT
 from .service_layer.message_bus import MessageBus
 from .economic_models import EconomicModel, PlantAgentsModel, AllocationModel, GeospatialModel
 from .domain.events import IterationOver
@@ -386,7 +386,9 @@ class SimulationConfig:
     consideration_time: int = (
         3  # Minimum number of years a considered business opportunity needs to be NPV-positive before being announced
     )
-    construction_time: int = 4  # Years it takes to construct a plant after it has been announced
+    construction_time: int = (
+        CONSTRUCTION_TIME_DEFAULT  # Years it takes to construct a plant after it has been announced
+    )
     # probability_of_construction, probability_of_announcement, calculate_npv_sites_share, and
     # geo_config.pick_priority_sites_share are all forced to deterministic values in
     # __post_init__ when probabilistic_agents is False.

--- a/tests/unit/test_master_excel_reader_furnace_units_sheet.py
+++ b/tests/unit/test_master_excel_reader_furnace_units_sheet.py
@@ -235,3 +235,140 @@ def test_missing_start_year_draw_is_reproducible(undated_furnace_units_excel_pat
     (plants_a, meta_a, _), (plants_b, meta_b, _) = reads
     for iso3 in ("CHN", "IND"):
         assert _drawn_start_years(plants_a, meta_a, iso3) == _drawn_start_years(plants_b, meta_b, iso3)
+
+
+@pytest.fixture
+def pipeline_furnace_units_excel_path(tmp_path):
+    """Sheet with undated and stale-dated announced / construction units next to dated and inactive ones."""
+    path = tmp_path / "pipeline_furnace_units.xlsx"
+    n = 30
+    status = ["construction"] * n + ["announced"] * n + ["announced", "construction", "cancelled", "retired"]
+    start_year = [None] * (2 * n) + [2028, 2023, None, None]
+    rows = len(status)
+    furnace_units = pd.DataFrame(
+        {
+            "plant_id": [f"P{i}" for i in range(rows)],
+            "plant_name": [f"Plant {i}" for i in range(rows)],
+            "iso3": ["IND"] * rows,
+            "region": ["x"] * rows,
+            "geo_unit_or_province": [None] * rows,
+            "latitude": [10.0] * rows,
+            "longitude": [10.0] * rows,
+            "technology": ["EAF"] * rows,
+            "capacity_ttpa": [1000.0] * rows,
+            "status": status,
+            "start_year": start_year,
+            "last_renovation_year": [None] * rows,
+            "soe_status": ["private"] * rows,
+            "power_source": ["grid"] * rows,
+            "parent_gem_id": [""] * rows,
+            "workforce_size": [100] * rows,
+            "source": ["gem_unit"] * rows,
+            "source_sheet": ["Electric arc furnaces"] * rows,
+            "source_row": list(range(2, rows + 2)),
+            "unit_id": [f"U{i}" for i in range(rows)],
+        }
+    )
+    with pd.ExcelWriter(path, engine="openpyxl") as writer:
+        furnace_units.to_excel(writer, sheet_name="Furnace units", index=False)
+    return path
+
+
+def _furnace_groups_by_status(plants):
+    by_status: dict[str, list] = {}
+    for plant in plants:
+        for fg in plant.furnace_groups:
+            by_status.setdefault(fg.status, []).append(fg)
+    return by_status
+
+
+def test_undated_pipeline_units_are_dated_forward_from_the_reference_year(pipeline_furnace_units_excel_path):
+    """Undated construction units start in 2025-2029 (mid-build), undated announced ones in 2029-2030 (a full
+    construction time after a drawn construction start), both spread; the lifetime and renovation date follow
+    the imputed start, so the simulation can switch them on."""
+    reader = MasterExcelReader(excel_path=pipeline_furnace_units_excel_path)
+    plants, metadata, _ = reader.read_plants_from_furnace_units_sheet(
+        dynamic_feedstocks_dict={}, aggregated_constraints=[], simulation_start_year=2025
+    )
+    by_status = _furnace_groups_by_status(plants)
+    undated = {
+        "construction": [fg for fg in by_status["construction"] if metadata[fg.furnace_group_id].source_row != 63],
+        "announced": [fg for fg in by_status["announced"] if metadata[fg.furnace_group_id].source_row != 62],
+    }
+    expected_range = {"construction": (2025, 2029), "announced": (2029, 2030)}
+    for status, fgs in undated.items():
+        lo, hi = expected_range[status]
+        starts = [fg.lifetime.time_frame.start for fg in fgs]
+        assert len(starts) == 30
+        assert all(lo <= y <= hi for y in starts), (status, sorted(starts))
+        assert len(set(starts)) > 1, f"{status} draws should spread across years"
+        for fg in fgs:
+            assert fg.last_renovation_date.year == fg.lifetime.time_frame.start
+            assert fg.lifetime.time_frame.end == fg.lifetime.time_frame.start + 20
+            meta = metadata[fg.furnace_group_id]
+            assert meta.age_source == "imputed"
+            assert meta.commissioning_year == fg.lifetime.time_frame.start, "metadata must anchor the imputed start"
+            assert meta.age_at_reference_year is None
+
+
+def test_dated_pipeline_units_keep_a_future_start_year_but_not_a_past_one(pipeline_furnace_units_excel_path):
+    """An announced unit dated 2028 keeps it; a construction unit dated 2023 (before the reference year) is
+    re-dated into the construction window instead of being stranded with a start year that never arrives."""
+    reader = MasterExcelReader(excel_path=pipeline_furnace_units_excel_path)
+    plants, metadata, _ = reader.read_plants_from_furnace_units_sheet(
+        dynamic_feedstocks_dict={}, aggregated_constraints=[], simulation_start_year=2025
+    )
+    by_row = {metadata[fg.furnace_group_id].source_row: fg for p in plants for fg in p.furnace_groups}
+    future_dated = by_row[62]
+    assert future_dated.status == "announced" and future_dated.lifetime.time_frame.start == 2028
+    assert metadata[future_dated.furnace_group_id].commissioning_year == 2028
+    assert metadata[future_dated.furnace_group_id].age_source == "exact"
+    stale_dated = by_row[63]
+    assert stale_dated.status == "construction" and 2025 <= stale_dated.lifetime.time_frame.start <= 2029
+    assert metadata[stale_dated.furnace_group_id].commissioning_year == stale_dated.lifetime.time_frame.start
+    assert metadata[stale_dated.furnace_group_id].age_source == "imputed"
+
+
+def test_undated_inactive_units_keep_the_vintage_draw(pipeline_furnace_units_excel_path):
+    """Cancelled / retired rows are not pipeline: they get the country vintage band, not a future start."""
+    reader = MasterExcelReader(excel_path=pipeline_furnace_units_excel_path)
+    plants, metadata, _ = reader.read_plants_from_furnace_units_sheet(
+        dynamic_feedstocks_dict={}, aggregated_constraints=[], simulation_start_year=2025
+    )
+    by_row = {metadata[fg.furnace_group_id].source_row: fg for p in plants for fg in p.furnace_groups}
+    for row in (64, 65):
+        fg = by_row[row]
+        assert fg.status in ("cancelled", "retired")
+        assert 2005 <= 2025 - metadata[fg.furnace_group_id].age_at_reference_year <= 2025
+
+
+def test_imputed_pipeline_start_survives_the_repository_round_trip(pipeline_furnace_units_excel_path, tmp_path):
+    """The simulation rebuilds every lifetime from plants_metadata.json, so the imputed start must come back
+    from a PlantJsonRepository load unchanged — otherwise the year loop would switch the units on at once."""
+    from steelo.adapters.dataprocessing.plant_metadata import create_metadata_dict, write_metadata_sidecar
+    from steelo.adapters.repositories.json_repository import PlantJsonRepository
+
+    reader = MasterExcelReader(excel_path=pipeline_furnace_units_excel_path)
+    plants, metadata, _ = reader.read_plants_from_furnace_units_sheet(
+        dynamic_feedstocks_dict={}, aggregated_constraints=[], simulation_start_year=2025
+    )
+    PlantJsonRepository(tmp_path / "plants.json", plant_lifetime=20).add_list(plants)
+    write_metadata_sidecar(
+        create_metadata_dict(
+            furnace_group_metadata=metadata,
+            plant_lifetime_used=20,
+            data_reference_year=2025,
+            master_excel_path=pipeline_furnace_units_excel_path,
+            master_excel_version="test",
+        ),
+        tmp_path,
+    )
+    prepared = {fg.furnace_group_id: fg for p in plants for fg in p.furnace_groups}
+    repo = PlantJsonRepository(tmp_path / "plants.json", plant_lifetime=20, current_simulation_year=2025)
+    loaded = {fg.furnace_group_id: fg for p in repo.list() for fg in p.furnace_groups}
+    assert loaded.keys() == prepared.keys()
+    pipeline = [fg for fg in loaded.values() if fg.status in ("announced", "construction")]
+    assert len(pipeline) == 62
+    for fg in pipeline:
+        assert fg.lifetime.time_frame.start == prepared[fg.furnace_group_id].lifetime.time_frame.start
+    assert sum(fg.lifetime.time_frame.start == 2025 for fg in pipeline) < len(pipeline) / 3

--- a/tests/unit/test_master_excel_reader_furnace_units_sheet.py
+++ b/tests/unit/test_master_excel_reader_furnace_units_sheet.py
@@ -158,3 +158,80 @@ class TestReadPlantsFromFurnaceUnitsSheetGeography:
         by_id = {p.plant_id: p for p in plants}
         assert by_id["P1"].location.geo_unit == "CN-HE"
         assert by_id["P1"].location.geo_key == "CHN:CN-HE"
+
+
+@pytest.fixture
+def undated_furnace_units_excel_path(tmp_path):
+    """Sheet with one dated unit and many undated CHN / non-CHN units."""
+    path = tmp_path / "undated_furnace_units.xlsx"
+    n = 40
+    iso3 = ["USA"] + ["CHN"] * n + ["IND"] * n
+    furnace_units = pd.DataFrame(
+        {
+            "plant_id": [f"P{i}" for i in range(len(iso3))],
+            "plant_name": [f"Plant {i}" for i in range(len(iso3))],
+            "iso3": iso3,
+            "region": ["x"] * len(iso3),
+            "geo_unit_or_province": [None] * len(iso3),
+            "latitude": [10.0] * len(iso3),
+            "longitude": [10.0] * len(iso3),
+            "technology": ["BOF"] * len(iso3),
+            "capacity_ttpa": [1000.0] * len(iso3),
+            "status": ["operating"] * len(iso3),
+            "start_year": [2005] + [None] * (2 * n),
+            "last_renovation_year": [None] * len(iso3),
+            "soe_status": ["private"] * len(iso3),
+            "power_source": ["grid"] * len(iso3),
+            "parent_gem_id": [""] * len(iso3),
+            "workforce_size": [100] * len(iso3),
+            "source": ["gem_unit"] * len(iso3),
+            "source_sheet": ["Basic oxygen furnaces"] * len(iso3),
+            "source_row": list(range(2, len(iso3) + 2)),
+            "unit_id": [f"U{i}" for i in range(len(iso3))],
+        }
+    )
+    with pd.ExcelWriter(path, engine="openpyxl") as writer:
+        furnace_units.to_excel(writer, sheet_name="Furnace units", index=False)
+    return path
+
+
+def _drawn_start_years(plants, metadata, iso3):
+    """Start years imputed for every furnace group in the given country, recovered from the metadata age."""
+    years = []
+    for plant in plants:
+        if plant.location.iso3 != iso3:
+            continue
+        for fg in plant.furnace_groups:
+            meta = metadata[fg.furnace_group_id]
+            assert meta.age_source == "imputed" and meta.commissioning_year is None
+            years.append(2025 - meta.age_at_reference_year)
+    return sorted(years)
+
+
+def test_missing_start_year_is_drawn_from_country_band(undated_furnace_units_excel_path):
+    """Undated CHN units draw from 2000-2013, others from 2005-2025; dated rows are kept."""
+    reader = MasterExcelReader(excel_path=undated_furnace_units_excel_path)
+    plants, metadata, _ = reader.read_plants_from_furnace_units_sheet(
+        dynamic_feedstocks_dict={}, aggregated_constraints=[]
+    )
+    chn = _drawn_start_years(plants, metadata, "CHN")
+    ind = _drawn_start_years(plants, metadata, "IND")
+    assert len(chn) == 40 and all(2000 <= y <= 2013 for y in chn)
+    assert len(ind) == 40 and all(2005 <= y <= 2025 for y in ind)
+    assert len(set(chn)) > 1 and len(set(ind)) > 1, "draws should spread across vintages"
+    (usa,) = [fg for p in plants if p.location.iso3 == "USA" for fg in p.furnace_groups]
+    assert metadata[usa.furnace_group_id].commissioning_year == 2005
+    assert metadata[usa.furnace_group_id].age_source == "exact"
+
+
+def test_missing_start_year_draw_is_reproducible(undated_furnace_units_excel_path):
+    """Two reads of the same sheet impute identical start years."""
+    reads = [
+        MasterExcelReader(excel_path=undated_furnace_units_excel_path).read_plants_from_furnace_units_sheet(
+            dynamic_feedstocks_dict={}, aggregated_constraints=[]
+        )
+        for _ in range(2)
+    ]
+    (plants_a, meta_a, _), (plants_b, meta_b, _) = reads
+    for iso3 in ("CHN", "IND"):
+        assert _drawn_start_years(plants_a, meta_a, iso3) == _drawn_start_years(plants_b, meta_b, iso3)


### PR DESCRIPTION
Many rows in the 'Furnace units' sheet have no start_year. All of them defaulted
to 2020: a large share of the fleet ended up on one renovation clock, and pipeline
units — which only switch on in the year equal to their start year — never came
online.

- Undated operating units draw a random start year from a per-country vintage band
  (CHN 2000–2013, elsewhere 2005–2025) with a fixed seed.
- Undated or stale-dated pipeline units are dated forward from the reference year:
  construction units within the construction window, announced units a full
  construction time after a drawn construction start. The imputed start is stored
  as commissioning_year so the repository rebuilds the same lifetime on load.

Prep CACHE_VERSION is bumped; results are not comparable with pre-fix runs.
