### PR TITLE
Delete dead TM_PAM_connector surface and clear audit leftovers

### DIFF
--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -7296,7 +7296,6 @@ class Environment:
         # Initialize default metallic charge mapping as empty dict
         self.default_metallic_charge_per_technology: dict[str, str] = {}
         self.transport_kpis: list[TransportKPI] = []  # Alias for transport_emissions for compatibility
-        self.allocation_and_transportation_costs: dict | None = None  # For storing allocation costs
         self.trade_allocations: Any = None  # For storing trade allocations from LP solution
         # Plot paths
         self.plot_paths: Optional[PlotPaths] = None

--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -106,7 +106,6 @@ class TM_PAM_connector:
 
         Attributes Created:
             flat_feedstocks_dict: Flattened dict for O(1) feedstock lookup by name.
-            feedstock_energy_requirements: Energy requirements per feedstock type.
             processing_energy_cost: Energy costs (total + carrier breakdown) by furnace group and
                 commodity, in USD per tonne of metallic INPUT (converted from the FG's per-tonne-of-
                 product energy_vopex dicts using each charge's required_quantity_per_ton_of_product).
@@ -156,17 +155,9 @@ class TM_PAM_connector:
                 self.processing_energy_cost[fg.furnace_group_id] = per_feed_energy
                 self.chosen_reductant[fg.furnace_group_id] = fg.chosen_reductant
         self.flat_feedstocks_dict = {}
-        self.feedstock_energy_requirements = {}
         for _key, items in self.dynamic_feedstocks.items():
             for entry in items:
-                name_lower = entry.name.lower()
-                self.flat_feedstocks_dict[name_lower] = entry
-                self.feedstock_energy_requirements[name_lower] = entry.energy_requirements
-
-        self.plants = [p.plant_id for p in plants.list()]
-        # self.furnaces = [fg for p in plants.list() for fg in p.furnace_groups]
-
-        self.plants_repo = plants
+                self.flat_feedstocks_dict[entry.name.lower()] = entry
 
         # Store transport costs in a dictionary for quick lookup
         self.transport_costs: dict[tuple[str, str, str], float] = {}
@@ -234,54 +225,6 @@ class TM_PAM_connector:
         ]:
             total += self.tariff_taxes.get(key, 0.0)
         return total
-
-    def process_energy_cost(
-        self,
-        furnace: str,
-        process: str,
-    ):
-        """Calculate processing energy cost for a furnace using a specific feedstock process.
-
-        Computes the total energy cost by multiplying each energy carrier requirement
-        (electricity, natural gas, hydrogen, etc.) by plant-specific or global energy prices.
-
-        Args:
-            furnace: Furnace group ID string (format: "plantid_furnacegroupid").
-            process: Process/feedstock name (e.g., "iron_ore", "scrap_steel") used to
-                lookup energy requirements from `self.flat_feedstocks_dict`.
-
-        Returns:
-            Total processing energy cost per ton of material processed (USD/ton).
-            Returns 0.0 if furnace plant not found or process not in feedstock dict.
-
-        Notes:
-            - Uses plant-specific energy costs if available (from plant.energy_costs).
-            - Falls back to global energy prices if plant-specific costs unavailable.
-            - Energy requirements are defined per feedstock type in PrimaryFeedstock objects.
-        """
-        global_cost_dict = dict(
-            natural_gas=1.05506 * 6, electricity=0.150, coke=0.05, pci=0, hydrogen=6.61, bio_pci=0.05, coal=98.6
-        )
-
-        process_energy_cost = 0.0
-        plant_id = furnace.split("_")[0]
-        if plant_id not in self.plants:
-            return 0
-        if process not in self.flat_feedstocks_dict:
-            return 0
-
-        p = self.plants_repo.get(plant_id)
-        plant_energy_cost = p.energy_costs
-        # p.get_energy_costs() # THis function doesn't exist but let's get it.
-        for key, value in self.feedstock_energy_requirements[process].items():
-            # if the plant has the attribute
-            if hasattr(plant_energy_cost, normalize_name(key)):
-                process_energy_cost += getattr(plant_energy_cost, normalize_name(key)) * value
-            else:
-                # logging.debug(f"Key {key} not found in global cost dict or plant")
-
-                process_energy_cost += float(global_cost_dict[normalize_name(key)]) * value
-        return process_energy_cost
 
     def calculate_allocations_for_graph(
         self,
@@ -654,69 +597,6 @@ class TM_PAM_connector:
 
         logger.info(f"Processed {edge_count} edges")
 
-    def validate_edge_attributes(
-        self,
-        source_attr="product_cost",
-        transport_attr="transport_cost",
-        process_attr="processing_energy_cost",
-        allocation_attr="allocations",
-        volume_attr="volume",
-        product_attr="output",
-        effeciency_attr="process_efficiency",
-        unit_cost_attr="unit_cost",
-    ):
-        """Validate presence of required attributes on graph edges before cost propagation.
-
-        Counts how many edges have each expected attribute (present, missing, or None)
-        to ensure the graph is properly constructed before running cost calculations.
-
-        Args:
-            source_attr: Node attribute for upstream product cost.
-            transport_attr: Edge attribute for transportation cost.
-            process_attr: Edge attribute for processing energy cost.
-            allocation_attr: Node attribute for allocations dict.
-            volume_attr: Edge attribute for shipment volume.
-            product_attr: Edge attribute for output commodity name.
-            effeciency_attr: Edge attribute for process efficiency.
-            unit_cost_attr: Node attribute for unit cost.
-
-        Returns:
-            None. Currently logs attribute presence counts internally (debug level).
-
-        Notes:
-            This is primarily for debugging/validation during development.
-            No exceptions raised - missing attributes may cause issues in propagation.
-        """
-        necessary_attributes = [
-            source_attr,
-            transport_attr,
-            process_attr,
-            allocation_attr,
-            volume_attr,
-            product_attr,
-            effeciency_attr,
-            unit_cost_attr,
-        ]
-        attribute_counts = {attr: {"present": 0, "missing": 0, "none": 0} for attr in necessary_attributes}
-
-        for _, _, comm, edge_data in self.G.edges(keys=True, data=True):
-            for attr in necessary_attributes:
-                if attr in edge_data:
-                    if edge_data[attr] is None:
-                        attribute_counts[attr]["none"] += 1
-                    else:
-                        attribute_counts[attr]["present"] += 1
-                else:
-                    attribute_counts[attr]["missing"] += 1
-
-        for attr, counts in attribute_counts.items():
-            # logging.debug(
-            #     f"Attribute '{attr}': {counts['present']} edges have it, "
-            #     f"{counts['missing']} edges don't have it, "
-            #     f"{counts['none']} edges have it as None."
-            # )
-            pass
-
     def set_up_network_and_propagate_costs(
         self,
         solved_trade_allocations: Allocations,
@@ -742,7 +622,7 @@ class TM_PAM_connector:
 
         Notes:
             Calls in sequence: create_graph() → calculate_allocations_for_graph() →
-            validate_edge_attributes() → propage_cost_forward_by_layers_and_normalize().
+            propage_cost_forward_by_layers_and_normalize().
         """
         logger = logging.getLogger(f"{__name__}.set_up_network_and_propagate_costs")
         logger.debug(f"[NETWORK] Setting up network with {len(solved_trade_allocations.allocations)} total allocations")
@@ -773,10 +653,7 @@ class TM_PAM_connector:
                 )
 
         # 1.1) Calculate the allocations for the graph
-        self.validate_edge_attributes()
         self.calculate_allocations_for_graph()
-        # 1.5) Validate the edge attributes before propagation
-        self.validate_edge_attributes()
         # 2) Propagate the costs forward
         self.propage_cost_forward_by_layers_and_normalize()
 
@@ -815,50 +692,6 @@ class TM_PAM_connector:
             else:
                 fg.set_allocated_volumes(0.0)
                 logger.debug(f"[ALLOCATION] FG {fg.furnace_group_id}: allocated_volumes = 0.0 (no outgoing edges)")
-
-    def extract_transportation_costs(
-        self,
-        furnace_groups: list[FurnaceGroup],
-        transport_costs_attr="transport_cost",
-        commodity_attr="commodity",
-        allocations_attr="allocations",
-    ) -> dict[str, list[dict[str, float]]]:
-        """Extract detailed transportation cost data for each furnace group's incoming shipments.
-
-        Collects all inbound edges to each furnace group and extracts their transport costs,
-        allocations, and commodity information for detailed cost accounting.
-
-        Args:
-            furnace_groups: List of FurnaceGroup objects to extract data for.
-            transport_costs_attr: Edge attribute name for transport cost (default: "transport_cost").
-            commodity_attr: Edge attribute name for commodity identifier (default: "commodity").
-            allocations_attr: Edge attribute name for allocation volume (default: "allocations").
-
-        Returns:
-            Dictionary mapping furnace_group_id to list of dicts, where each dict contains:
-                - "source": Source node name
-                - allocations_attr: Allocation volume value
-                - commodity_attr: Commodity name
-                - transport_costs_attr: Transport cost value
-
-        Notes:
-            Returns empty list for furnaces not found in graph.
-        """
-        _test_this: dict[str, list[dict[str, float]]] = {}
-        for fg in furnace_groups:
-            if self.G is not None and fg.furnace_group_id in self.G.nodes:
-                _test_this[fg.furnace_group_id] = []
-                ingoing_edges = list(self.G.in_edges(fg.furnace_group_id, data=True))
-                for source, recipient, edge_data in ingoing_edges:
-                    _test_this[recipient].append(
-                        {
-                            "source": source,
-                            allocations_attr: edge_data[allocations_attr],
-                            commodity_attr: edge_data[commodity_attr],
-                            transport_costs_attr: edge_data[transport_costs_attr],
-                        }
-                    )
-        return _test_this
 
     def update_furnace_group_utilisation(self, furnace_groups: list[FurnaceGroup], volume_attribute="volume"):
         """Calculate and set utilization rates for furnace groups based on allocated volumes.

--- a/src/steelo/domain/trade_modelling/TM_PAM_connector.py
+++ b/src/steelo/domain/trade_modelling/TM_PAM_connector.py
@@ -226,40 +226,6 @@ class TM_PAM_connector:
             total += self.tariff_taxes.get(key, 0.0)
         return total
 
-    def calculate_allocations_for_graph(
-        self,
-        allocation_attr="allocations",
-        volume_attr="volume",
-        effectiveness_attr="process_efficiency",
-        commodity_attr="commodity",
-    ):
-        """Compute input allocations from output volumes using process efficiencies.
-
-        For each edge in the graph, calculates the required input quantity by dividing
-        the shipped volume by the process efficiency (yield). This converts output volumes
-        to input requirements for cost accounting.
-
-        Args:
-            allocation_attr: Edge attribute name to store computed allocation values.
-            volume_attr: Edge attribute name containing shipped/output volumes.
-            effectiveness_attr: Edge attribute name for process efficiency/yield (output/input ratio).
-            commodity_attr: Edge attribute name for commodity identifier.
-
-        Side Effects:
-            Updates `self.G` edges with `allocation_attr` values = volume / efficiency.
-
-        Example:
-            If 100 tons steel shipped with 0.95 efficiency → allocation = 100/0.95 = 105.3 tons input.
-        """
-        for _from_node, _to_node, _commodity, data in self.G.edges(keys=True, data=True):
-            if volume_attr in data:
-                volume = data[volume_attr]
-                effectiveness = data.get(effectiveness_attr, 1)
-                if effectiveness is None:
-                    effectiveness = 1
-                # Calculate the allocation based on the volume and effectiveness
-                data[allocation_attr] = volume / effectiveness if effectiveness > 0 else 0
-
     def create_graph(self, solved_trade_allocations):
         """
         Build a directed multigraph of all process centers, with parallel edges, by key
@@ -384,14 +350,13 @@ class TM_PAM_connector:
             if to_pc.process.type == ProcessType.SUPPLY:
                 self.G.add_node(
                     to_name,
-                    process=process,
                     allocations={},
                     export={},
                     unit_cost={},
                     product_cost=to_pc.production_cost,
                 )
             else:
-                self.G.add_node(to_name, process=process, allocations={}, export={}, unit_cost={}, product_cost={})
+                self.G.add_node(to_name, allocations={}, export={}, unit_cost={}, product_cost={})
 
             # Finally, add the directed edge with all computed attributes
             self.G.add_edge(from_name, to_name, key=commodity, **edge_attrs)  # allow parallel edges keyed by commodity
@@ -473,6 +438,14 @@ class TM_PAM_connector:
             node_cost = G.nodes[u].get(source_attr, {})  # may be dict by commodity
             unit_cost = {}
 
+            # A production node with outgoing flows but no booked inputs prices its
+            # exports at own_unit_cost alone — a balanced LP should never produce one.
+            if G.in_degree(u) == 0 and G.out_degree(u) > 0 and "own_unit_cost" in G.nodes[u]:
+                logger.warning(
+                    "Production node %s ships with no booked inputs; outgoing flows carry only its own unit cost",
+                    u,
+                )
+
             if allocation_attr in G.nodes[u]:
                 # Initialize export dict if it doesn't exist
                 if export_attr not in G.nodes[u]:
@@ -508,16 +481,19 @@ class TM_PAM_connector:
                     # Multi-output process: use total export volume
                     export_volume_at_u = sum(export.values())
                 else:
-                    # Single-output process or supplier: use commodity-specific volume
+                    # Single-output process or supplier: use commodity-specific volume.
+                    # Suppliers never build an export dict and their production_cost is
+                    # already per-unit, so the 1.0 default is the per-unit pass-through,
+                    # not a fallback.
                     export_volume_at_u = export.get(comm, 1.0)
 
                 per_unit_base = base_cost / export_volume_at_u
                 # Embed producing furnaces' own carbon onto outgoing flows. Suppliers
-                # (root nodes) are skipped — their cost already enters via base_cost.
-                if G.in_degree(u) > 0:
-                    own = G.nodes[u].get("own_unit_cost")
-                    if own:
-                        per_unit_base += float(own)
+                # never carry own_unit_cost, so no gate on in-degree is needed — and a
+                # production node without booked inputs must still price its own carbon.
+                own = G.nodes[u].get("own_unit_cost")
+                if own:
+                    per_unit_base += float(own)
                 unit_cost.update({comm: per_unit_base})
                 if G.out_degree(v) == 0:
                     # print(f"Skipping sink node {v} with no outgoing edges")
@@ -621,8 +597,7 @@ class TM_PAM_connector:
             - Computes and stores unit costs at each node.
 
         Notes:
-            Calls in sequence: create_graph() → calculate_allocations_for_graph() →
-            propage_cost_forward_by_layers_and_normalize().
+            Calls in sequence: create_graph() → propage_cost_forward_by_layers_and_normalize().
         """
         logger = logging.getLogger(f"{__name__}.set_up_network_and_propagate_costs")
         logger.debug(f"[NETWORK] Setting up network with {len(solved_trade_allocations.allocations)} total allocations")
@@ -652,8 +627,6 @@ class TM_PAM_connector:
                     "Cost propagation requires a directed acyclic graph (DAG)."
                 )
 
-        # 1.1) Calculate the allocations for the graph
-        self.calculate_allocations_for_graph()
         # 2) Propagate the costs forward
         self.propage_cost_forward_by_layers_and_normalize()
 
@@ -1425,9 +1398,6 @@ class TM_PAM_connector:
                 for _, dest, edge_data in list(self.G.out_edges(fg_id, data=True)):
                     old_vol = edge_data.get("volume", 0.0)
                     edge_data["volume"] = old_vol * scale_production
-                    old_alloc = edge_data.get("allocations", 0.0)
-                    if old_alloc:
-                        edge_data["allocations"] = old_alloc * scale_production
 
             # Update BOM demands and costs
             for comm, info in materials.items():

--- a/src/steelo/service_layer/handlers.py
+++ b/src/steelo/service_layer/handlers.py
@@ -342,7 +342,6 @@ def update_furnace_utilization_rates(event: events.SteelAllocationsCalculated, u
                     f"[BOM-CHECK] Year {env.year}: corrected utilization for {corrected} supply-constrained FG(s)"
                 )
         tmpc.update_furnace_group_emissions(fgs)
-        env.allocation_and_transportation_costs = tmpc.extract_transportation_costs(fgs)
 
         # Store trade allocations for data collection
         env.trade_allocations = trade_allocations

--- a/tests/unit/test_tm_pam_connector_supplier_costs.py
+++ b/tests/unit/test_tm_pam_connector_supplier_costs.py
@@ -391,5 +391,37 @@ def test_scrap_supplier_with_country_based_id():
     assert node_data["product_cost"] == 450.0, "Scrap supplier should have production_cost set correctly"
 
 
+def test_production_root_still_prices_own_unit_cost():
+    """A production node with no booked inputs (LP anomaly) must still price its own
+    carbon on outgoing flows instead of shipping at zero."""
+    furnace_process = tlp.Process(name="EAF", type=tlp.ProcessType.PRODUCTION, bill_of_materials=[])
+    demand_process = tlp.Process(name="demand", type=tlp.ProcessType.DEMAND, bill_of_materials=[])
+
+    furnace_pc = tlp.ProcessCenter(
+        name="plant_root_eaf",
+        process=furnace_process,
+        capacity=1_000.0,
+        location=DummyLocation(iso3="USA"),
+        production_cost=25.0,
+    )
+    demand_pc = tlp.ProcessCenter(
+        name="usa_demand",
+        process=demand_process,
+        capacity=1_000.0,
+        location=DummyLocation(iso3="USA"),
+        production_cost=0.0,
+    )
+
+    allocations = tlp.Allocations(
+        allocations={(furnace_pc, demand_pc, tlp.Commodity(name="steel")): 100.0},
+    )
+
+    connector = TM_PAM_connector(dynamic_feedstocks_classes={}, plants=PlantInMemoryRepository(), transport_kpis=None)
+    connector.create_graph(allocations)
+    connector.propage_cost_forward_by_layers_and_normalize()
+
+    assert connector.G.nodes["plant_root_eaf"]["unit_cost"]["steel"] == pytest.approx(25.0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Removes code in the trade-graph connector that the TM/PAM audit found dead, and clears the small issues left behind:

- `process_energy_cost` (hardcoded energy prices, zero callers) plus the attributes that existed only for it; the `validate_edge_attributes` no-op; `extract_transportation_costs` and the never-read `env.allocation_and_transportation_costs`
- `calculate_allocations_for_graph`, whose edge-level value lost its last reader with the above
- carbon costing: the in-degree gate on `own_unit_cost` was redundant for suppliers and wrongly zeroed a no-input production node's outgoing cost — such nodes now warn instead
- drop the write-only node `process` attribute; document the supplier per-unit pass-through