### PR TITLE
Geo-keyed power grid emissivity with country fallback

### DIFF
--- a/src/steelo/adapters/dataprocessing/excel_reader.py
+++ b/src/steelo/adapters/dataprocessing/excel_reader.py
@@ -1343,15 +1343,21 @@ def read_carbon_costs(carbon_cost_excel_path: Path, sheet_name="Carbon cost") ->
 
 def read_regional_emissivities(excel_path: Path, grid_sheet_name: str, gas_sheet_name: str) -> list[RegionEmissivity]:
     """
-    Read grid_emissivity from from an Excel file and return a dictionary mapping ISO3 codes to Year and cost.
+    Read regional grid and gas/coke emissivities from the master Excel.
 
     Args:
         excel_path (Path): Path to the Excel file containing grid emissions data.
         grid_sheet_name (str): Name of the sheet containing grid emissions data.
         gas_sheet_name (str): Name of the sheet containing gas coke emissions data.
+
     Returns:
-        list[RegionEmissivity]: A list of RegionEmissivity objects containing emissions data
-        for each country and scenario.
+        list[RegionEmissivity]: One entry per geography and scenario.
+
+    Notes:
+        The grid sheet's ISO column holds either a country ("CHN") or a sub-national
+        geo_key ("CHN:CN-HE"). Sub-national groups take gas/coke factors from their
+        country, and years they do not author are filled from the country's
+        same-scenario values. Sheets without geo_keys are read unchanged.
     """
     grid_emission_df = pd.read_excel(excel_path, sheet_name=grid_sheet_name)
     gas_coke_emissions_df = pd.read_excel(excel_path, sheet_name=gas_sheet_name)
@@ -1413,16 +1419,41 @@ def read_regional_emissivities(excel_path: Path, grid_sheet_name: str, gas_sheet
 
     grouped_gas_coke = gas_coke_emissions_df.groupby([gas_iso_column, "Vector"])[carbon_intensity_columns].sum()
 
+    emissivity_by_group: dict[tuple[str, str], dict[Year, dict[str, float]]] = {
+        (str(key[0]), str(key[1])): dict(metrics)  # type: ignore[index]
+        for key, metrics in grouped_data.items()
+    }
+
+    # Fill years a sub-national group does not author from its country's same-scenario
+    # group, so a resolved sub-national entry never has a year hole the country could cover.
+    gap_fill_logger = logging.getLogger(f"{__name__}.read_regional_emissivities")
+    for (group_key, scenario_key), year_values in emissivity_by_group.items():
+        country_iso3, _, sub_code = group_key.partition(":")
+        if not sub_code:
+            continue
+        parent = emissivity_by_group.get((country_iso3, scenario_key)) or {}
+        filled = sorted(year for year in parent if year not in year_values)
+        if filled:
+            gap_fill_logger.warning(
+                "Grid emissivity: %s (%s) missing %d year(s); filled %s-%s from %s.",
+                group_key,
+                scenario_key,
+                len(filled),
+                filled[0],
+                filled[-1],
+                country_iso3,
+            )
+            for year in filled:
+                year_values[year] = parent[year]
+
     grid_emissivity_list: list[RegionEmissivity] = []
-    for key, metrics in grouped_data.items():
-        iso3_raw, scenario_raw = key  # type: ignore[misc]
-        iso3: str = str(iso3_raw)  # type: ignore[has-type]
-        scenario: str = str(scenario_raw)  # type: ignore[has-type]
-        # metrics is {'grid_carbon_intensity_value': {year: value}}
-        emissivity = metrics  # type: ignore[index]
+    for (group_key, scenario), emissivity in emissivity_by_group.items():
+        # The ISO column holds a country ("CHN") or a sub-national geo_key ("CHN:CN-HE");
+        # gas/coke factors are authored per country only.
+        iso3, _, geo_unit = group_key.partition(":")
 
         # look up the country name & net‐zero year
-        country_name: str = meta.at[(iso3_raw, scenario_raw), "country"]  # type: ignore[assignment]
+        country_name: str = meta.at[(group_key, scenario), "country"]  # type: ignore[assignment]
 
         # Cast the results of to_dict() to the expected type
         coke_dict = cast(dict[str, float], grouped_gas_coke.loc[iso3].loc["Coking coal"].to_dict())
@@ -1430,10 +1461,11 @@ def read_regional_emissivities(excel_path: Path, grid_sheet_name: str, gas_sheet
 
         grid_emissivity_list.append(
             RegionEmissivity(
-                iso3=iso3,  # type: ignore[has-type]
+                iso3=iso3,
+                geo_unit=geo_unit or None,
                 country_name=country_name,
-                scenario=scenario.removeprefix("projection_").replace("_", " ").title(),  # type: ignore[has-type]
-                grid_emissivity={key: value for key, value in emissivity.items()},
+                scenario=scenario.removeprefix("projection_").replace("_", " ").title(),
+                grid_emissivity=emissivity,
                 coke_emissivity=coke_dict,
                 gas_emissivity=gas_dict,
             )

--- a/src/steelo/adapters/dataprocessing/excel_reader.py
+++ b/src/steelo/adapters/dataprocessing/excel_reader.py
@@ -1400,6 +1400,11 @@ def read_regional_emissivities(excel_path: Path, grid_sheet_name: str, gas_sheet
     )
 
     # 2) Group gas coke emissions by vector name (only one year data) and no projections
+    # TODO FOR BACKLOG: coke/gas emissivity is scaffolding — it feeds env.fossil_emissivity,
+    # which nothing consumes. Known data bugs to fix before wiring it in: the sheet authors only
+    # ghg_factor_scope_1, so the .sum() below fabricates 0.0 for the all-NaN scope_2/scope_3_rest
+    # columns; the ghg_factor_scope3_methane_* columns miss the "ghg_factor_scope_" prefix and are
+    # silently dropped; units differ per vector (coal tCO2e/t vs gas tCO2e/GJ) and are not recorded.
     carbon_intensity_columns = [
         col for col in gas_coke_emissions_df.columns if col.lower().startswith("ghg_factor_scope_")
     ]

--- a/src/steelo/adapters/repositories/json_repository.py
+++ b/src/steelo/adapters/repositories/json_repository.py
@@ -1570,12 +1570,13 @@ class CarbonCostsJsonRepository:
 # ---- Pydantic "In-DB" Models ----
 class RegionEmissivityInDb(BaseModel):
     iso3: str
+    geo_unit: str | None = None
     country_name: str
     scenario: str
     grid_emissivity: dict[Year, dict[str, float]]
     coke_emissivity: dict[str, float]
     gas_emissivity: dict[str, float]
-    id: str = Field(..., description="iso3_scenario id")
+    id: str = Field(..., description="geo_key_scenario id")
 
     def __lt__(self, other: "RegionEmissivityInDb") -> bool:
         return self.id < other.id
@@ -1584,6 +1585,7 @@ class RegionEmissivityInDb(BaseModel):
     def to_domain(self) -> RegionEmissivity:
         return RegionEmissivity(
             iso3=self.iso3,
+            geo_unit=self.geo_unit,
             country_name=self.country_name,
             scenario=self.scenario,
             grid_emissivity=self.grid_emissivity,
@@ -1595,6 +1597,7 @@ class RegionEmissivityInDb(BaseModel):
     def from_domain(cls, domain: RegionEmissivity) -> "RegionEmissivityInDb":
         return cls(
             iso3=domain.iso3,
+            geo_unit=domain.geo_unit,
             country_name=domain.country_name,
             scenario=domain.scenario,
             grid_emissivity=domain.grid_emissivity,

--- a/src/steelo/data/cache_manager.py
+++ b/src/steelo/data/cache_manager.py
@@ -51,7 +51,7 @@ class CacheMetadata:
 class DataPreparationCache:
     """Manages cached data preparations based on content hashing."""
 
-    CACHE_VERSION = "1.7"  # Bump to invalidate all caches (imputed start years for undated furnace units)
+    CACHE_VERSION = "1.8"  # Bump to invalidate all caches (geo-keyed grid emissivity)
 
     def __init__(self, cache_root: Optional[Path] = None):
         """Initialize cache manager.

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -574,14 +574,21 @@ class RegionEmissivity:
         grid_emissivity: dict[Year, dict[str, float]],
         coke_emissivity: dict[str, float],
         gas_emissivity: dict[str, float],
+        geo_unit: str | None = None,
     ) -> None:
         self.iso3 = iso3
+        self.geo_unit = geo_unit  # ISO 3166-2 code, e.g. "CN-HE"; None ⇒ country-level
         self.country_name = country_name
         self.scenario = scenario
         self.grid_emissivity = grid_emissivity
         self.coke_emissivity = coke_emissivity
         self.gas_emissivity = gas_emissivity
-        self.id = f"{self.iso3}_{self.scenario.lower().replace(' ', '_')}"
+        self.id = f"{self.geo_key}_{self.scenario.lower().replace(' ', '_')}"
+
+    @property
+    def geo_key(self) -> str:
+        """Finest-available geographic key (mirrors ``Location.geo_key``)."""
+        return compose_geo_key(self.iso3, self.geo_unit)
 
     def __repr__(self) -> str:
         return f"RegionEmissivity: <{self.id}>"
@@ -7780,49 +7787,55 @@ class Environment:
             emissivities (list[RegionEmissivity]): A list of RegionEmissivity objects to be added to the environment.
 
         Side Effects:
-            Updates the `grid_emissivities` dictionary to map ISO3 codes to their respective emiss
+            Updates the `grid_emissivities` dictionary to map geo_keys (bare ISO3 or
+            sub-national ``iso3:code``) to their respective emissivities.
+
+        Raises:
+            ValueError: If emissivities are supplied but none match the chosen scenario
+                (a scenario-name typo would otherwise zero all grid emissions silently).
         """
         self.grid_emissivities = {
-            ge.iso3: ge.grid_emissivity
+            ge.geo_key: ge.grid_emissivity
             for ge in emissivities
             if ge.scenario == self.config.chosen_grid_emissions_scenario
         }
+        if emissivities and not self.grid_emissivities:
+            raise ValueError(
+                f"No grid emissivities match scenario {self.config.chosen_grid_emissions_scenario!r}; "
+                f"available: {sorted({ge.scenario for ge in emissivities})}"
+            )
 
     def propagate_grid_emissivity_to_furnace_groups(self, plants: list[Plant]) -> None:
         """
-        Propagate the grid emissivities to all plants and furnace groups based on their location ISO3 code.
+        Propagate the grid emissivities to all plants and furnace groups, resolving each
+        plant's location finest-available first (sub-national geo_key, then country ISO3).
 
         Args:
             plants (list[Plant]): List of Plant objects to update with grid emissivities.
 
         Side Effects:
             Updates the `grid_emissivity` attribute of each FurnaceGroup object for the current year.
+
+        Raises:
+            ValueError: If a plant's location resolves to no grid emissivity entry, or the
+                entry has no Electricity value for the current year.
         """
         logger = logging.getLogger(f"{__name__}.Environment.propagate_grid_emissivity_to_furnace_groups")
-        # If grid_emissivities hasn't been initialized, skip propagation
-        if not hasattr(self, "grid_emissivities") or self.grid_emissivities is None:
+        # If grid_emissivities hasn't been initialized or no data was supplied, skip propagation
+        if not getattr(self, "grid_emissivities", None):
             logger.warning("Grid emissivities not initialized, skipping propagation to furnace groups")
             return
 
         for plant in plants:
-            emissivity_dict = self.grid_emissivities.get(plant.location.iso3)
-            if emissivity_dict is not None:
-                # Extract the grid emissivity for the current year
-                year_data = emissivity_dict.get(self.year)
-                if year_data is not None and "Electricity" in year_data:
-                    emissivity_value = year_data["Electricity"]
-                    for furnace_group in plant.furnace_groups:
-                        furnace_group.grid_emissivity = emissivity_value
-                else:
-                    logger.warning(
-                        f"Grid emissivity not found for ISO3 code {plant.location.iso3} and year {self.year}, setting to 0"
-                    )
-                    for furnace_group in plant.furnace_groups:
-                        furnace_group.grid_emissivity = 0.0
-            else:
-                logger.warning(f"Grid emissivity not found for ISO3 code {plant.location.iso3}, setting to 0")
-                for furnace_group in plant.furnace_groups:
-                    furnace_group.grid_emissivity = 0.0
+            emissivity_dict = plant.location.resolve(self.grid_emissivities, what="grid emissivity")
+            if emissivity_dict is None:
+                raise ValueError(f"Grid emissivity not found for {plant.location.geo_key}")
+            year_data = emissivity_dict.get(self.year)
+            if year_data is None or "Electricity" not in year_data:
+                raise ValueError(f"Grid emissivity not found for {plant.location.geo_key} in year {self.year}")
+            emissivity_value = year_data["Electricity"]
+            for furnace_group in plant.furnace_groups:
+                furnace_group.grid_emissivity = emissivity_value
 
     def initiate_gas_coke_emissivity(self, emissivities: list[RegionEmissivity]) -> None:
         """
@@ -7832,10 +7845,11 @@ class Environment:
             emissivities (list[RegionEmissivity]): A list of RegionEmissivity objects to be added to the environment.
 
         Side Effects:
-            Updates the `fossil_emissivity` dictionary to map ISO3 codes to their respective emiss
+            Updates the `fossil_emissivity` dictionary to map geo_keys (bare ISO3 or
+            sub-national ``iso3:code``) to their respective emissivities.
         """
         self.fossil_emissivity = {
-            ge.iso3: {"Coke": ge.coke_emissivity, "Natural gas": ge.gas_emissivity}
+            ge.geo_key: {"Coke": ge.coke_emissivity, "Natural gas": ge.gas_emissivity}
             for ge in emissivities
             if ge.scenario == self.config.chosen_grid_emissions_scenario
         }

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -7848,6 +7848,8 @@ class Environment:
             Updates the `fossil_emissivity` dictionary to map geo_keys (bare ISO3 or
             sub-national ``iso3:code``) to their respective emissivities.
         """
+        # TODO FOR BACKLOG: fossil_emissivity is never consumed — scaffolding for a future
+        # coke/gas emissions feature; see the data bugs noted in read_regional_emissivities.
         self.fossil_emissivity = {
             ge.geo_key: {"Coke": ge.coke_emissivity, "Natural gas": ge.gas_emissivity}
             for ge in emissivities

--- a/tests/unit/test_grid_emissivity_propagation.py
+++ b/tests/unit/test_grid_emissivity_propagation.py
@@ -1,0 +1,105 @@
+"""Grid emissivity propagation resolves plant locations finest-available first."""
+
+from pathlib import Path
+
+import pytest
+
+from steelo.devdata import get_plant
+from steelo.domain.models import Environment, Location, RegionEmissivity, Year
+from steelo.simulation import SimulationConfig
+
+
+def make_env(tmp_path) -> Environment:
+    config = SimulationConfig(
+        start_year=Year(2025),
+        end_year=Year(2027),
+        master_excel_path=Path("test.xlsx"),
+        output_dir=tmp_path,
+    )
+    tech_switches_csv = tmp_path / "tech_switches_allowed.csv"
+    tech_switches_csv.write_text("origin,BF\nBF,YES\n", encoding="utf-8")
+    env = Environment(config=config, tech_switches_csv=tech_switches_csv)
+    env.year = Year(2025)
+    return env
+
+
+def region(iso3, geo_unit=None, years=None, scenario="Business As Usual"):
+    return RegionEmissivity(
+        iso3=iso3,
+        geo_unit=geo_unit,
+        country_name="China",
+        scenario=scenario,
+        grid_emissivity={Year(year): {"Electricity": value} for year, value in (years or {}).items()},
+        coke_emissivity={},
+        gas_emissivity={},
+    )
+
+
+def chn_plant(geo_unit=None):
+    location = Location(iso3="CHN", country="China", region="Asia", lat=30.0, lon=110.0, geo_unit=geo_unit)
+    return get_plant(location=location)
+
+
+def test_plant_with_geo_unit_gets_provincial_value(tmp_path):
+    """A plant in an authored province gets the provincial value, others the country value."""
+    env = make_env(tmp_path)
+    env.initiate_grid_emissivity(
+        emissivities=[region("CHN", years={2025: 0.5}), region("CHN", "CN-AH", years={2025: 0.3})]
+    )
+    provincial, national = chn_plant(geo_unit="CN-AH"), chn_plant()
+
+    env.propagate_grid_emissivity_to_furnace_groups(plants=[provincial, national])
+
+    assert all(fg.grid_emissivity == 0.3 for fg in provincial.furnace_groups)
+    assert all(fg.grid_emissivity == 0.5 for fg in national.furnace_groups)
+
+
+def test_plant_with_unauthored_geo_unit_falls_back_to_country(tmp_path):
+    """A plant in a province without its own entry falls back to the country value."""
+    env = make_env(tmp_path)
+    env.initiate_grid_emissivity(emissivities=[region("CHN", years={2025: 0.5})])
+    plant = chn_plant(geo_unit="CN-HE")
+
+    env.propagate_grid_emissivity_to_furnace_groups(plants=[plant])
+
+    assert all(fg.grid_emissivity == 0.5 for fg in plant.furnace_groups)
+
+
+def test_missing_country_raises(tmp_path):
+    """A plant whose location has no entry at all fails loudly, never a silent 0.0."""
+    env = make_env(tmp_path)
+    env.initiate_grid_emissivity(emissivities=[region("CHN", years={2025: 0.5})])
+    location = Location(iso3="IND", country="India", region="Asia", lat=20.0, lon=77.0)
+    plant = get_plant(location=location)
+
+    with pytest.raises(ValueError, match="Grid emissivity not found for IND"):
+        env.propagate_grid_emissivity_to_furnace_groups(plants=[plant])
+
+
+def test_missing_year_raises(tmp_path):
+    """An entry without the current year fails loudly, never a silent 0.0."""
+    env = make_env(tmp_path)
+    env.initiate_grid_emissivity(emissivities=[region("CHN", years={2025: 0.5})])
+    env.year = Year(2026)
+
+    with pytest.raises(ValueError, match="Grid emissivity not found for CHN in year 2026"):
+        env.propagate_grid_emissivity_to_furnace_groups(plants=[chn_plant()])
+
+
+def test_scenario_mismatch_raises_on_initiate(tmp_path):
+    """Supplied emissivities matching no chosen scenario fail loudly at initiation."""
+    env = make_env(tmp_path)
+
+    with pytest.raises(ValueError, match="No grid emissivities match scenario 'Business As Usual'"):
+        env.initiate_grid_emissivity(emissivities=[region("CHN", years={2025: 0.5}, scenario="Net Zero")])
+
+
+def test_empty_emissivities_skip_propagation(tmp_path):
+    """No emissivity data at all (test fixtures) skips propagation without raising."""
+    env = make_env(tmp_path)
+    env.initiate_grid_emissivity(emissivities=[])
+    plant = chn_plant()
+
+    env.propagate_grid_emissivity_to_furnace_groups(plants=[plant])
+
+    assert all(fg.grid_emissivity is None for fg in plant.furnace_groups)

--- a/tests/unit/test_grid_emissivity_propagation.py
+++ b/tests/unit/test_grid_emissivity_propagation.py
@@ -2,8 +2,10 @@
 
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
+from steelo.adapters.dataprocessing.excel_reader import read_regional_emissivities
 from steelo.devdata import get_plant
 from steelo.domain.models import Environment, Location, RegionEmissivity, Year
 from steelo.simulation import SimulationConfig
@@ -92,6 +94,47 @@ def test_scenario_mismatch_raises_on_initiate(tmp_path):
 
     with pytest.raises(ValueError, match="No grid emissivities match scenario 'Business As Usual'"):
         env.initiate_grid_emissivity(emissivities=[region("CHN", years={2025: 0.5}, scenario="Net Zero")])
+
+
+def test_provincial_values_flow_from_sheet_to_furnace_groups(tmp_path):
+    """Authored provincial sheet values reach furnace groups in that province end to end."""
+    grid_rows = [
+        {
+            "Vector": "Electricity",
+            "country": country,
+            "country_iso3": iso3,
+            "region": "Asia",
+            "year": 2025,
+            "projection_scenario": "projection_business_as_usual",
+            "ghg_factor_unit": "tCO2/kWh",
+            "ghg_factor_scope_2": value,
+        }
+        for iso3, country, value in [
+            ("CHN", "China", 0.5),
+            ("CHN:CN-AH", "Anhui", 0.3),
+            ("CHN:CN-HE", "Hebei", 0.4),
+        ]
+    ]
+    gas_rows = [
+        {"Vector": vector, "country": "China", "country_iso3": "CHN", "year": 2020, "ghg_factor_scope_1": 1.0}
+        for vector in ("Coking coal", "Natural gas")
+    ]
+    master = tmp_path / "master.xlsx"
+    with pd.ExcelWriter(master) as writer:
+        pd.DataFrame(grid_rows).to_excel(writer, sheet_name="Power grid emissivity", index=False)
+        pd.DataFrame(gas_rows).to_excel(writer, sheet_name="Met coal & gas emissions", index=False)
+
+    env = make_env(tmp_path)
+    env.initiate_grid_emissivity(
+        emissivities=read_regional_emissivities(master, "Power grid emissivity", "Met coal & gas emissions")
+    )
+    anhui, hebei, national = chn_plant(geo_unit="CN-AH"), chn_plant(geo_unit="CN-HE"), chn_plant()
+
+    env.propagate_grid_emissivity_to_furnace_groups(plants=[anhui, hebei, national])
+
+    assert all(fg.grid_emissivity == pytest.approx(0.3) for fg in anhui.furnace_groups)
+    assert all(fg.grid_emissivity == pytest.approx(0.4) for fg in hebei.furnace_groups)
+    assert all(fg.grid_emissivity == pytest.approx(0.5) for fg in national.furnace_groups)
 
 
 def test_empty_emissivities_skip_propagation(tmp_path):

--- a/tests/unit/test_regional_emissivity_geo_key.py
+++ b/tests/unit/test_regional_emissivity_geo_key.py
@@ -1,0 +1,148 @@
+"""Geo-keyed Power-grid-emissivity rows split into iso3 + geo_unit with country gap-fill."""
+
+import pandas as pd
+import pytest
+
+from steelo.adapters.dataprocessing.excel_reader import read_regional_emissivities
+
+GRID_SHEET = "Power grid emissivity"
+GAS_SHEET = "Met coal & gas emissions"
+
+
+def write_master(tmp_path, grid_rows, gas_rows):
+    """Write grid and gas/coke emissivity sheets and return the workbook path."""
+    path = tmp_path / "master.xlsx"
+    with pd.ExcelWriter(path) as writer:
+        pd.DataFrame(grid_rows).to_excel(writer, sheet_name=GRID_SHEET, index=False)
+        pd.DataFrame(gas_rows).to_excel(writer, sheet_name=GAS_SHEET, index=False)
+    return path
+
+
+def grid_row(iso3, year, value, scenario="projection_business_as_usual", country="China"):
+    return {
+        "Vector": "Electricity",
+        "country": country,
+        "country_iso3": iso3,
+        "region": "Asia",
+        "year": year,
+        "projection_scenario": scenario,
+        "ghg_factor_unit": "tCO2/kWh",
+        "ghg_factor_scope_2": value,
+    }
+
+
+def gas_row(iso3, vector, scope_1):
+    return {
+        "Vector": vector,
+        "country": "China",
+        "country_iso3": iso3,
+        "year": 2020,
+        "ghg_factor_unit": "tCO2/t",
+        "ghg_factor_scope_1": scope_1,
+    }
+
+
+def by_id(result):
+    return {entry.id: entry for entry in result}
+
+
+@pytest.fixture
+def master_with_province_rows(tmp_path):
+    """Country rows for 2025-2026 plus a province authoring 2026 only."""
+    return write_master(
+        tmp_path,
+        [
+            grid_row("CHN", 2025, 0.00055),
+            grid_row("CHN", 2026, 0.00050),
+            grid_row("CHN:CN-AH", 2026, 0.00030, country="Anhui"),
+        ],
+        [
+            gas_row("CHN", "Coking coal", 3.1),
+            gas_row("CHN", "Natural gas", 2.2),
+        ],
+    )
+
+
+def test_province_key_splits_into_iso3_and_geo_unit(master_with_province_rows):
+    """A combined ISO3:code key is split, keeps a distinct id, and composes its geo_key."""
+    entries = by_id(read_regional_emissivities(master_with_province_rows, GRID_SHEET, GAS_SHEET))
+
+    province = entries["CHN:CN-AH_business_as_usual"]
+    assert province.iso3 == "CHN"
+    assert province.geo_unit == "CN-AH"
+    assert province.geo_key == "CHN:CN-AH"
+
+    country = entries["CHN_business_as_usual"]
+    assert country.geo_unit is None
+    assert country.geo_key == "CHN"
+
+
+def test_province_inherits_gas_coke_from_country(master_with_province_rows):
+    """Gas/coke factors are authored per country, so the province takes the country's."""
+    entries = by_id(read_regional_emissivities(master_with_province_rows, GRID_SHEET, GAS_SHEET))
+
+    province = entries["CHN:CN-AH_business_as_usual"]
+    assert province.coke_emissivity == pytest.approx({"ghg_factor_scope_1": 3.1})
+    assert province.gas_emissivity == pytest.approx({"ghg_factor_scope_1": 2.2})
+
+
+def test_province_years_gap_filled_from_country(master_with_province_rows):
+    """Years the province does not author are filled from the country's same-scenario group."""
+    entries = by_id(read_regional_emissivities(master_with_province_rows, GRID_SHEET, GAS_SHEET))
+
+    province = entries["CHN:CN-AH_business_as_usual"]
+    assert province.grid_emissivity[2025]["Electricity"] == pytest.approx(0.00055)
+    assert province.grid_emissivity[2026]["Electricity"] == pytest.approx(0.00030)
+
+    country = entries["CHN_business_as_usual"]
+    assert country.grid_emissivity[2026]["Electricity"] == pytest.approx(0.00050)
+
+
+def test_gap_fill_logs_warning(master_with_province_rows, caplog):
+    """Filling provincial years from the country is surfaced as a warning during prep."""
+    with caplog.at_level("WARNING"):
+        read_regional_emissivities(master_with_province_rows, GRID_SHEET, GAS_SHEET)
+
+    assert "CHN:CN-AH (projection_business_as_usual) missing 1 year(s); filled 2025-2025 from CHN" in caplog.text
+
+
+def test_gap_fill_stays_within_scenario(tmp_path):
+    """A province group only takes years from the country's group for the same scenario."""
+    master = write_master(
+        tmp_path,
+        [
+            grid_row("CHN", 2024, 0.00060, scenario="historical"),
+            grid_row("CHN", 2025, 0.00055),
+            grid_row("CHN:CN-AH", 2026, 0.00030, country="Anhui"),
+        ],
+        [
+            gas_row("CHN", "Coking coal", 3.1),
+            gas_row("CHN", "Natural gas", 2.2),
+        ],
+    )
+    entries = by_id(read_regional_emissivities(master, GRID_SHEET, GAS_SHEET))
+
+    province = entries["CHN:CN-AH_business_as_usual"]
+    assert sorted(province.grid_emissivity) == [2025, 2026]
+
+
+def test_plain_iso3_sheet_reads_unchanged(tmp_path):
+    """A sheet without any geo_keys yields country-level entries only."""
+    master = write_master(
+        tmp_path,
+        [
+            grid_row("CHN", 2025, 0.00055),
+            grid_row("CHN", 2026, 0.00050),
+        ],
+        [
+            gas_row("CHN", "Coking coal", 3.1),
+            gas_row("CHN", "Natural gas", 2.2),
+        ],
+    )
+    entries = read_regional_emissivities(master, GRID_SHEET, GAS_SHEET)
+
+    assert len(entries) == 1
+    (country,) = entries
+    assert country.geo_unit is None
+    assert country.id == "CHN_business_as_usual"
+    assert sorted(country.grid_emissivity) == [2025, 2026]


### PR DESCRIPTION
Supports `ISO3:geo_unit` rows in the Power grid emissivity sheet (currently 32 Chinese provinces); sheets with plain ISO3 only are read unchanged.

- Reader splits combined keys, takes gas/coke factors from the base country, and fills unauthored provincial years from the country's same-scenario group (warned during prep)
- Propagation resolves plant locations finest-first (`Location.resolve`); missing data or a scenario matching no emissivities now raises instead of silently writing 0.0
- `CACHE_VERSION` 1.7 → 1.8
- Reader and propagation unit tests plus an end-to-end sheet→furnace-group test; `TODO FOR BACKLOG` comments record the dormant coke/gas chain's known data bugs