### PR TITLE
Derive hot-metal producers from the bill of materials instead of hard-coded technology lists

### DIFF
--- a/src/steelo/domain/constants.py
+++ b/src/steelo/domain/constants.py
@@ -92,8 +92,6 @@ DISTANTLY_ALLOCATED_PRODUCTS = [
     Commodities.ELECTROLYTIC_IRON.value,
 ]
 IRON_PRODUCTS = ["iron", "hot_metal", "pig_iron", "dri_low", "dri_mid", "dri_high", "hbi_low", "hbi_mid", "hbi_high"]
-# Note: CLOSElY_ALLOCATED_PRODUCTS with lowercase 'l' is an alias for CLOSELY_ALLOCATED_PRODUCTS
-CLOSElY_ALLOCATED_PRODUCTS = CLOSELY_ALLOCATED_PRODUCTS
 
 
 # Sub-country demand and scrap share per center for major steel consuming countries

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -1365,6 +1365,15 @@ class FurnaceGroup:
         return "ccs" in name or "ccu" in name
 
     @property
+    def produces_hot_metal(self) -> bool:
+        """Whether the technology's bill of materials outputs hot metal, the feedstock behind a BOF's minimum share."""
+        return any(
+            normalize_name(output) == Commodities.HOT_METAL.value
+            for feedstock in self.technology.dynamic_business_case or []
+            for output in feedstock.outputs
+        )
+
+    @property
     def effective_primary_feedstocks(self) -> list[PrimaryFeedstock]:
         """
         Returns the effective primary feedstock for the furnace group.
@@ -4958,12 +4967,9 @@ class PlantGroup:
         self.plants = plants
         self.balance = 0.0
         self.events: list[events.Event] = []
-        self.hot_metal_access: dict[str, list[str]] = defaultdict(
-            list
-        )  # BOF furnace group -> list of furnace groups that produce hot metal for it
 
     def update_hot_metal_access(self, hot_metal_radius: float) -> None:
-        """Update the hot metal access mapping for BOF furnace groups in the plant group.
+        """Flag BOF furnace groups (and their plants) that a hot-metal producer in the group can feed.
 
         Args:
             hot_metal_radius: Maximum distance (km) over which hot metal can be transported.
@@ -4973,32 +4979,14 @@ class PlantGroup:
             for fg in plant.furnace_groups:
                 if fg.technology.name.lower() == "bof":
                     fg.has_hot_metal_access = False  # Initialize access flag
-                    self.hot_metal_access[fg.furnace_group_id] = []  # Initialize list for this BOF furnace group
-                    # Identify furnace groups that produce hot metal for this BOF group
                     for other_plant in self.plants:
                         for other_fg in other_plant.furnace_groups:
-                            # check if other furnace group produces hot metal and is within hot metal radius of the BOF plant
                             if (
-                                other_fg.technology.name.lower()
-                                in [
-                                    "bf",
-                                    "dri+esf",
-                                    "sr",
-                                    "bf+ccu",
-                                    "dri+esf+ccu",
-                                    "sr+ccu",
-                                    "bf+ccs",
-                                    "dri+esf+ccs",
-                                    "sr+ccs",
-                                    "bf_charcoal",
-                                    "bf_charcoal+ccu",
-                                    "bf_charcoal+ccs",
-                                ]
+                                other_fg.produces_hot_metal
                                 and plant.distance_to(other_plant.location) <= hot_metal_radius
                             ):
                                 fg.has_hot_metal_access = True
                                 plant.has_hot_metal_access = True
-                                self.hot_metal_access[fg.furnace_group_id].append(other_fg.furnace_group_id)
 
     def deduct_equity(self, amount: float, reason: str) -> None:
         """

--- a/src/steelo/domain/trade_modelling/furnace_group_clustering.py
+++ b/src/steelo/domain/trade_modelling/furnace_group_clustering.py
@@ -247,7 +247,7 @@ def _compute_effective_bof_capacity(
     Args:
         fg: The furnace group.
         plant: Plant that contains the FG (used for location/distance calculations).
-        hot_metal_producers_by_iso3: Active BF/ESF/SR groups indexed by ISO3.
+        hot_metal_producers_by_iso3: Active hot-metal producers indexed by ISO3.
         aggregated_constraints: Aggregated metallic-charge constraints (may be None).
         config: Simulation configuration.
 
@@ -263,8 +263,8 @@ def _compute_effective_bof_capacity(
     if min_share is None or min_share <= 0:
         return physical_cap
 
-    # Sum BF/ESF/SR capacity within hot_metal_radius of this BOF FG (same ISO3 only,
-    # matching the per-country clustering constraint)
+    # Sum hot-metal producer capacity within hot_metal_radius of this BOF FG (same ISO3
+    # only, matching the per-country clustering constraint)
     iso3 = plant.location.iso3
     producers = hot_metal_producers_by_iso3.get(iso3, [])
     reachable_hm_cap = sum(
@@ -581,7 +581,7 @@ def cluster_furnace_groups(
     logger.info("[CLUSTERING] Starting furnace group clustering...")
 
     # Step 1: Collect all active furnace groups with their plants.
-    # Drop BOFs that have no active, in-country BF/ESF/SR within hot_metal_radius.
+    # Drop BOFs that have no active, in-country hot-metal producer within hot_metal_radius.
     #
     # The domain-model flag fg.has_hot_metal_access (set by PlantGroup.update_hot_metal_access)
     # is too permissive: PlantGroups can span countries, so a BOF near a border may get access
@@ -596,7 +596,7 @@ def cluster_furnace_groups(
     hot_metal_producers_by_iso3: dict[str, list[tuple[FurnaceGroup, Plant]]] = {}
     for plant in plants:
         for fg in plant.furnace_groups:
-            if fg.status.lower() in config.active_statuses and fg.technology.name.lower() in ("bf", "esf", "sr"):
+            if fg.status.lower() in config.active_statuses and fg.produces_hot_metal:
                 iso3 = plant.location.iso3
                 hot_metal_producers_by_iso3.setdefault(iso3, []).append((fg, plant))
 
@@ -616,7 +616,7 @@ def cluster_furnace_groups(
                         filtered_bofs_no_hot_metal += 1
                         logger.debug(
                             f"[CLUSTERING] Filtering BOF FG {fg.furnace_group_id} "
-                            f"(plant {plant.plant_id}, {iso3}): no active BF/ESF/SR "
+                            f"(plant {plant.plant_id}, {iso3}): no active hot-metal producer "
                             f"in same country within {config.hot_metal_radius:.0f} km"
                         )
                         continue

--- a/src/steelo/domain/trade_modelling/set_up_steel_trade_lp.py
+++ b/src/steelo/domain/trade_modelling/set_up_steel_trade_lp.py
@@ -755,7 +755,7 @@ def fix_to_zero_allocations_where_distance_doesnt_match_commodity(
     Args:
         trade_lp: The trade LP model with allocation variables to constrain
         config: Simulation configuration with:
-            - hot_metal_radius: Maximum distance for hot metal transport (km, typically ~100)
+            - hot_metal_radius: Maximum distance for hot metal transport (km)
             - closely_allocated_products: Products limited to short distances (e.g., ["hot_metal"])
             - distantly_allocated_products: Products requiring longer distances (e.g., ["pig_iron", "steel"])
             - enable_furnace_group_clustering: Whether clustering is enabled (optional)

--- a/tests/unit/test_furnace_group_clustering.py
+++ b/tests/unit/test_furnace_group_clustering.py
@@ -17,6 +17,7 @@ class MockConfig:
 
     active_statuses: list[str]
     closely_allocated_products: list[str] = None  # Add field with default
+    hot_metal_radius: float = 5.0
 
     def __post_init__(self):
         if self.closely_allocated_products is None:
@@ -63,8 +64,9 @@ def create_test_furnace_group(
     chosen_reductant: str = "coke",
     carbon_cost: float = 50.0,
     status: str = "operating",
+    outputs: dict[str, float] | None = None,
 ) -> FurnaceGroup:
-    """Helper to create a test furnace group."""
+    """Helper to create a test furnace group; ``outputs`` is attached to every feedstock of its business case."""
     from steelo.domain.models import PrimaryFeedstock
 
     # Create dynamic_business_case with appropriate feedstocks based on technology
@@ -85,6 +87,8 @@ def create_test_furnace_group(
         dynamic_business_case = [
             PrimaryFeedstock(metallic_charge="io_mid", reductant=chosen_reductant, technology=technology_name),
         ]
+    for feedstock in dynamic_business_case:
+        feedstock.outputs = dict(outputs or {})
 
     technology = Technology(
         name=technology_name,
@@ -113,6 +117,68 @@ def create_test_furnace_group(
     )
 
     return fg
+
+
+HOT_METAL_PRODUCERS = [
+    "BF",
+    "BF+CCS",
+    "BF+CCU",
+    "BF_CHARCOAL",
+    "BF_CHARCOAL+CCS",
+    "BF_CHARCOAL+CCU",
+    "DRI+ESF",
+    "DRI+ESF+CCS",
+    "DRI+ESF+CCU",
+    "SR",
+    "SR+CCS",
+    "SR+CCU",
+]
+
+
+def _clustered_fg_ids(mapping: dict[str, list[str]]) -> set[str]:
+    return {fg_id for fg_ids in mapping.values() for fg_id in fg_ids}
+
+
+@pytest.mark.parametrize("producer_tech", HOT_METAL_PRODUCERS)
+def test_bof_is_kept_when_any_hot_metal_producer_is_within_radius(producer_tech):
+    """A BOF stays in the LP when a co-located furnace of any hot-metal-producing technology is active."""
+    plant = create_test_plant("plant1", create_test_location(lat=35.0, lon=110.0, iso3="CHN"))
+    producer = create_test_furnace_group("producer", producer_tech, capacity=1000.0, outputs={"hot_metal": 1.0})
+    bof = create_test_furnace_group("bof", "BOF", capacity=1000.0, chosen_reductant="hot_metal")
+    plant.furnace_groups = [producer, bof]
+
+    _, mapping = cluster_furnace_groups([plant], MockConfig(active_statuses=["operating"]))
+
+    assert "bof" in _clustered_fg_ids(mapping)
+
+
+def test_bof_is_dropped_without_hot_metal_producer_within_radius():
+    """A BOF whose only neighbour outputs DRI/HBI (no hot metal) is filtered out of the LP."""
+    plant = create_test_plant("plant1", create_test_location(lat=35.0, lon=110.0, iso3="CHN"))
+    dri = create_test_furnace_group(
+        "dri", "DRI", capacity=1000.0, chosen_reductant="natural_gas", outputs={"dri_high": 1.0, "hbi_high": 1.0}
+    )
+    bof = create_test_furnace_group("bof", "BOF", capacity=1000.0, chosen_reductant="hot_metal")
+    plant.furnace_groups = [dri, bof]
+
+    _, mapping = cluster_furnace_groups([plant], MockConfig(active_statuses=["operating"]))
+
+    assert "bof" not in _clustered_fg_ids(mapping)
+
+
+def test_bof_effective_capacity_counts_every_hot_metal_producer():
+    """Reachable hot-metal supply sums all producing technologies, so a BF + BF+CCS site is not halved."""
+    plant = create_test_plant("plant1", create_test_location(lat=35.0, lon=110.0, iso3="CHN"))
+    bf = create_test_furnace_group("bf", "BF", capacity=700.0, outputs={"hot_metal": 1.0})
+    bf_ccs = create_test_furnace_group("bf_ccs", "BF+CCS", capacity=700.0, outputs={"hot_metal": 1.0})
+    bof = create_test_furnace_group("bof", "BOF", capacity=3000.0, chosen_reductant="hot_metal")
+    bof.technology.dynamic_business_case[0].minimum_share_in_product = 0.7
+    plant.furnace_groups = [bf, bf_ccs, bof]
+
+    meta_fgs, _ = cluster_furnace_groups([plant], MockConfig(active_statuses=["operating"]))
+
+    bof_meta = next(meta_fg for meta_fg in meta_fgs if meta_fg.technology_name == "BOF")
+    assert float(bof_meta.total_capacity) == pytest.approx(1400.0 / 0.7)
 
 
 class TestClusterKey:

--- a/tests/unit/test_hot_metal_access.py
+++ b/tests/unit/test_hot_metal_access.py
@@ -1,0 +1,104 @@
+"""PlantGroup.update_hot_metal_access flags BOFs fed by any hot-metal-producing technology within radius."""
+
+import pytest
+
+from steelo.domain.models import (
+    FurnaceGroup,
+    Location,
+    Plant,
+    PlantGroup,
+    PointInTime,
+    PrimaryFeedstock,
+    Technology,
+    TimeFrame,
+    Volumes,
+    Year,
+)
+
+HOT_METAL_PRODUCERS = [
+    "BF",
+    "BF+CCS",
+    "BF+CCU",
+    "BF_CHARCOAL",
+    "BF_CHARCOAL+CCS",
+    "BF_CHARCOAL+CCU",
+    "DRI+ESF",
+    "DRI+ESF+CCS",
+    "DRI+ESF+CCU",
+    "SR",
+    "SR+CCS",
+    "SR+CCU",
+]
+
+
+def make_furnace_group(fg_id: str, technology_name: str, outputs: dict[str, float]) -> FurnaceGroup:
+    """Build a minimal operating furnace group whose business case outputs ``outputs``."""
+    feedstock = PrimaryFeedstock(metallic_charge="io_high", reductant="coke", technology=technology_name)
+    feedstock.outputs = outputs
+    return FurnaceGroup(
+        furnace_group_id=fg_id,
+        technology=Technology(
+            name=technology_name,
+            product="iron",
+            bill_of_materials=None,
+            capex_type="greenfield",
+            dynamic_business_case=[feedstock],
+        ),
+        capacity=Volumes(1000.0),
+        lifetime=PointInTime(
+            plant_lifetime=20,
+            current=2025,
+            time_frame=TimeFrame(start=Year(2025), end=Year(2045)),
+        ),
+        status="operating",
+        chosen_reductant="coke",
+        last_renovation_date=None,
+        historical_production={},
+        utilization_rate=0.8,
+    )
+
+
+def make_plant(plant_id: str, lat: float, lon: float, furnace_groups: list[FurnaceGroup]) -> Plant:
+    """Build a minimal plant at (lat, lon) holding ``furnace_groups``."""
+    return Plant(
+        plant_id=plant_id,
+        location=Location(lat=lat, lon=lon, iso3="CHN", country="China", region="Asia", distance_to_other_iso3=None),
+        furnace_groups=furnace_groups,
+        technology_unit_fopex={},
+        power_source="grid",
+        soe_status="private",
+        parent_gem_id="E100000000000",
+        workforce_size=100,
+        certified=False,
+        category_steel_product=set(),
+    )
+
+
+def hot_metal_access_after_update(producer_tech: str, outputs: dict[str, float], distance_deg: float = 0.01):
+    """Return (fg flag, plant flag) for a BOF whose group holds one ``producer_tech`` plant ``distance_deg`` away."""
+    bof = make_furnace_group("bof", "BOF", outputs={"steel": 1.0})
+    bof_plant = make_plant("bof_plant", 35.0, 110.0, [bof])
+    producer_plant = make_plant(
+        "producer_plant", 35.0 + distance_deg, 110.0, [make_furnace_group("producer", producer_tech, outputs)]
+    )
+
+    PlantGroup(plant_group_id="group", plants=[bof_plant, producer_plant]).update_hot_metal_access(hot_metal_radius=5.0)
+
+    return bof.has_hot_metal_access, bof_plant.has_hot_metal_access
+
+
+@pytest.mark.parametrize("producer_tech", HOT_METAL_PRODUCERS)
+def test_bof_gets_access_from_any_hot_metal_producer_within_radius(producer_tech):
+    """Every technology whose bill of materials outputs hot metal grants access, not only a hard-coded name list."""
+    assert hot_metal_access_after_update(producer_tech, {"hot_metal": 1.0}) == (True, True)
+
+
+def test_bof_gets_no_access_from_producers_of_other_iron_products():
+    """DRI/HBI or liquid iron outputs do not satisfy a BOF's hot-metal minimum share."""
+    assert hot_metal_access_after_update("DRI", {"dri_high": 1.0, "hbi_high": 1.0}) == (False, False)
+    assert hot_metal_access_after_update("MOE", {"liquid_iron": 1.0, "electrolytic_iron": 1.0}) == (False, False)
+
+
+def test_bof_gets_no_access_from_a_hot_metal_producer_outside_the_radius():
+    """A blast furnace ~11 km away is beyond the 5 km hot-metal radius."""
+    assert hot_metal_access_after_update("BF", {"hot_metal": 1.0}, distance_deg=0.1) == (False, False)


### PR DESCRIPTION
## Problem

Two places decided which furnace groups can feed hot metal to a BOF, each with its own hard-coded list of technology names:

- The clustering step (`furnace_group_clustering.py`) recognised only `"bf"`, `"esf"` and `"sr"`. `"esf"` is not a technology name (the technology is `DRI+ESF`), and none of the CCS, CCU or charcoal variants matched. A BOF whose only in-radius feeder was a `BF+CCS`, `BF_CHARCOAL` or `DRI+ESF` furnace was therefore dropped from the allocation LP as "no hot metal access", and `_compute_effective_bof_capacity` ignored that feeder's capacity when capping the BOF. In the carbon-cost arm of the capacity-pool sweep, BOFs fed only by `BF_CHARCOAL` ran at 5 % utilisation over 270 plant-years versus 73 % with a plain BF — an integrated plant that decarbonises its blast furnace silently strands its own BOF.
- `PlantGroup.update_hot_metal_access` in the plant-agent model carried a separate 12-entry list that was correct, so the trade model and the plant-agent model disagreed about which BOFs had access.

## Change

The bill of materials already says what each technology produces, so there is no need to maintain technology name lists at all. This PR adds `FurnaceGroup.produces_hot_metal` — true when any feedstock of the technology's business case outputs `hot_metal` — and uses it in all three places (clustering filter, BOF effective-capacity cap, plant-agent access flag). Against the current prepared data that is exactly 12 of 19 technologies: BF, SR, DRI+ESF and their CCS/CCU/charcoal variants. Any technology added to the BOM sheet in future is picked up automatically.

Also removed: the unused `PlantGroup.hot_metal_access` mapping and the `CLOSElY_ALLOCATED_PRODUCTS` typo alias.

## Tests

- `test_furnace_group_clustering.py`: a BOF is kept for each of the 12 producing technologies, dropped when its only neighbour outputs DRI/HBI, and its effective capacity sums a BF + BF+CCS pair rather than halving it.
- New `test_hot_metal_access.py`: same 12-way check for `PlantGroup.update_hot_metal_access`, plus DRI/MOE outputs and an out-of-radius BF granting nothing.

## Impact on results

BOFs co-located with decarbonised or charcoal blast furnaces and DRI+ESF now stay in the LP and count that capacity. Runs from before this change are not comparable across it for BOF utilisation or hot-metal flows.
