### PR TITLE
Exclude BOF from greenfield consideration via a new GeoConfig technology list

### DIFF
--- a/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
+++ b/docs/domain_simulation_logic/geospatial_model/new_plant_opening.md
@@ -138,6 +138,7 @@ Filters technologies based on what will be allowed at the earliest possible cons
 **Purpose:** Prevents companies from considering plants using technologies that would be illegal to build by the time construction begins. For example, if BF-BOF will be banned in 2034, it won't be considered as an opportunity in 2030 even though it's currently legal.
 
 **Process:**
+- Drop technologies listed in `geo_config.excluded_greenfield_technologies` (default `["BOF"]`) before anything else; these are never built greenfield regardless of `technology_settings`
 - Calculate target year when the earliest possible construction would start 
 - Check which technologies are allowed in that future year
 - Filter opportunities to only include permitted technologies
@@ -311,6 +312,7 @@ Models real-world risk factors: financing may fall through, permits may be denie
 | `plant_lifetime` | int | 20 years | Expected operational lifetime of plant |
 | `expanded_capacity` | float | 2.5 Mt/year | Standard capacity for new plants (same than for plant expansion) |
 | `top_n_loctechs_as_business_op` | int | 5 | Number of opportunities to track per product per year |
+| `geo_config.excluded_greenfield_technologies` | list[str] | `["BOF"]` | Technologies removed from the greenfield candidate set before the allowed-technology filter of Step 1. A greenfield plant has a single furnace group, so a BOF built this way has no hot-metal supply of its own. Brownfield switching and renovation are unaffected (they use `technology_settings`) |
 
 ### Probability Parameters
 

--- a/docs/domain_simulation_logic/geospatial_model/priority_location_selection.md
+++ b/docs/domain_simulation_logic/geospatial_model/priority_location_selection.md
@@ -271,6 +271,7 @@ Key parameters affecting priority location selection:
 | `hydrogen_ceiling_percentile` | 20 | Regional hydrogen cost cap (percentile) |
 | `intraregional_trade_allowed` | True | Enable hydrogen imports between regions |
 | `long_dist_pipeline_transport_cost` | 1.0 | Pipeline transport cost (USD/kg H2) |
+| `excluded_greenfield_technologies` | `["BOF"]` | Technologies never considered for new greenfield plants (see [New Plant Opening](new_plant_opening.md)); brownfield switching is unaffected |
 
 #### `GeoDataPaths` Parameters
 

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -287,7 +287,11 @@ class GeospatialModel:
                 get_bom_from_avg_boms=bus.env.get_bom_from_avg_boms,
                 reductant_score_series=bus.env.reductant_score_series,
                 global_risk_free_rate=bus.env.config.global_risk_free_rate,
-                tech_to_product=bus.env.technology_to_product,
+                tech_to_product={
+                    tech: product
+                    for tech, product in bus.env.technology_to_product.items()
+                    if tech not in geo_config.excluded_greenfield_technologies
+                },
                 allowed_techs=bus.env.allowed_techs,
                 top_n_loctechs_as_business_op=bus.env.config.top_n_loctechs_as_business_op,
                 opportunity_pool_depth=bus.env.config.opportunity_pool_depth,

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -263,6 +263,10 @@ class GeoConfig:
         }
     )
 
+    # === Technology scope ===
+    # Technologies never considered for new greenfield plants; brownfield switching is unaffected
+    excluded_greenfield_technologies: list[str] = field(default_factory=lambda: ["BOF"])
+
     # === Other ===
     random_seed: int = RANDOM_SEED_DEFAULT  # Seed for random number generation to ensure reproducibility
 

--- a/tests/unit/test_identify_new_business_opportunities_4indi.py
+++ b/tests/unit/test_identify_new_business_opportunities_4indi.py
@@ -13,6 +13,7 @@ from steelo.domain.new_plant_opening import (
 )
 from steelo.domain.models import Subsidy, PlantGroup
 from steelo.devdata import Year
+from steelo.simulation import GeoConfig
 from steelo.domain.calculate_costs import ReductantScoreSeries
 
 
@@ -264,6 +265,27 @@ class TestGetListOfAllowedTechsForTargetYear:
                 tech_to_product=tech_to_product,
                 target_year=Year(2030),  # Not in allowed_techs
             )
+
+    def test_excluded_greenfield_technologies_never_reach_the_candidate_set(self):
+        """BOF is dropped from greenfield candidates by the GeoConfig default even when allowed in the target year."""
+        geo_config = GeoConfig()
+        assert geo_config.excluded_greenfield_technologies == ["BOF"]
+
+        allowed_techs = {Year(2030): ["EAF", "BOF", "DRI"]}
+        tech_to_product = {"EAF": "steel", "BOF": "steel", "DRI": "iron"}
+        greenfield_tech_to_product = {
+            tech: product
+            for tech, product in tech_to_product.items()
+            if tech not in geo_config.excluded_greenfield_technologies
+        }
+
+        product_to_tech = get_list_of_allowed_techs_for_target_year(
+            allowed_techs=allowed_techs,
+            tech_to_product=greenfield_tech_to_product,
+            target_year=Year(2030),
+        )
+
+        assert product_to_tech == {"steel": ["EAF"], "iron": ["DRI"]}
 
 
 class TestPrepareDataForBusinessOpportunity:


### PR DESCRIPTION
Adds `GeoConfig.excluded_greenfield_technologies` (default `["BOF"]`) and filters the greenfield technology candidates with it at the single call site in `GeospatialModel.run`. Brownfield switching and renovation are unaffected.

A greenfield plant has a single furnace group, so a greenfield BOF has no hot-metal supply of its own and only produces if another hot-metal producer happens to sit within `hot_metal_radius` — the cause of the zero-output greenfield BOFs seen in earlier runs.

Includes a unit test and docs rows in `new_plant_opening.md` and `priority_location_selection.md`.