### PR TITLE
Reconfigure CLI streams to UTF-8 so Windows redirection survives

### DIFF
--- a/src/boa/cli/__init__.py
+++ b/src/boa/cli/__init__.py
@@ -1,1 +1,23 @@
 """Console-script entry points: boa-run, boa-promote-lcoe, boa-cds-prepare, boa-cds-download."""
+
+import sys
+
+
+def reconfigure_streams_utf8() -> None:
+    """
+    Reconfigure stdout/stderr to UTF-8 so non-ASCII output survives a redirected console.
+
+    A redirected stdout on Windows gets the cp1252 codec, which cannot encode the em
+    dashes, arrows, and status glyphs these CLIs print. `print`/`rich` let the resulting
+    UnicodeEncodeError propagate and crash the process; the stdlib `logging` module
+    catches it instead and substitutes "--- Logging error ---" for the line. Neither
+    outcome is acceptable when the run is unattended and redirected to a log for its
+    whole duration: one loses the run, the other silently loses the message.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (ValueError, OSError):
+                pass  # already detached or not reconfigurable

--- a/src/boa/cli/promote_lcoe.py
+++ b/src/boa/cli/promote_lcoe.py
@@ -15,6 +15,7 @@ import argparse
 import logging
 import sys
 
+from boa.cli import reconfigure_streams_utf8
 from boa.config.paths import PathConfig
 from boa.model.lcoe_promotion import promote_all
 
@@ -31,6 +32,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging.")
     args = parser.parse_args(argv)
 
+    reconfigure_streams_utf8()
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",

--- a/src/boa/cli/run_cds.py
+++ b/src/boa/cli/run_cds.py
@@ -47,11 +47,24 @@ from boa.cds import download as cds_download
 from boa.cds import install as cds_install
 from boa.cds import max_capacity as cds_max_capacity
 from boa.cds.spec import CDS_VARS, TECHS
+from boa.cli import reconfigure_streams_utf8
 from boa.config.paths import DEFAULT_SET, PathConfig
 from boa.config.settings import CAPACITY_DENSITY_MW_PER_KM2, ERA5_DATA_YEAR, REGION_COORDS
 from boa.store_schema import max_cap_store_stem, profile_store_stem
 
-console = Console()
+
+def _utf8_console() -> Console:
+    """
+    A console that survives a non-UTF-8 stdout.
+
+    Fixing the underlying streams (rather than each writer) also covers rich's own
+    progress-bar glyphs (U+2501, U+257A), not just the status ticks this module prints.
+    """
+    reconfigure_streams_utf8()
+    return Console(legacy_windows=False)
+
+
+console = _utf8_console()
 
 
 def _parser(prog: str, description: str) -> argparse.ArgumentParser:

--- a/src/boa/cli/run_simulation.py
+++ b/src/boa/cli/run_simulation.py
@@ -41,6 +41,7 @@ from typing import List
 
 import xarray as xr
 
+from boa.cli import reconfigure_streams_utf8
 from boa.config.paths import DEFAULT_SET, PathConfig
 from boa.config.settings import REGION_COORDS
 from boa.model.global_extension import (
@@ -102,6 +103,7 @@ def parse_workers(value: str) -> int:
 
 
 # Configure logging
+reconfigure_streams_utf8()
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logging.getLogger("distributed").setLevel(logging.WARNING)
 

--- a/tests/boa/test_cli_encoding.py
+++ b/tests/boa/test_cli_encoding.py
@@ -1,0 +1,88 @@
+"""
+Non-ASCII output must survive a non-UTF-8 stdout/stderr.
+
+On Windows, a redirected stdout gets the cp1252 codec, which cannot encode the
+status glyphs, em dashes, and arrows these CLIs print. `boa.cli.reconfigure_streams_utf8`
+reconfigures the streams to UTF-8 (`errors="replace"`) so writers never see the failure,
+rather than patching each call site.
+"""
+
+import io
+import logging
+import sys
+
+import pytest
+
+from boa.cli import reconfigure_streams_utf8
+from boa.cli.run_cds import _utf8_console
+
+# The literals that motivated the fix: rich's own progress-bar glyphs plus the
+# status ticks/crosses and dashes/arrows used across the CLI modules.
+NON_ASCII_SAMPLE = "✓ ✗ — → ━ ╺"
+
+
+def _cp1252_stream() -> io.TextIOWrapper:
+    return io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="strict")
+
+
+def test_cp1252_stream_rejects_the_sample_without_the_fix():
+    # Establishes the failure this module exists to prevent.
+    with pytest.raises(UnicodeEncodeError):
+        _cp1252_stream().write(NON_ASCII_SAMPLE)
+
+
+def test_reconfigure_streams_utf8_survives_non_ascii_writes(monkeypatch):
+    stdout = _cp1252_stream()
+    stderr = _cp1252_stream()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    reconfigure_streams_utf8()
+
+    stdout.write(NON_ASCII_SAMPLE)
+    stderr.write(NON_ASCII_SAMPLE)
+
+
+def test_reconfigure_streams_utf8_ignores_streams_without_reconfigure(monkeypatch):
+    class NoReconfigure:
+        pass
+
+    monkeypatch.setattr(sys, "stdout", NoReconfigure())
+    monkeypatch.setattr(sys, "stderr", NoReconfigure())
+
+    reconfigure_streams_utf8()  # must not raise
+
+
+def test_utf8_console_prints_status_and_progress_glyphs_on_cp1252_stdout(monkeypatch):
+    monkeypatch.setattr(sys, "stdout", _cp1252_stream())
+
+    console = _utf8_console()
+    console.print(f"[green]✓ done[/green] {NON_ASCII_SAMPLE}")
+    console.print("━━╺")  # rich's own bar-fill and bar-tip glyphs
+
+
+def test_logging_through_cp1252_stream_writes_the_message_once_reconfigured(monkeypatch):
+    # logging swallows an encoding failure into a "--- Logging error ---" traceback on
+    # stderr rather than crashing (see run_simulation.py / promote_lcoe.py, which only
+    # configure logging handlers, no Console) -- the message itself is lost either way.
+    # A non-raise alone wouldn't distinguish "wrote the message" from "silently dropped
+    # it", so this checks the underlying bytes too.
+    buf = io.BytesIO()
+    stream = io.TextIOWrapper(buf, encoding="cp1252", errors="strict")
+    fake_stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stream)
+    monkeypatch.setattr(sys, "stderr", fake_stderr)
+    reconfigure_streams_utf8()
+
+    logger = logging.getLogger("test_cli_encoding")
+    handler = logging.StreamHandler(stream)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    try:
+        logger.info(f"build design caches first {NON_ASCII_SAMPLE}")
+    finally:
+        logger.removeHandler(handler)
+
+    assert "Logging error" not in fake_stderr.getvalue()
+    stream.flush()
+    assert NON_ASCII_SAMPLE.encode("utf-8") in buf.getvalue()


### PR DESCRIPTION
boa-cds-prepare ran for ~40 minutes, wrote all 9 renewable-profile stores correctly, then died with UnicodeEncodeError while printing a status tick: a redirected stdout on Windows gets the cp1252 codec, which cannot encode rich's glyphs. logging degrades this into a swallowed "--- Logging error ---" instead of crashing, but the effect is the same loss of information during an unattended, log-redirected run. Fixing the streams once, rather than each writer, also covers rich's own progress-bar glyphs.

boa-run and boa-promote-lcoe only configure logging handlers (no rich Console), so they were extended too via a shared reconfigure_streams_utf8() in boa.cli rather than repeating the fix per entrypoint.