### PR TITLE
Add run-surface flags, geo_key in the post-processed CSV, and a trade-map fix

### DIFF
--- a/docs/user_guide/running_simulations_locally.md
+++ b/docs/user_guide/running_simulations_locally.md
@@ -15,6 +15,7 @@ Common options:
 - `--start-year` / `--end-year`: define the scenario horizon.
 - `--config-file`: load a saved configuration.
 - `--log-level`: control verbosity (`INFO`, `DEBUG`, etc.).
+- `--demand-scenario` / `--scrap-scenario`: pick the `Scenario` rows of the master Excel "Demand and scrap availability" sheet used for steel demand and for scrap availability (both default to `BAU`; `--scrap-scenario` falls back to the demand scenario). Applied when the data is prepared, so each scenario pair gets its own preparation cache entry.
 
 The CLI writes metrics, logs, and artefacts to the chosen output directory. Review the [Configuration](configuration.md) guide for a comprehensive list of parameters and environment variables.
 
@@ -193,7 +194,7 @@ The CLI implements a content-based caching system that significantly speeds up r
 
 ### How It Works
 
-1. **Content Hashing**: The master Excel file is hashed using SHA256 to create a unique cache key
+1. **Content Hashing**: The master Excel file is hashed using SHA256, together with the selected demand/scrap scenarios, to create a unique cache key
 2. **Cache Storage**: Prepared data is stored in `$STEELO_HOME/preparation_cache/prep_<hash>/`
 3. **Fast Lookups**: An index file tracks all cached preparations for instant lookups
 4. **Automatic Reuse**: When running with the same master Excel, cached data is reused instantly

--- a/src/steelo/adapters/dataprocessing/excel_reader.py
+++ b/src/steelo/adapters/dataprocessing/excel_reader.py
@@ -53,7 +53,6 @@ from steelo.domain.constants import (
 # TODO: Remove overwriting and replace by simulation config
 EXCEL_READER_START_YEAR = 2020
 EXCEL_READER_END_YEAR = 2060
-CHOSEN_DEMAND_SCENARIO = "BAU"
 
 EXCEL_BIOMASS_CO2_START_YEAR = 2024
 EXCEL_BIOMASS_CO2_END_YEAR = EXCEL_READER_END_YEAR
@@ -937,17 +936,56 @@ def refine_demand_centers_for_major_countries(old_centers):
     return corrected_old_centers + new_centers
 
 
+def _select_scenario_rows(df: pd.DataFrame, scenario: str, sheet_name: str) -> pd.DataFrame:
+    """
+    Return the rows of a demand/scrap sheet that belong to one scenario.
+
+    Args:
+        df: Sheet contents with a "Scenario" column.
+        scenario: Scenario name to keep.
+        sheet_name: Sheet name, used in the error message only.
+
+    Returns:
+        pd.DataFrame: The matching rows.
+
+    Raises:
+        ValueError: If no row carries the scenario, listing the names the sheet does have.
+    """
+    selected = df[df["Scenario"] == scenario]
+    if selected.empty:
+        available = sorted(df["Scenario"].dropna().unique())
+        raise ValueError(f"No rows for scenario {scenario!r} in sheet {sheet_name!r}; available: {available}")
+    return selected
+
+
 def read_demand_centers(
     *,
     gravity_distances_path: Path,
     demand_excel_path: Path,
     demand_sheet_name: str,
     location_csv: Path,
+    demand_scenario: str,
 ) -> list[DemandCenter]:
+    """
+    Read steel demand centres for one scenario from the demand sheet.
+
+    Args:
+        gravity_distances_path: Pickled {iso3: {iso3: distance}} dict.
+        demand_excel_path: Workbook holding the demand sheet.
+        demand_sheet_name: Sheet with "Scenario" / "Metric" columns and one column per year.
+        location_csv: Country centroid CSV used to place each centre.
+        demand_scenario: Value of the "Scenario" column to read.
+
+    Returns:
+        list[DemandCenter]: One centre per country, major countries split into sub-centres.
+
+    Raises:
+        ValueError: If the scenario is not present in the sheet.
+    """
     with gravity_distances_path.open("rb") as f:
         gravity_dict = pickle.load(f)
     demand_df = pd.read_excel(demand_excel_path, sheet_name=demand_sheet_name)
-    demand_df = demand_df[demand_df["Scenario"] == CHOSEN_DEMAND_SCENARIO]
+    demand_df = _select_scenario_rows(demand_df, demand_scenario, demand_sheet_name)
     # Strip whitespace from metric names to handle Excel inconsistencies
     demand_df["Metric"] = demand_df["Metric"].str.strip()
     demand_df = demand_df[demand_df["Metric"] == "Crude steel consumption for forming [kt]"]
@@ -1080,9 +1118,24 @@ def read_scrap_as_suppliers(
     scrap_sheet_name: str,
     location_csv: str,
     gravity_distances_pkl_path: Path | None = None,
+    *,
+    scrap_scenario: str,
 ) -> list[Supplier]:
     """
     Read scrap supply data from Excel and return a list of Supplier domain objects for scrap.
+
+    Args:
+        scrap_excel_path: Workbook holding the scrap sheet.
+        scrap_sheet_name: Sheet with "Scenario" / "Metric" columns and one column per year.
+        location_csv: Country centroid CSV used to place each supplier.
+        gravity_distances_pkl_path: Pickled {iso3: {iso3: distance}} dict (required).
+        scrap_scenario: Value of the "Scenario" column to read.
+
+    Returns:
+        list[Supplier]: One scrap supplier per country, major countries split into sub-centres.
+
+    Raises:
+        ValueError: If the scenario is not present in the sheet, or the gravity path is missing.
     """
     if not gravity_distances_pkl_path:
         raise ValueError("gravity_distances_pkl_path must be provided")
@@ -1090,7 +1143,7 @@ def read_scrap_as_suppliers(
     with gravity_path.open("rb") as f:
         gravity_dict = pickle.load(f)
     scrap_df = pd.read_excel(scrap_excel_path, sheet_name=scrap_sheet_name)
-    scrap_df = scrap_df[scrap_df["Scenario"] == CHOSEN_DEMAND_SCENARIO]
+    scrap_df = _select_scenario_rows(scrap_df, scrap_scenario, scrap_sheet_name)
     # Strip whitespace from metric names to handle Excel inconsistencies
     scrap_df["Metric"] = scrap_df["Metric"].str.strip()
     scrap_df = scrap_df[scrap_df["Metric"] == "Total available scrap"]

--- a/src/steelo/adapters/dataprocessing/postprocessing/post_process_datacollection.py
+++ b/src/steelo/adapters/dataprocessing/postprocessing/post_process_datacollection.py
@@ -209,8 +209,11 @@ def extract_and_process_stored_dataCollection(
                 for col in carbon_breakdown_columns:
                     full_furnace_df[col] = None
         full_furnace_df["plant_id"] = full_furnace_df["furnace_group_id"].apply(lambda x: x.split("_")[0])
+        plant_cols = ["location", "plant_profit_and_loss", "plant_group_id", "plant_group_balance"]
+        if "geo_key" in df.columns:
+            plant_cols.append("geo_key")
         full_furnace_df = (
-            df[["location", "plant_profit_and_loss", "plant_group_id", "plant_group_balance"]]
+            df[plant_cols]
             .reset_index()
             .rename(columns={"index": "plant_id"})
             .merge(full_furnace_df, on="plant_id", how="right")
@@ -323,6 +326,7 @@ def extract_and_process_stored_dataCollection(
         "region",
         "country",
         "iso3",
+        "geo_key",
         "plant_group_id",
         "plant_group_balance",
         "plant_id",

--- a/src/steelo/data/cache_manager.py
+++ b/src/steelo/data/cache_manager.py
@@ -12,12 +12,16 @@ if TYPE_CHECKING:
     from .preparation import PreparationResult
 
 
-def get_preparation_hash(master_excel_path: Path, version: str = "1.0") -> str:
-    """Generate cache key from file content and version.
+def get_preparation_hash(
+    master_excel_path: Path, version: str = "1.0", *, demand_scenario: str = "BAU", scrap_scenario: str = "BAU"
+) -> str:
+    """Generate cache key from file content, version and the demand/scrap scenarios read from it.
 
     Args:
         master_excel_path: Path to master Excel file
         version: Cache version (bump to invalidate old caches)
+        demand_scenario: "Scenario" column value the demand centres were read for
+        scrap_scenario: "Scenario" column value the scrap suppliers were read for
 
     Returns:
         16-character hex string for use in directory names
@@ -29,8 +33,9 @@ def get_preparation_hash(master_excel_path: Path, version: str = "1.0") -> str:
         while chunk := f.read(65536):  # 64KB chunks
             sha256_hash.update(chunk)
 
-    # Include version for cache invalidation
+    # Include version for cache invalidation and the scenario selection baked into the fixtures
     sha256_hash.update(version.encode())
+    sha256_hash.update(f"|demand={demand_scenario}|scrap={scrap_scenario}".encode())
 
     return sha256_hash.hexdigest()[:16]
 
@@ -46,12 +51,14 @@ class CacheMetadata:
     preparation_time_seconds: float
     file_count: int
     total_size_bytes: int
+    demand_scenario: str
+    scrap_scenario: str
 
 
 class DataPreparationCache:
     """Manages cached data preparations based on content hashing."""
 
-    CACHE_VERSION = "1.8"  # Bump to invalidate all caches (geo-keyed grid emissivity)
+    CACHE_VERSION = "1.9"  # Bump to invalidate all caches (demand/scrap scenario in the cache key)
 
     def __init__(self, cache_root: Optional[Path] = None):
         """Initialize cache manager.
@@ -132,20 +139,30 @@ class DataPreparationCache:
             del self.index["entries"][cache_key]
             self._save_index()
 
-    def get_cache_key(self, master_excel_path: Path) -> str:
-        """Generate cache key from file content."""
-        return get_preparation_hash(master_excel_path, self.CACHE_VERSION)
+    def get_cache_key(
+        self, master_excel_path: Path, *, demand_scenario: str = "BAU", scrap_scenario: str = "BAU"
+    ) -> str:
+        """Generate cache key from file content and the demand/scrap scenario selection."""
+        return get_preparation_hash(
+            master_excel_path, self.CACHE_VERSION, demand_scenario=demand_scenario, scrap_scenario=scrap_scenario
+        )
 
-    def get_cached_preparation(self, master_excel_path: Path) -> Optional[Path]:
+    def get_cached_preparation(
+        self, master_excel_path: Path, *, demand_scenario: str = "BAU", scrap_scenario: str = "BAU"
+    ) -> Optional[Path]:
         """Return path to cached preparation if exists and valid.
 
         Args:
             master_excel_path: Path to master Excel file
+            demand_scenario: "Scenario" column value the demand centres were read for
+            scrap_scenario: "Scenario" column value the scrap suppliers were read for
 
         Returns:
             Path to cached data directory or None if not cached
         """
-        cache_key = self.get_cache_key(master_excel_path)
+        cache_key = self.get_cache_key(
+            master_excel_path, demand_scenario=demand_scenario, scrap_scenario=scrap_scenario
+        )
 
         # Fast path: check index first
         if cache_key in self.index.get("entries", {}):
@@ -198,6 +215,9 @@ class DataPreparationCache:
         master_excel_path: Path,
         preparation_time: float,
         result: Optional["PreparationResult"] = None,
+        *,
+        demand_scenario: str = "BAU",
+        scrap_scenario: str = "BAU",
     ) -> Path:
         """Save preparation to cache.
 
@@ -206,11 +226,15 @@ class DataPreparationCache:
             master_excel_path: Path to master Excel file
             preparation_time: Time taken to prepare data in seconds
             result: Optional PreparationResult with detailed timing
+            demand_scenario: "Scenario" column value the demand centres were read for
+            scrap_scenario: "Scenario" column value the scrap suppliers were read for
 
         Returns:
             Path to cached directory
         """
-        cache_key = self.get_cache_key(master_excel_path)
+        cache_key = self.get_cache_key(
+            master_excel_path, demand_scenario=demand_scenario, scrap_scenario=scrap_scenario
+        )
         cache_dir = self.cache_root / f"prep_{cache_key}"
 
         # Remove existing if present
@@ -234,6 +258,8 @@ class DataPreparationCache:
             preparation_time_seconds=preparation_time,
             file_count=file_count,
             total_size_bytes=total_size,
+            demand_scenario=demand_scenario,
+            scrap_scenario=scrap_scenario,
         )
 
         metadata_dict = {
@@ -244,6 +270,8 @@ class DataPreparationCache:
             "preparation_time_seconds": metadata.preparation_time_seconds,
             "file_count": metadata.file_count,
             "total_size_bytes": metadata.total_size_bytes,
+            "demand_scenario": metadata.demand_scenario,
+            "scrap_scenario": metadata.scrap_scenario,
         }
 
         # Include detailed timing if available

--- a/src/steelo/data/preparation.py
+++ b/src/steelo/data/preparation.py
@@ -225,6 +225,8 @@ class DataPreparationService:
         geo_version: Optional[str] = None,
         force_refresh: bool = False,
         use_furnace_units_sheet: bool = True,
+        demand_scenario: str = "BAU",
+        scrap_scenario: str = "BAU",
     ) -> PreparationResult:
         """
         Prepare all data files for simulation.
@@ -237,6 +239,8 @@ class DataPreparationService:
             progress_callback: Optional callback for progress updates
             geo_version: Specific version of geo-data to use (optional)
             force_refresh: Force re-preparation even if cached
+            demand_scenario: "Scenario" column value read for demand centres (part of the cache key)
+            scrap_scenario: "Scenario" column value read for scrap suppliers (part of the cache key)
 
         Returns:
             PreparationResult with all file and timing information
@@ -257,7 +261,9 @@ class DataPreparationService:
 
         # Now check cache with the resolved master Excel path
         if self.use_cache and not force_refresh and master_excel_path.exists():
-            cached_dir = self.cache_manager.get_cached_preparation(master_excel_path)
+            cached_dir = self.cache_manager.get_cached_preparation(
+                master_excel_path, demand_scenario=demand_scenario, scrap_scenario=scrap_scenario
+            )
             if cached_dir:
                 if verbose:
                     logging.info(f"Using cached preparation from: {cached_dir}")
@@ -308,6 +314,8 @@ class DataPreparationService:
             progress_callback=progress_callback,
             geo_version=geo_version,
             use_furnace_units_sheet=use_furnace_units_sheet,
+            demand_scenario=demand_scenario,
+            scrap_scenario=scrap_scenario,
         )
 
         # Ensure master_excel_path is set in result (it might have been resolved in _prepare_data_internal)
@@ -322,6 +330,8 @@ class DataPreparationService:
                     master_excel_path=master_excel_path,
                     preparation_time=result.total_duration,
                     result=result,
+                    demand_scenario=demand_scenario,
+                    scrap_scenario=scrap_scenario,
                 )
                 if verbose:
                     logging.info("Saved preparation to cache")
@@ -340,6 +350,8 @@ class DataPreparationService:
         progress_callback: Optional[Any] = None,
         geo_version: Optional[str] = None,
         use_furnace_units_sheet: bool = True,
+        demand_scenario: str = "BAU",
+        scrap_scenario: str = "BAU",
     ) -> PreparationResult:
         """Internal method - existing prepare_data logic."""
         start_time = time.time()
@@ -397,6 +409,8 @@ class DataPreparationService:
             progress_callback,
             use_furnace_units_sheet,
             valid_geo_keys=valid_geo_keys or None,
+            demand_scenario=demand_scenario,
+            scrap_scenario=scrap_scenario,
         )
         result.add_step(PreparationStep("JSON repository creation", time.time() - step_start))
 
@@ -800,6 +814,8 @@ class DataPreparationService:
         progress_callback: Optional[Any] = None,
         use_furnace_units_sheet: bool = True,
         valid_geo_keys: Optional[set[str]] = None,
+        demand_scenario: str = "BAU",
+        scrap_scenario: str = "BAU",
     ) -> None:
         """Create JSON repositories using the centralized recreation system."""
         # Create recreation config
@@ -822,6 +838,8 @@ class DataPreparationService:
             package_name="core-data",
             use_furnace_units_sheet=use_furnace_units_sheet,
             valid_geo_keys=valid_geo_keys,
+            demand_scenario=demand_scenario,
+            scrap_scenario=scrap_scenario,
         )
 
         # Track all created files

--- a/src/steelo/data/recreate.py
+++ b/src/steelo/data/recreate.py
@@ -68,6 +68,8 @@ class DataRecreator:
         master_excel_path: Path | None = None,
         track_timing: bool = False,
         use_furnace_units_sheet: bool = True,
+        demand_scenario: str = "BAU",
+        scrap_scenario: str = "BAU",
     ) -> dict[str, Path]:
         """Recreate JSON repositories from a downloaded package.
 
@@ -79,6 +81,8 @@ class DataRecreator:
             track_timing: If True, track and display timing for each file creation
             use_furnace_units_sheet: If True (default), read from 'Furnace units' sheet (new method).
                                      If False, read from 'Iron and steel plants' sheet (old method).
+            demand_scenario: "Scenario" column value read for demand centres
+            scrap_scenario: "Scenario" column value read for scrap suppliers
 
         Returns:
             Dictionary mapping repository types to their output paths
@@ -248,6 +252,7 @@ class DataRecreator:
                     mines_sheet_name="Iron ore mines",
                     location_csv=package_dir / "countries.csv",
                     gravity_distances_pkl_path=package_dir / "gravity_distances_dict.pkl",
+                    scrap_scenario=scrap_scenario,
                 )
                 console.print(
                     f"  ✓ Created {output_paths['suppliers'].name} "
@@ -262,6 +267,7 @@ class DataRecreator:
                     demand_sheet_name="Demand and scrap availability",
                     gravity_distances_path=package_dir / "gravity_distances_dict.pkl",
                     location_csv=package_dir / "countries.csv",
+                    demand_scenario=demand_scenario,
                 )
                 console.print(
                     f"  ✓ Created {output_paths['demand_centers'].name} "
@@ -332,6 +338,8 @@ class DataRecreator:
         package_name: str = "core-data",
         use_furnace_units_sheet: bool = True,
         valid_geo_keys: set[str] | None = None,
+        demand_scenario: str = "BAU",
+        scrap_scenario: str = "BAU",
     ) -> dict[str, Path]:
         """
         Recreate files using a RecreationConfig for fine-grained control.
@@ -346,6 +354,8 @@ class DataRecreator:
             valid_geo_keys: Recognised sub-national geo-keys for the plants readers to
                             validate against (the in-memory geo_hierarchy built during
                             prep). None falls back to the prepared geo_hierarchy.json.
+            demand_scenario: "Scenario" column value read for demand centres
+            scrap_scenario: "Scenario" column value read for scrap suppliers
 
         Returns:
             Dictionary mapping filenames to their output paths
@@ -408,7 +418,14 @@ class DataRecreator:
 
                     # Call the appropriate recreation function
                     success = self._recreate_single_file(
-                        spec, output_dir, package_dir, master_excel_path, use_furnace_units_sheet, valid_geo_keys
+                        spec,
+                        output_dir,
+                        package_dir,
+                        master_excel_path,
+                        use_furnace_units_sheet,
+                        valid_geo_keys,
+                        demand_scenario=demand_scenario,
+                        scrap_scenario=scrap_scenario,
                     )
 
                     if success and file_path.exists():
@@ -447,6 +464,8 @@ class DataRecreator:
         master_excel_path: Path | None,
         use_furnace_units_sheet: bool = True,
         valid_geo_keys: set[str] | None = None,
+        demand_scenario: str = "BAU",
+        scrap_scenario: str = "BAU",
     ) -> bool:
         """
         Recreate a single file based on its specification.
@@ -508,6 +527,7 @@ class DataRecreator:
                     demand_sheet_name=spec.master_excel_sheet,
                     gravity_distances_path=package_dir / "gravity_distances_dict.pkl",
                     location_csv=package_dir / "countries.csv",
+                    demand_scenario=demand_scenario,
                 )
             elif spec.recreate_function == "recreate_mines_and_scrap_as_suppliers_data":
                 func(
@@ -517,6 +537,7 @@ class DataRecreator:
                     mines_sheet_name=spec.master_excel_sheet,
                     location_csv=package_dir / "countries.csv",
                     gravity_distances_pkl_path=package_dir / "gravity_distances_dict.pkl",
+                    scrap_scenario=scrap_scenario,
                 )
             elif spec.recreate_function == "recreate_tariffs_data":
                 func(

--- a/src/steelo/data/recreation_functions.py
+++ b/src/steelo/data/recreation_functions.py
@@ -226,10 +226,13 @@ def recreate_demand_center_data(
     demand_sheet_name: str,
     gravity_distances_path: Path | None = None,
     location_csv: Path | None = None,
+    *,
+    demand_scenario: str,
 ) -> DemandCenterJsonRepository:
     """
     Recreate the JSON sample demand center data from the current CSV file.
 
+    Only the rows of `demand_scenario` (the sheet's "Scenario" column) are read.
     Note: gravity_distances_path and location_csv must be provided by the caller.
     """
     if not gravity_distances_path:
@@ -242,6 +245,7 @@ def recreate_demand_center_data(
         demand_excel_path=demand_excel_path,
         demand_sheet_name=demand_sheet_name,
         location_csv=location_csv,
+        demand_scenario=demand_scenario,
     )
 
     write_repository = DemandCenterJsonRepository(json_path)
@@ -258,10 +262,13 @@ def recreate_mines_and_scrap_as_suppliers_data(
     mines_sheet_name: str = "Iron ore mines",
     location_csv: Path | None = None,
     gravity_distances_pkl_path: Path | None = None,
+    *,
+    scrap_scenario: str,
 ) -> SupplierJsonRepository:
     """
     Recreate the JSON sample mines/scrap suppliers data from the current Excel file.
 
+    Scrap suppliers are read for `scrap_scenario` (the sheet's "Scenario" column); mines have no scenario.
     Note: location_csv is now a required parameter.
     """
     if location_csv is None:
@@ -277,6 +284,7 @@ def recreate_mines_and_scrap_as_suppliers_data(
         scrap_sheet_name=scrap_sheet_name,
         location_csv=location_path,
         gravity_distances_pkl_path=gravity_path,
+        scrap_scenario=scrap_scenario,
     )
     console.print(f"[blue]  Read {len(scrap_suppliers)} scrap suppliers[/blue]")
 

--- a/src/steelo/data/validation.py
+++ b/src/steelo/data/validation.py
@@ -191,6 +191,7 @@ class ExcelValidator:
                             demand_excel_path=file_path,
                             demand_sheet_name="Sheet1",
                             location_csv=self.location_csv_path,
+                            demand_scenario="BAU",
                         )
                         result.data = demand_centers
                     else:
@@ -217,7 +218,11 @@ class ExcelValidator:
             if self.location_csv_path:
                 if is_scrap:
                     suppliers = excel_reader.read_scrap_as_suppliers(
-                        str(file_path), "Sheet1", str(self.location_csv_path), gravity_distances_pkl_path=None
+                        str(file_path),
+                        "Sheet1",
+                        str(self.location_csv_path),
+                        gravity_distances_pkl_path=None,
+                        scrap_scenario="BAU",
                     )
                 else:
                     suppliers = excel_reader.read_mines_as_suppliers(

--- a/src/steelo/domain/datacollector.py
+++ b/src/steelo/domain/datacollector.py
@@ -818,6 +818,7 @@ class DataCollector:
                 "furnace_groups": plant_dict,
                 "plant_group_id": plant_group_id,
                 "location": p.location.iso3,
+                "geo_key": p.location.geo_key,
                 "plant_profit_and_loss": sum(fg.historic_balance for fg in p.furnace_groups),
                 "plant_group_balance": plant_group_balance,
             }

--- a/src/steelo/entrypoints/cli.py
+++ b/src/steelo/entrypoints/cli.py
@@ -80,6 +80,15 @@ def run_full_simulation() -> str:
         help="Scenario name in the same sheet used for scrap availability (default: same as --demand-scenario)",
     )
     parser.add_argument(
+        "--grid-emissions-scenario",
+        type=str,
+        default="Business As Usual",
+        help=(
+            "Grid emissivity projection applied at run time, named as in the 'Power grid emissivity' sheet "
+            "without its 'projection_' prefix (default: 'Business As Usual'; alternative: 'Net Zero')"
+        ),
+    )
+    parser.add_argument(
         "--location-csv",
         type=str,
         default=None,
@@ -202,7 +211,11 @@ def run_full_simulation() -> str:
         # Scrap availability follows the demand scenario unless picked separately
         demand_scenario = args.demand_scenario
         scrap_scenario = args.scrap_scenario or args.demand_scenario
-        console.print(f"[blue]Demand scenario:[/blue] {demand_scenario}  [blue]Scrap scenario:[/blue] {scrap_scenario}")
+        grid_emissions_scenario = args.grid_emissions_scenario
+        console.print(
+            f"[blue]Demand scenario:[/blue] {demand_scenario}  [blue]Scrap scenario:[/blue] {scrap_scenario}  "
+            f"[blue]Grid emissions scenario:[/blue] {grid_emissions_scenario}"
+        )
 
         # Prepare data with caching
         from ..data import DataPreparationService
@@ -267,6 +280,7 @@ def run_full_simulation() -> str:
                 "demand_sheet_name": args.demand_sheet,
                 "chosen_demand_scenario": demand_scenario,
                 "chosen_scrap_scenario": scrap_scenario,
+                "chosen_grid_emissions_scenario": grid_emissions_scenario,
                 "log_level": log_level,
             }
 
@@ -351,6 +365,7 @@ def run_full_simulation() -> str:
                     "demand_sheet_name": args.demand_sheet,
                     "chosen_demand_scenario": demand_scenario,
                     "chosen_scrap_scenario": scrap_scenario,
+                    "chosen_grid_emissions_scenario": grid_emissions_scenario,
                     "log_level": log_level,
                 }
 

--- a/src/steelo/entrypoints/cli.py
+++ b/src/steelo/entrypoints/cli.py
@@ -68,6 +68,18 @@ def run_full_simulation() -> str:
         help="Sheet name in the demand excel file (default: 'Steel_Demand_Chris Bataille')",
     )
     parser.add_argument(
+        "--demand-scenario",
+        type=str,
+        default="BAU",
+        help="Scenario name in the 'Demand and scrap availability' sheet used for steel demand (default: BAU)",
+    )
+    parser.add_argument(
+        "--scrap-scenario",
+        type=str,
+        default=None,
+        help="Scenario name in the same sheet used for scrap availability (default: same as --demand-scenario)",
+    )
+    parser.add_argument(
         "--location-csv",
         type=str,
         default=None,
@@ -187,6 +199,11 @@ def run_full_simulation() -> str:
         }
         log_level = log_levels[args.log_level]
 
+        # Scrap availability follows the demand scenario unless picked separately
+        demand_scenario = args.demand_scenario
+        scrap_scenario = args.scrap_scenario or args.demand_scenario
+        console.print(f"[blue]Demand scenario:[/blue] {demand_scenario}  [blue]Scrap scenario:[/blue] {scrap_scenario}")
+
         # Prepare data with caching
         from ..data import DataPreparationService
 
@@ -221,7 +238,9 @@ def run_full_simulation() -> str:
         # Check if we can use cached data directly
         cached_data_dir = None
         if not args.no_cache and not args.force_refresh:
-            cached_data_dir = cache_manager.get_cached_preparation(master_excel_path)
+            cached_data_dir = cache_manager.get_cached_preparation(
+                master_excel_path, demand_scenario=demand_scenario, scrap_scenario=scrap_scenario
+            )
             if cached_data_dir:
                 # cached_data_dir already points to the data directory
                 console.print(f"[blue]Using cached preparation from:[/blue] {cached_data_dir}")
@@ -246,6 +265,8 @@ def run_full_simulation() -> str:
                 "output_dir": output_dir,
                 "master_excel_path": master_excel_path,
                 "demand_sheet_name": args.demand_sheet,
+                "chosen_demand_scenario": demand_scenario,
+                "chosen_scrap_scenario": scrap_scenario,
                 "log_level": log_level,
             }
 
@@ -286,6 +307,8 @@ def run_full_simulation() -> str:
                 "cache_used": True,
                 "master_excel": str(master_excel_path),
                 "cached_from": str(cached_data_dir),
+                "demand_scenario": demand_scenario,
+                "scrap_scenario": scrap_scenario,
             }
             (output_dir / "preparation_metadata.json").write_text(json.dumps(prep_metadata, indent=2))
 
@@ -305,6 +328,8 @@ def run_full_simulation() -> str:
                     master_excel_path=master_excel_path,
                     force_refresh=args.force_refresh,
                     verbose=True,
+                    demand_scenario=demand_scenario,
+                    scrap_scenario=scrap_scenario,
                 )
 
                 actual_data_dir = prep_dir
@@ -324,6 +349,8 @@ def run_full_simulation() -> str:
                     "output_dir": output_dir,
                     "master_excel_path": master_excel_path,
                     "demand_sheet_name": args.demand_sheet,
+                    "chosen_demand_scenario": demand_scenario,
+                    "chosen_scrap_scenario": scrap_scenario,
                     "log_level": log_level,
                 }
 
@@ -368,6 +395,8 @@ def run_full_simulation() -> str:
                     "preparation_duration": prep_result.total_duration,
                     "files_prepared": len(prep_result.files),
                     "temp_prep_dir": str(prep_dir),
+                    "demand_scenario": demand_scenario,
+                    "scrap_scenario": scrap_scenario,
                 }
                 (output_dir / "preparation_metadata.json").write_text(json.dumps(prep_metadata, indent=2))
 

--- a/src/steelo/entrypoints/cli.py
+++ b/src/steelo/entrypoints/cli.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ..domain import Year
+from ..domain.constants import RANDOM_SEED_DEFAULT
 
 from ..simulation import SimulationConfig
 from ..bootstrap import bootstrap_simulation
@@ -163,6 +164,15 @@ def run_full_simulation() -> str:
         default=0.8,
         help="Ratio of steel price for iron floor when pegging is enabled (default: 0.8 = 80%%)",
     )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=RANDOM_SEED_DEFAULT,
+        help=(
+            "Seed for the run-time RNGs shared by the plant agent, geospatial and trade LP modules "
+            "(default: %(default)s); data preparation keeps its own fixed seed"
+        ),
+    )
 
     # Parse the command-line arguments
     try:
@@ -282,6 +292,7 @@ def run_full_simulation() -> str:
                 "chosen_scrap_scenario": scrap_scenario,
                 "chosen_grid_emissions_scenario": grid_emissions_scenario,
                 "log_level": log_level,
+                "random_seed": args.random_seed,
             }
 
             # Add custom baseload_power_sim_dir if provided
@@ -367,6 +378,7 @@ def run_full_simulation() -> str:
                     "chosen_scrap_scenario": scrap_scenario,
                     "chosen_grid_emissions_scenario": grid_emissions_scenario,
                     "log_level": log_level,
+                    "random_seed": args.random_seed,
                 }
 
                 # Add custom baseload_power_sim_dir if provided

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -409,7 +409,10 @@ class SimulationConfig:
     )
 
     # === Scenario and Policy Settings ===
+    # Applied at data-prep time (rows of the "Demand and scrap availability" sheet) and part of the
+    # prep cache key; kept on the config so the choice is recorded in simulation_config.json
     chosen_demand_scenario: str = "BAU"
+    chosen_scrap_scenario: str = "BAU"
     chosen_grid_emissions_scenario: str = "Business As Usual"
     scrap_generation_scenario: str = "business_as_usual"
     chosen_emissions_boundary_for_carbon_costs: str = "rs-inspired"

--- a/src/steelo/utilities/plotting.py
+++ b/src/steelo/utilities/plotting.py
@@ -1430,6 +1430,12 @@ def plot_detailed_trade_map(
 
         let deckgl;
 
+        // This map never uses Mapbox-hosted styles/tiles (basemap comes from CARTO's
+        // free CDN), so disable Mapbox GL JS's access-token requirement rather than
+        // needing a real Mapbox account/key.
+        mapboxgl.accessToken = 'not-needed';
+        mapboxgl.config.REQUIRE_ACCESS_TOKEN = false;
+
         // Make functions available globally for onclick handlers
         window.toggleCommodity = function(commodity) {{
             console.log('toggleCommodity called with:', commodity);

--- a/tests/e2e/test_cli_simulation_config.py
+++ b/tests/e2e/test_cli_simulation_config.py
@@ -155,3 +155,38 @@ def test_cli_grid_emissions_scenario_flag_lands_on_the_config(
 
         config = mock_create_runner.call_args[0][0]
         assert config.chosen_grid_emissions_scenario == expected
+
+
+@pytest.mark.parametrize(
+    "flag_argv, expected",
+    [([], 42), (["--random-seed", "7"], 7)],
+)
+@patch("steelo.entrypoints.cli.setup_legacy_symlinks")
+@patch("steelo.entrypoints.cli.update_output_symlink")
+@patch("steelo.entrypoints.cli.update_data_symlink")
+@patch("steelo.entrypoints.cli.bootstrap_simulation")
+@patch("steelo.data.DataPreparationService")
+@patch("steelo.data.DataManager")
+def test_cli_random_seed_lands_on_the_config_and_geo_config(
+    mock_data_manager_class,
+    mock_data_prep_service_class,
+    mock_create_runner,
+    mock_update_data_symlink,
+    mock_update_output_symlink,
+    mock_setup_legacy_symlinks,
+    flag_argv,
+    expected,
+):
+    """``--random-seed`` sets the run-time seed and propagates into GeoConfig; absent, the default 42 applies."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cli_temp_base = Path(tmpdir)
+        stub_cli_dependencies(cli_temp_base, mock_data_manager_class, mock_data_prep_service_class, mock_create_runner)
+
+        argv = ["run_simulation", "--start-year", "2026", "--end-year", "2027", *flag_argv]
+        with patch.object(sys, "argv", argv):
+            with patch("sys.exit"):
+                run_full_simulation()
+
+        config = mock_create_runner.call_args[0][0]
+        assert config.random_seed == expected
+        assert config.geo_config.random_seed == expected

--- a/tests/e2e/test_cli_simulation_config.py
+++ b/tests/e2e/test_cli_simulation_config.py
@@ -7,9 +7,74 @@ from unittest.mock import patch, MagicMock, Mock
 from pathlib import Path
 import tempfile
 
+import pytest
+
 from steelo.simulation import SimulationConfig
 from steelo.entrypoints.cli import run_full_simulation
 from steelo.domain import Year
+
+
+def stub_cli_dependencies(cli_temp_base, mock_data_manager_class, mock_data_prep_service_class, mock_create_runner):
+    """Wire the S3 download, data preparation and runner factory out of the CLI path."""
+    # Setup the data directory where CLI will create it
+    data_dir = cli_temp_base / "data"
+    fixtures_dir = data_dir / "fixtures"
+
+    # Mock DataManager to avoid S3 download
+    mock_data_manager = MagicMock()
+    mock_master_input_path = cli_temp_base / "master-input"
+    mock_master_input_path.mkdir(parents=True, exist_ok=True)
+    (mock_master_input_path / "master_input.xlsx").touch()
+    mock_data_manager.get_package_path.return_value = mock_master_input_path
+    mock_data_manager.download_package.return_value = None
+    mock_data_manager_class.return_value = mock_data_manager
+
+    # Mock data preparation service
+    mock_prep_service = MagicMock()
+    mock_prep_result = MagicMock()
+    mock_prep_result.data_dir = data_dir
+    mock_prep_result.output_directory = fixtures_dir
+
+    # Add specific attributes that will be serialized
+    mock_prep_result.master_excel_path = None
+    mock_prep_result.master_excel_source = "S3"
+    mock_prep_result.data_package_version = "1.0.0"
+    mock_prep_result.cache_used = False
+    mock_prep_result.preparation_time = 1.23
+    mock_prep_result.total_duration = 2.5
+    mock_prep_result.files = ["file1.json", "file2.json"]
+
+    # Make prepare_data create the required files
+    def prepare_data_side_effect(*args, **kwargs):
+        # Get the actual output_dir from kwargs
+        actual_output_dir = kwargs.get("output_dir", fixtures_dir)
+        # Create the directories and files when prepare_data is called
+        actual_output_dir.parent.mkdir(parents=True, exist_ok=True)
+        actual_output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create the fixtures subdirectory where files are expected
+        fixtures_subdir = actual_output_dir / "fixtures"
+        fixtures_subdir.mkdir(parents=True, exist_ok=True)
+
+        # Create required JSON files in fixtures directory
+        (fixtures_subdir / "plants.json").write_text("[]")
+        (fixtures_subdir / "demand_centers.json").write_text("[]")
+        (fixtures_subdir / "suppliers.json").write_text("[]")
+        (fixtures_subdir / "country_mappings.json").write_text("[]")
+        (fixtures_subdir / "railway_costs.json").write_text("[]")
+
+        # Update the mock result to use the actual directory
+        mock_prep_result.output_directory = fixtures_subdir
+        mock_prep_result.data_dir = actual_output_dir
+        return mock_prep_result
+
+    mock_prep_service.prepare_data.side_effect = prepare_data_side_effect
+    mock_data_prep_service_class.return_value = mock_prep_service
+
+    # Mock the runner to avoid actual simulation
+    mock_runner = MagicMock()
+    mock_runner.run = Mock()
+    mock_create_runner.return_value = mock_runner
 
 
 @patch("steelo.entrypoints.cli.setup_legacy_symlinks")  # Mock to prevent symlink creation
@@ -34,66 +99,7 @@ def test_cli_creates_and_passes_simulation_config(
     with tempfile.TemporaryDirectory() as tmpdir:
         # Setup the CLI's expected temp directory structure
         cli_temp_base = Path(tmpdir)
-
-        # Setup the data directory where CLI will create it
-        data_dir = cli_temp_base / "data"
-        fixtures_dir = data_dir / "fixtures"
-
-        # Mock DataManager to avoid S3 download
-        mock_data_manager = MagicMock()
-        mock_master_input_path = cli_temp_base / "master-input"
-        mock_master_input_path.mkdir(parents=True, exist_ok=True)
-        (mock_master_input_path / "master_input.xlsx").touch()
-        mock_data_manager.get_package_path.return_value = mock_master_input_path
-        mock_data_manager.download_package.return_value = None
-        mock_data_manager_class.return_value = mock_data_manager
-
-        # Mock data preparation service
-        mock_prep_service = MagicMock()
-        mock_prep_result = MagicMock()
-        mock_prep_result.data_dir = data_dir
-        mock_prep_result.output_directory = fixtures_dir
-
-        # Add specific attributes that will be serialized
-        mock_prep_result.master_excel_path = None
-        mock_prep_result.master_excel_source = "S3"
-        mock_prep_result.data_package_version = "1.0.0"
-        mock_prep_result.cache_used = False
-        mock_prep_result.preparation_time = 1.23
-        mock_prep_result.total_duration = 2.5
-        mock_prep_result.files = ["file1.json", "file2.json"]
-
-        # Make prepare_data create the required files
-        def prepare_data_side_effect(*args, **kwargs):
-            # Get the actual output_dir from kwargs
-            actual_output_dir = kwargs.get("output_dir", fixtures_dir)
-            # Create the directories and files when prepare_data is called
-            actual_output_dir.parent.mkdir(parents=True, exist_ok=True)
-            actual_output_dir.mkdir(parents=True, exist_ok=True)
-
-            # Create the fixtures subdirectory where files are expected
-            fixtures_subdir = actual_output_dir / "fixtures"
-            fixtures_subdir.mkdir(parents=True, exist_ok=True)
-
-            # Create required JSON files in fixtures directory
-            (fixtures_subdir / "plants.json").write_text("[]")
-            (fixtures_subdir / "demand_centers.json").write_text("[]")
-            (fixtures_subdir / "suppliers.json").write_text("[]")
-            (fixtures_subdir / "country_mappings.json").write_text("[]")
-            (fixtures_subdir / "railway_costs.json").write_text("[]")
-
-            # Update the mock result to use the actual directory
-            mock_prep_result.output_directory = fixtures_subdir
-            mock_prep_result.data_dir = actual_output_dir
-            return mock_prep_result
-
-        mock_prep_service.prepare_data.side_effect = prepare_data_side_effect
-        mock_data_prep_service_class.return_value = mock_prep_service
-
-        # Mock the runner to avoid actual simulation
-        mock_runner = MagicMock()
-        mock_runner.run = Mock()
-        mock_create_runner.return_value = mock_runner
+        stub_cli_dependencies(cli_temp_base, mock_data_manager_class, mock_data_prep_service_class, mock_create_runner)
 
         # Simulate running the CLI with specific arguments
         with patch.object(sys, "argv", ["run_simulation", "--start-year", "2026", "--end-year", "2035"]):
@@ -115,3 +121,37 @@ def test_cli_creates_and_passes_simulation_config(
         config = args[0]
         assert config.start_year == Year(2026)
         assert config.end_year == Year(2035)
+
+
+@pytest.mark.parametrize(
+    "flag_argv, expected",
+    [([], "Business As Usual"), (["--grid-emissions-scenario", "Net Zero"], "Net Zero")],
+)
+@patch("steelo.entrypoints.cli.setup_legacy_symlinks")
+@patch("steelo.entrypoints.cli.update_output_symlink")
+@patch("steelo.entrypoints.cli.update_data_symlink")
+@patch("steelo.entrypoints.cli.bootstrap_simulation")
+@patch("steelo.data.DataPreparationService")
+@patch("steelo.data.DataManager")
+def test_cli_grid_emissions_scenario_flag_lands_on_the_config(
+    mock_data_manager_class,
+    mock_data_prep_service_class,
+    mock_create_runner,
+    mock_update_data_symlink,
+    mock_update_output_symlink,
+    mock_setup_legacy_symlinks,
+    flag_argv,
+    expected,
+):
+    """``--grid-emissions-scenario`` selects the grid emissivity projection; absent, BAU applies."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cli_temp_base = Path(tmpdir)
+        stub_cli_dependencies(cli_temp_base, mock_data_manager_class, mock_data_prep_service_class, mock_create_runner)
+
+        argv = ["run_simulation", "--start-year", "2026", "--end-year", "2027", *flag_argv]
+        with patch.object(sys, "argv", argv):
+            with patch("sys.exit"):
+                run_full_simulation()
+
+        config = mock_create_runner.call_args[0][0]
+        assert config.chosen_grid_emissions_scenario == expected

--- a/tests/unit/test_cache_manager.py
+++ b/tests/unit/test_cache_manager.py
@@ -256,3 +256,52 @@ def test_cache_version_invalidation(tmp_path):
 
     # Should not find cache with different version
     assert cache_manager.get_cached_preparation(sample_file) is None
+
+
+def test_hash_changes_with_demand_scenario(tmp_path):
+    """Same workbook, different demand scenario → different cache key."""
+    sample_file = tmp_path / "sample.xlsx"
+    sample_file.write_bytes(b"PK\x03\x04" + b"X" * 1000)
+
+    assert get_preparation_hash(sample_file, demand_scenario="BAU") != get_preparation_hash(
+        sample_file, demand_scenario="China-high"
+    )
+
+
+def test_hash_changes_with_scrap_scenario_alone(tmp_path):
+    """Scrap scenario is keyed independently of the demand scenario."""
+    sample_file = tmp_path / "sample.xlsx"
+    sample_file.write_bytes(b"PK\x03\x04" + b"X" * 1000)
+
+    assert get_preparation_hash(
+        sample_file, demand_scenario="China-high", scrap_scenario="BAU"
+    ) != get_preparation_hash(sample_file, demand_scenario="China-high", scrap_scenario="China-high")
+
+
+def test_cached_preparation_is_keyed_by_scenarios(tmp_path):
+    """A preparation saved for one scenario pair is not served for another, and its metadata records the pair."""
+    import json
+
+    cache_manager = DataPreparationCache(cache_root=tmp_path / "cache")
+    sample_file = tmp_path / "sample.xlsx"
+    sample_file.write_bytes(b"PK\x03\x04" + b"X" * 1000)
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "test.txt").write_text("test")
+
+    cache_dir = cache_manager.save_preparation(
+        source_dir, sample_file, 1.0, demand_scenario="China-high", scrap_scenario="BAU"
+    )
+
+    metadata = json.loads((cache_dir / "metadata.json").read_text())
+    assert metadata["demand_scenario"] == "China-high"
+    assert metadata["scrap_scenario"] == "BAU"
+    assert (
+        cache_manager.get_cached_preparation(sample_file, demand_scenario="China-high", scrap_scenario="BAU")
+        is not None
+    )
+    assert (
+        cache_manager.get_cached_preparation(sample_file, demand_scenario="China-high", scrap_scenario="China-high")
+        is None
+    )
+    assert cache_manager.get_cached_preparation(sample_file) is None

--- a/tests/unit/test_excel_reader_demand_scenario.py
+++ b/tests/unit/test_excel_reader_demand_scenario.py
@@ -1,0 +1,81 @@
+"""Scenario selection in the demand-centre and scrap-supplier Excel readers."""
+
+import pickle
+
+import pandas as pd
+import pytest
+
+from steelo.adapters.dataprocessing import excel_reader
+from steelo.domain.models import Year
+
+SHEET = "Demand and scrap availability"
+KT_TO_T = excel_reader.KT_TO_T
+
+
+@pytest.fixture
+def scenario_workbook(tmp_path):
+    """Two-scenario demand/scrap sheet plus the location and gravity inputs the readers need."""
+    rows = []
+    for iso3, country in [("AUT", "Austria"), ("PRT", "Portugal")]:
+        for scenario, demand, scrap in [("BAU", 100, 10), ("China-high", 200, 20)]:
+            rows.append([country, iso3, "Crude steel consumption for forming [kt]", scenario, "kt", demand, demand + 1])
+            rows.append([country, iso3, "Total available scrap", scenario, "kt", scrap, scrap + 1])
+    df = pd.DataFrame(rows, columns=["Country", "ISO-3 code", "Metric", "Scenario", "Unit", 2025, 2030])
+    excel_path = tmp_path / "master.xlsx"
+    df.to_excel(excel_path, sheet_name=SHEET, index=False)
+
+    location_csv = tmp_path / "countries.csv"
+    pd.DataFrame(
+        {"COUNTRY": ["Austria", "Portugal"], "ISO": ["AT", "PT"], "latitude": [47.5, 39.5], "longitude": [14.5, -8.0]},
+    ).to_csv(location_csv, index=False)
+
+    gravity_path = tmp_path / "gravity_distances_dict.pkl"
+    gravity_path.write_bytes(pickle.dumps({}))
+    return excel_path, location_csv, gravity_path
+
+
+def _demand_2025(scenario_workbook, scenario):
+    excel_path, location_csv, gravity_path = scenario_workbook
+    centres = excel_reader.read_demand_centers(
+        gravity_distances_path=gravity_path,
+        demand_excel_path=excel_path,
+        demand_sheet_name=SHEET,
+        location_csv=location_csv,
+        demand_scenario=scenario,
+    )
+    return {dc.center_of_gravity.iso3: dc.demand_by_year[Year(2025)] for dc in centres}
+
+
+def _scrap_2025(scenario_workbook, scenario):
+    excel_path, location_csv, gravity_path = scenario_workbook
+    suppliers = excel_reader.read_scrap_as_suppliers(
+        str(excel_path),
+        SHEET,
+        str(location_csv),
+        gravity_distances_pkl_path=gravity_path,
+        scrap_scenario=scenario,
+    )
+    return {s.location.iso3: s.capacity_by_year[Year(2025)] for s in suppliers}
+
+
+def test_read_demand_centers_selects_the_requested_scenario(scenario_workbook):
+    """Each scenario name yields that scenario's demand volumes, not the other's."""
+    assert _demand_2025(scenario_workbook, "BAU") == {"AUT": 100 * KT_TO_T, "PRT": 100 * KT_TO_T}
+    assert _demand_2025(scenario_workbook, "China-high") == {"AUT": 200 * KT_TO_T, "PRT": 200 * KT_TO_T}
+
+
+def test_read_scrap_as_suppliers_selects_the_requested_scenario(scenario_workbook):
+    """Scrap availability follows its own scenario argument."""
+    assert _scrap_2025(scenario_workbook, "BAU") == {"AUT": 10 * KT_TO_T, "PRT": 10 * KT_TO_T}
+    assert _scrap_2025(scenario_workbook, "China-high") == {"AUT": 20 * KT_TO_T, "PRT": 20 * KT_TO_T}
+
+
+def test_unknown_scenario_fails_listing_available_names(scenario_workbook):
+    """A scenario absent from the sheet raises instead of silently producing no centres."""
+    expected = (
+        r"No rows for scenario 'Nope' in sheet 'Demand and scrap availability'; available: \['BAU', 'China-high'\]"
+    )
+    with pytest.raises(ValueError, match=expected):
+        _demand_2025(scenario_workbook, "Nope")
+    with pytest.raises(ValueError, match=expected):
+        _scrap_2025(scenario_workbook, "Nope")

--- a/tests/unit/test_post_process_datacollection.py
+++ b/tests/unit/test_post_process_datacollection.py
@@ -363,3 +363,59 @@ def test_chosen_reductant_values_are_normalized():
         reductants = df.loc[df["furnace_group_id"] == "plant_001_fg_001", "chosen_reductant"].unique()
         assert len(reductants) == 1
         assert reductants[0] == "natural_gas"
+
+
+def test_geo_key_column_follows_iso3_when_present():
+    """Plant records carrying a geo_key land in the CSV right after iso3; older pickles without it still process."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data_dir = Path(tmpdir)
+        furnace_groups = pd.DataFrame(
+            [
+                {
+                    "furnace_group_id": "P1_0",
+                    "technology": "BF",
+                    "product": "iron",
+                    "chosen_reductant": "coke",
+                    "capacity": 1000,
+                    "production": 900,
+                    "unit_vopex": 100,
+                    "unit_fopex": 50,
+                    "unit_production_cost": 150,
+                    "debt_repayment_for_current_year": 10,
+                    "furnace_group_profit_and_loss": 500,
+                    "materials": {},
+                    "energy": {},
+                }
+            ]
+        )
+        sample_data = {
+            "P1": {
+                "location": "CHN",
+                "geo_key": "CHN:CN-HE",
+                "plant_profit_and_loss": 1000,
+                "plant_group_id": "plant_001_group",
+                "plant_group_balance": 1000,
+                "furnace_groups": furnace_groups,
+            },
+        }
+        with open(data_dir / "datacollection_post_allocation_2025.pkl", "wb") as f:
+            pickle.dump(sample_data, f)
+
+        df = pd.read_csv(
+            extract_and_process_stored_dataCollection(
+                commands={2025: {}}, data_dir=data_dir, output_path=data_dir / "with_geo_key.csv", store=True
+            )
+        )
+        columns = list(df.columns)
+        assert columns.index("geo_key") == columns.index("iso3") + 1
+        assert df["geo_key"].iloc[0] == "CHN:CN-HE"
+
+        del sample_data["P1"]["geo_key"]
+        with open(data_dir / "datacollection_post_allocation_2025.pkl", "wb") as f:
+            pickle.dump(sample_data, f)
+        df = pd.read_csv(
+            extract_and_process_stored_dataCollection(
+                commands={2025: {}}, data_dir=data_dir, output_path=data_dir / "without_geo_key.csv", store=True
+            )
+        )
+        assert "geo_key" not in df.columns


### PR DESCRIPTION
- **`--demand-scenario` / `--scrap-scenario`**: select the demand and scrap-availability scenario from the master workbook at data-prep time; the choice is part of the preparation cache key. Scrap follows the demand scenario unless picked separately.
- **`--grid-emissions-scenario`**: exposes the grid emissivity projection on the CLI, named as in the 'Power grid emissivity' sheet without its `projection_` prefix (default `Business As Usual`).
- **`--random-seed`**: varies run-time stochasticity per run (plant agent, geospatial, trade LP; default stays 42). Data preparation keeps its own fixed seed, so prepared inputs are identical across seeds.
- **`geo_key` in the post-processed CSV**: carried through the data collector, after `iso3`, for province-level analysis.
- **Detailed trade map**: disable Mapbox GL's access-token requirement; the basemap comes from CARTO's free CDN, so no Mapbox account is needed.