### PR TITLE
Scrap bootstrap price as a config parameter + debt-repayment floor

### DIFF
--- a/docs/domain_simulation_logic/plant_agent_model/economic_considerations.md
+++ b/docs/domain_simulation_logic/plant_agent_model/economic_considerations.md
@@ -142,6 +142,7 @@ annual_payment = annual_principal + annual_interest
 
 **Impact on Profitability**:
 - Debt repayment added to unit production cost
+- Per-tonne debt divides the annual payment by production, with utilisation floored at `production_threshold.low` (default 0.1) — the same floor `unit_fopex` uses — so a barely-producing furnace group does not book runaway per-tonne debt
 - Higher debt → Higher per-tonne cost → Lower competitiveness
 - Debt fully repaid after `plant_lifetime` years (default 20)
 

--- a/docs/domain_simulation_logic/trade_model/trade_model_setup.md
+++ b/docs/domain_simulation_logic/trade_model/trade_model_setup.md
@@ -96,6 +96,8 @@ The model represents the global steel value chain as a network:
 
 Trade-LP setup, the average-commodity-price calculation in `Environment.calculate_average_commodity_price_per_region()`, and downstream callers all read the value for the current simulation year. The same per-year structure applies to non-mine suppliers (scrap, etc.) — they simply populate a flat constant across years if their underlying input has no annual variation. Suppliers whose `production_cost_by_year` does not contain the current year are silently skipped from the average-price calculation.
 
+**Scrap production costs.** Scrap suppliers start the run at `SimulationConfig.initial_scrap_production_cost` (default `INITIAL_SCRAP_PRODUCTION_COST`, 333 USD/t): data preparation writes the constant into `suppliers.json` for every horizon year, and `bootstrap_simulation` re-applies the configured value at run time, so a cached preparation cannot pin a stale placeholder. From the second simulation year onward, `finalise_iteration` (step 4 in `handlers.py`) reprices the current year from BOF hot-metal costs — 0.95 × the average-BOM unit cost when available, else 0.90 × the country's fallback material cost, else the same configured default — meaning only the first year trades scrap at the placeholder.
+
 ---
 
 ### 3. Constraint Functions

--- a/src/steelo/adapters/dataprocessing/excel_reader.py
+++ b/src/steelo/adapters/dataprocessing/excel_reader.py
@@ -40,6 +40,7 @@ from steelo.utilities.utils import normalize_name
 # Import only true constants from global_variables
 from steelo.domain.constants import (
     Commodities,
+    INITIAL_SCRAP_PRODUCTION_COST,
     GJ_TO_KWH,
     MWH_TO_KWH,
     PERMWh_TO_PERkWh,
@@ -1045,6 +1046,19 @@ def read_demand_centers(
     return refine_demand_centers_for_major_countries(demand_centers)
 
 
+def _initial_scrap_costs() -> dict[Year, float]:
+    """Placeholder scrap production cost for the whole simulation horizon.
+
+    Returns:
+        INITIAL_SCRAP_PRODUCTION_COST for every year from EXCEL_READER_START_YEAR to
+        EXCEL_READER_END_YEAR. Overwritten at run time: bootstrap applies the configured
+        value, then the annual repricing in handlers.py reprices from BOF hot-metal costs.
+    """
+    return {
+        Year(year): INITIAL_SCRAP_PRODUCTION_COST for year in range(EXCEL_READER_START_YEAR, EXCEL_READER_END_YEAR + 1)
+    }
+
+
 def refine_scrap_centers_for_major_countries(old_centers):
     """
     Refine centers for major (scrap exporting) countries by breaking down the absolute amount from
@@ -1086,12 +1100,6 @@ def refine_scrap_centers_for_major_countries(old_centers):
             for year in years:
                 amount_by_year[Year(year)] = old_center.capacity_by_year[Year(year)] * center["share"]
 
-            # Create constant production cost dictionary for all years in simulation horizon
-            # This initial value of 450 will be overwritten annually in handlers.py based on BOF hot_metal costs
-            production_cost_by_year = {
-                Year(year): 450.0 for year in range(EXCEL_READER_START_YEAR, EXCEL_READER_END_YEAR + 1)
-            }
-
             # Create new center with the new location and amount_by_year
             new_centers.append(
                 Supplier(
@@ -1099,7 +1107,7 @@ def refine_scrap_centers_for_major_countries(old_centers):
                     supplier_id=new_id,
                     location=location,
                     capacity_by_year=amount_by_year,
-                    production_cost_by_year=production_cost_by_year,
+                    production_cost_by_year=_initial_scrap_costs(),
                     mine_cost_by_year={},
                     mine_price_by_year={},
                 )
@@ -1189,18 +1197,12 @@ def read_scrap_as_suppliers(
             except ValueError:
                 continue
 
-        # Create constant production cost dictionary for all years in simulation horizon
-        # This initial value of 450 will be overwritten annually in handlers.py based on BOF hot_metal costs
-        production_cost_by_year = {
-            Year(year): 450.0 for year in range(EXCEL_READER_START_YEAR, EXCEL_READER_END_YEAR + 1)
-        }
-
         supply_center = Supplier(
             commodity=Commodities.SCRAP.value,
             supplier_id=f"{scrap_location.country}_scrap",
             location=scrap_location,
             capacity_by_year=scrap_by_year,
-            production_cost_by_year=production_cost_by_year,
+            production_cost_by_year=_initial_scrap_costs(),
             mine_cost_by_year={},
             mine_price_by_year={},
         )

--- a/src/steelo/bootstrap.py
+++ b/src/steelo/bootstrap.py
@@ -7,7 +7,8 @@ from typing import Optional, TYPE_CHECKING
 
 import numpy as np
 from .service_layer import handlers, UnitOfWork, MessageBus, SimulationCheckpoint
-from .domain.models import Environment, PlantGroup
+from .domain.constants import Commodities
+from .domain.models import Environment, PlantGroup, Supplier
 from .adapters.repositories import JsonRepository, InMemoryRepository, Repository
 from .data.path_resolver import DataPathResolver
 
@@ -209,6 +210,31 @@ def _load_secondary_feedstock_constraints(env, repository_json):
         logger.info(f"Total {len(constraints)} secondary feedstock constraints loaded")
 
 
+def apply_supplier_cost_config(suppliers: list[Supplier], config: "SimulationConfig") -> None:
+    """Apply the configured cost choices to the loaded suppliers' production costs.
+
+    Args:
+        suppliers: The suppliers loaded from the prepared fixtures.
+        config: The simulation configuration.
+
+    Notes:
+        Mines get mine_price_by_year (with iron ore premiums) or mine_cost_by_year (without),
+        per config.use_iron_ore_premiums. Scrap suppliers (empty mine dictionaries) get
+        config.initial_scrap_production_cost for every year, replacing the placeholder written
+        at data preparation; the annual repricing in handlers.py overwrites it from the second
+        year onward.
+    """
+    for supplier in suppliers:
+        if supplier.commodity == Commodities.SCRAP.value:
+            supplier.production_cost_by_year = {
+                year: config.initial_scrap_production_cost for year in supplier.production_cost_by_year
+            }
+        elif config.use_iron_ore_premiums and supplier.mine_price_by_year:
+            supplier.production_cost_by_year = supplier.mine_price_by_year.copy()
+        elif not config.use_iron_ore_premiums and supplier.mine_cost_by_year:
+            supplier.production_cost_by_year = supplier.mine_cost_by_year.copy()
+
+
 def bootstrap_simulation(
     config: "SimulationConfig",
     repository: Optional[Repository] = None,  # Allow injecting a repository for testing
@@ -285,15 +311,8 @@ def bootstrap_simulation(
         repository.demand_centers.add_list(repository_json.demand_centers.list())
         repository.suppliers.add_list(repository_json.suppliers.list())
 
-        # Apply use_iron_ore_premiums flag to iron ore supplier costs
-        for supplier in repository.suppliers.list():
-            if config.use_iron_ore_premiums and supplier.mine_price_by_year:
-                # Copy mine_price_by_year to production_cost_by_year
-                supplier.production_cost_by_year = supplier.mine_price_by_year.copy()
-            elif not config.use_iron_ore_premiums and supplier.mine_cost_by_year:
-                # Copy mine_cost_by_year to production_cost_by_year
-                supplier.production_cost_by_year = supplier.mine_cost_by_year.copy()
-            # If mine_cost/mine_price dictionaries are empty (e.g., for scrap suppliers), keep existing production_cost_by_year
+        # Apply the iron-ore-premium choice and the initial scrap cost to supplier costs
+        apply_supplier_cost_config(repository.suppliers.list(), config)
 
         # Plant groups setup from SimulationRunner.setup()
         plant_groups = []

--- a/src/steelo/domain/constants.py
+++ b/src/steelo/domain/constants.py
@@ -17,6 +17,11 @@ LP_TOLERANCE = 1e-4  # Linear programming solver tolerance, values below are tre
 # ===== Hardcoded Parameters =====
 MINIMUM_UTILIZATION_RATE_FOR_COST_CURVE = 0.3
 MINIMUM_PRODUCTION_VOLUME_FOR_COST_CURVE = 50e3  # tpa; minimum production volume for a plant to have a cost curve
+INITIAL_SCRAP_PRODUCTION_COST = 333.0  # USD/t; placeholder scrap production cost written at data
+# preparation (called before the SimulationConfig is created) and re-applied at bootstrap from
+# SimulationConfig.initial_scrap_production_cost. The annual repricing in handlers.py overwrites it
+# from the second simulation year onward (falling back to the same configured value when it has no
+# cost data to price from), so only the first year is guaranteed to trade scrap at this value.
 
 # ===== Unit Conversion Factors =====
 GJ_TO_KWH = 1e3 / 3.6  # 1 GJ = 1e3/3e6 kWh and 1/3.6 MWh

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -2204,13 +2204,23 @@ class FurnaceGroup:
         """
         Debt repayment per unit of production (USD/t) or per unit of capacity if not producing.
 
+        Mirrors the unit_fopex floor: utilisation is floored at production_threshold.low so a
+        barely-producing furnace group does not spread its debt over a near-zero tonnage.
+
         Returns:
-            float: Debt repayment divided by production when utilization > 0, otherwise divided by capacity.
+            float: Debt repayment divided by floored production when utilization > 0, otherwise
+            divided by capacity.
         """
-        if self.utilization_rate > 0.0:
-            return self.debt_repayment_for_current_year / self.production
-        else:
+        if self.utilization_rate <= 0.0:
             return self.debt_repayment_for_current_year / self.capacity
+
+        threshold_low = self.production_threshold.low
+        if threshold_low is not None and threshold_low > 0:
+            effective_utilisation = max(self.utilization_rate, threshold_low)
+        else:
+            effective_utilisation = self.utilization_rate
+
+        return self.debt_repayment_for_current_year / (effective_utilisation * self.capacity)
 
     @property
     def cost_breakdown_by_feedstock(self) -> dict[str, dict[str, float]]:

--- a/src/steelo/service_layer/handlers.py
+++ b/src/steelo/service_layer/handlers.py
@@ -578,9 +578,9 @@ def finalise_iteration(
         for supplier in uow.repository.suppliers.list():
             if supplier.commodity == "scrap":
                 pricing_source = "default"
-                source_cost = 200.0  # Default scrap cost
+                source_cost = env.config.initial_scrap_production_cost  # Default when no cost data exists
                 sample_size = getattr(env, "_diag_bof_sample_count", None)
-                # Use BOF hot_metal cost if available, otherwise use hardcoded default
+                # Use BOF hot_metal cost if available, otherwise use the configured default
                 if "BOF" in env.avg_boms and "hot_metal" in env.avg_boms["BOF"]:
                     source_cost = env.avg_boms["BOF"]["hot_metal"]["unit_cost"] * 0.95
                     pricing_source = "avg_bom"
@@ -592,7 +592,7 @@ def finalise_iteration(
                         pricing_source = "fallback"
                     else:
                         # Ultimate fallback if no cost data available
-                        source_cost = 200.0
+                        source_cost = env.config.initial_scrap_production_cost
                         pricing_source = "default"
                 # Update production cost for the current year
                 supplier.production_cost_by_year[env.year] = source_cost

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -35,7 +35,7 @@ from steelo.utilities.plotting import (
 )
 from .adapters.geospatial.geospatial_statistics import aggregate_lcoe_lcoh_statistics
 from .logging_config import LoggingConfig
-from steelo.domain.constants import T_TO_KT, MT_TO_T
+from steelo.domain.constants import T_TO_KT, MT_TO_T, INITIAL_SCRAP_PRODUCTION_COST
 from steelo.domain.calculate_costs import (
     collect_subsidies_for_geo,
     filter_subsidies_for_year,
@@ -362,6 +362,11 @@ class SimulationConfig:
     # Price increase when demand exceeds supply
     steel_price_buffer: float = 200.0  # USD/tonne - buffer above highest cost curve price when demand exceeds supply
     iron_price_buffer: float = 200.0  # USD/tonne - buffer above highest cost curve price when demand exceeds supply
+
+    # Placeholder scrap production cost applied to every scrap supplier at bootstrap; the annual
+    # repricing overwrites it from the second year onward and also uses it as the default when it
+    # has no BOF cost data to price from
+    initial_scrap_production_cost: float = INITIAL_SCRAP_PRODUCTION_COST  # USD/tonne
 
     # Fraction of total capacity that participates in market clearing; above this triggers shortage buffer
     # e.g. 0.95 truncates top 5% at price-extraction; 1.0 keeps the full curve

--- a/tests/unit/test_bootstrap_supplier_costs.py
+++ b/tests/unit/test_bootstrap_supplier_costs.py
@@ -1,0 +1,69 @@
+"""Run-time supplier cost configuration applied at bootstrap (steelo.bootstrap.apply_supplier_cost_config)."""
+
+from pathlib import Path
+
+from steelo.bootstrap import apply_supplier_cost_config
+from steelo.domain.models import Location, Supplier, Volumes, Year
+from steelo.simulation import SimulationConfig
+
+
+def make_supplier(commodity, *, production_costs, mine_costs=None, mine_prices=None):
+    """One supplier of the given commodity with the given cost dictionaries."""
+    location = Location(lat=47.5, lon=14.5, country="Austria", region="Europe", iso3="AUT")
+    return Supplier(
+        supplier_id=f"{commodity}_supplier",
+        location=location,
+        commodity=commodity,
+        capacity_by_year={Year(2025): Volumes(1_000_000)},
+        production_cost_by_year=production_costs,
+        mine_cost_by_year=mine_costs or {},
+        mine_price_by_year=mine_prices or {},
+    )
+
+
+def make_config(tmp_path, **overrides):
+    """A minimal SimulationConfig with the given field overrides."""
+    return SimulationConfig(
+        start_year=Year(2025),
+        end_year=Year(2030),
+        master_excel_path=Path("test.xlsx"),
+        output_dir=tmp_path,
+        **overrides,
+    )
+
+
+def test_scrap_suppliers_get_the_configured_initial_cost(tmp_path):
+    """The prep-time placeholder is replaced for every year with the configured scrap cost."""
+    supplier = make_supplier("scrap", production_costs={Year(2025): 450.0, Year(2026): 450.0})
+    config = make_config(tmp_path, initial_scrap_production_cost=333.0)
+
+    apply_supplier_cost_config([supplier], config)
+
+    assert supplier.production_cost_by_year == {Year(2025): 333.0, Year(2026): 333.0}
+
+
+def test_mine_suppliers_follow_the_iron_ore_premium_flag(tmp_path):
+    """Mines copy mine prices with premiums enabled and mine costs without."""
+    mine_costs = {Year(2025): 40.0}
+    mine_prices = {Year(2025): 55.0}
+
+    with_premiums = make_supplier(
+        "io_low", production_costs={Year(2025): 1.0}, mine_costs=mine_costs, mine_prices=mine_prices
+    )
+    apply_supplier_cost_config([with_premiums], make_config(tmp_path, use_iron_ore_premiums=True))
+    assert with_premiums.production_cost_by_year == mine_prices
+
+    without_premiums = make_supplier(
+        "io_low", production_costs={Year(2025): 1.0}, mine_costs=mine_costs, mine_prices=mine_prices
+    )
+    apply_supplier_cost_config([without_premiums], make_config(tmp_path, use_iron_ore_premiums=False))
+    assert without_premiums.production_cost_by_year == mine_costs
+
+
+def test_other_suppliers_without_mine_costs_keep_their_costs(tmp_path):
+    """A non-scrap supplier with empty mine dictionaries keeps its prepared production costs."""
+    supplier = make_supplier("coal", production_costs={Year(2025): 80.0})
+
+    apply_supplier_cost_config([supplier], make_config(tmp_path, use_iron_ore_premiums=True))
+
+    assert supplier.production_cost_by_year == {Year(2025): 80.0}

--- a/tests/unit/test_excel_reader_demand_scenario.py
+++ b/tests/unit/test_excel_reader_demand_scenario.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from steelo.adapters.dataprocessing import excel_reader
+from steelo.domain.constants import INITIAL_SCRAP_PRODUCTION_COST
 from steelo.domain.models import Year
 
 SHEET = "Demand and scrap availability"
@@ -68,6 +69,23 @@ def test_read_scrap_as_suppliers_selects_the_requested_scenario(scenario_workboo
     """Scrap availability follows its own scenario argument."""
     assert _scrap_2025(scenario_workbook, "BAU") == {"AUT": 10 * KT_TO_T, "PRT": 10 * KT_TO_T}
     assert _scrap_2025(scenario_workbook, "China-high") == {"AUT": 20 * KT_TO_T, "PRT": 20 * KT_TO_T}
+
+
+def test_read_scrap_as_suppliers_bootstraps_the_shared_placeholder_cost(scenario_workbook):
+    """Every scrap supplier starts every horizon year at the shared placeholder cost."""
+    excel_path, location_csv, gravity_path = scenario_workbook
+    suppliers = excel_reader.read_scrap_as_suppliers(
+        str(excel_path),
+        SHEET,
+        str(location_csv),
+        gravity_distances_pkl_path=gravity_path,
+        scrap_scenario="BAU",
+    )
+    assert suppliers
+    for supplier in suppliers:
+        assert set(supplier.production_cost_by_year.values()) == {INITIAL_SCRAP_PRODUCTION_COST}
+        assert min(supplier.production_cost_by_year) == excel_reader.EXCEL_READER_START_YEAR
+        assert max(supplier.production_cost_by_year) == excel_reader.EXCEL_READER_END_YEAR
 
 
 def test_unknown_scenario_fails_listing_available_names(scenario_workbook):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -461,6 +461,26 @@ def test_unit_fopex_uses_minimum_utilization_threshold():
     assert fg.unit_fopex == pytest.approx(80.0 / 0.5)
 
 
+def test_unit_current_debt_repayment_uses_minimum_utilization_threshold():
+    """Debt repayment per tonne floors utilisation at the low threshold, mirroring unit_fopex."""
+    fg = get_furnace_group(utilization_rate=0.01, fg_id="fg_low_util_debt", tech_name="BOF")
+    fg.technology.capex = 500.0
+    fg.production_threshold = ProductionThreshold(low=0.1, high=0.95)
+    debt = fg.debt_repayment_for_current_year
+    assert debt > 0
+
+    # Utilisation below the configured low threshold should clamp to the threshold value
+    assert fg.unit_current_debt_repayment == pytest.approx(debt / (0.1 * fg.capacity))
+
+    # Adjusting the threshold should change the clamped result accordingly
+    fg.production_threshold = ProductionThreshold(low=0.02, high=0.95)
+    assert fg.unit_current_debt_repayment == pytest.approx(debt / (0.02 * fg.capacity))
+
+    # For utilisations above the threshold, the raw production is used
+    fg.utilization_rate = 0.5
+    assert fg.unit_current_debt_repayment == pytest.approx(debt / fg.production)
+
+
 @pytest.fixture
 def multi_furnace_groups():
     return [


### PR DESCRIPTION
**Scrap bootstrap price.** Year 1 traded scrap at a hardcoded 450 USD/t (annual repricing only starts in year 2), driving the 2025 iron overshoot and the 2025→26 cliff. The placeholder is now `SimulationConfig.initial_scrap_production_cost` (default 333, single constant `INITIAL_SCRAP_PRODUCTION_COST`), applied to every scrap supplier at bootstrap and used as the repricing's no-data default. Pre/post-fix runs are no longer comparable in 2025.

**Debt-repayment floor.** `unit_current_debt_repayment` now floors utilisation at `production_threshold.low` (default 0.1), mirroring `unit_fopex`, so near-idle furnace groups no longer book runaway per-tonne debt.