### PR TITLE
Add a metallic charge use viewer and a steel demand overlay on the capacity viewer

### DIFF
--- a/docs/domain_simulation_logic/outputs_and_postprocessing.md
+++ b/docs/domain_simulation_logic/outputs_and_postprocessing.md
@@ -88,12 +88,13 @@ All viewers share one shell (`common.js` / `common.css`): a run selector, a geog
 | Viewer | Shows | Data source |
 |--------|-------|-------------|
 | `emissions.html` | Furnace-group emissions with direct / indirect / incl.-biogenic scope tickboxes, for every emissions boundary in the table, stacked by technology or region, annual or cumulative-to-year | `post_processed_<timestamp>.csv` |
-| `capacity_and_production.html` | Capacity and production over time, with a capacity-vs-production compare mode | `post_processed_<timestamp>.csv` |
+| `capacity_and_production.html` | Capacity and production over time, with a capacity-vs-production compare mode and a steel demand overlay | `post_processed_<timestamp>.csv` + `fixtures/demand_centers.json` |
 | `cost_curves.html` | Per-commodity cost curves with the engine's market-clearing rule (clearing shares and price buffers from the run config) | `post_processed_<timestamp>.csv` + `data/market_prices_<start>_<end>.csv` |
 | `trade_matrix.html` | Steel, iron products, iron ore (mine-labelled origins) and scrap shipped between geographies, per year, each product selectable individually | `TM/steel_trade_allocations_<year>.csv` |
 | `trade_network.html` | The same trade flows as a chord diagram with a map layout | `TM/steel_trade_allocations_<year>.csv` |
 | `supply_demand.html` | Supply and demand for steel, scrap, iron ore, CO2 storage and biomass | `TM/` allocations + `fixtures/suppliers.json` + `fixtures/biomass_availability.json` |
 | `reductant_use.html` | Iron production and absolute reductant use per reductant | `post_processed_<timestamp>.csv` + `fixtures/primary_feedstocks.json` |
+| `metallic_charge_use.html` | Metallic charges fed into steel (scrap, hot metal, pig iron, DRI/HBI) and iron (ore grades), per charge / technology / region, with a local scrap supply overlay | `post_processed_<timestamp>.csv` + `fixtures/primary_feedstocks.json` + `fixtures/suppliers.json` |
 
 A missing input file skips that viewer with a warning instead of failing the plot stage.
 

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -1502,8 +1502,12 @@ class SimulationRunner:
                 if self.config.data_dir
                 else None,
             )
+            fixtures_dir = self.config.data_dir / "fixtures" if self.config.data_dir else None
             interactive.plot_emissions(post_processed_csv=Path(output_path))
-            interactive.plot_capacity_and_production(post_processed_csv=Path(output_path))
+            interactive.plot_capacity_and_production(
+                post_processed_csv=Path(output_path),
+                demand_centers_json=fixtures_dir / "demand_centers.json" if fixtures_dir else None,
+            )
             interactive.plot_cost_curves(
                 post_processed_csv=Path(output_path),
                 market_prices_csv=self.config.output_dir / "data" / f"market_prices_{start_year}_{end_year}.csv",
@@ -1517,7 +1521,6 @@ class SimulationRunner:
             )
             interactive.plot_trade_matrix(tm_dir=self.config.output_dir / "TM")
             interactive.plot_trade_network(tm_dir=self.config.output_dir / "TM")
-            fixtures_dir = self.config.data_dir / "fixtures" if self.config.data_dir else None
             interactive.plot_supply_demand(
                 tm_dir=self.config.output_dir / "TM",
                 suppliers_json=fixtures_dir / "suppliers.json" if fixtures_dir else None,
@@ -1526,6 +1529,11 @@ class SimulationRunner:
             interactive.plot_reductant_use(
                 post_processed_csv=Path(output_path),
                 primary_feedstocks_json=fixtures_dir / "primary_feedstocks.json" if fixtures_dir else None,
+            )
+            interactive.plot_metallic_charge_use(
+                post_processed_csv=Path(output_path),
+                primary_feedstocks_json=fixtures_dir / "primary_feedstocks.json" if fixtures_dir else None,
+                suppliers_json=fixtures_dir / "suppliers.json" if fixtures_dir else None,
             )
 
         # Aggregate per-year LCOE/LCOH statistics into stacked CSVs

--- a/src/steelo/utilities/interactive/capacity_and_production.html
+++ b/src/steelo/utilities/interactive/capacity_and_production.html
@@ -37,6 +37,9 @@ window.addEventListener("error", function(e) {
       <option value="region">Region</option>
     </select>
   </div>
+  <div id="demand-panel">
+    <label class="inline" id="demand-label"><input type="checkbox" id="demand-toggle">Steel demand</label>
+  </div>
 </div>
 <div class="toolbar" id="shared-filters"></div>
 <div id="summary"></div>
@@ -110,6 +113,15 @@ function render() {
   const selectedGeo = Interactive.selectedGeos(), selectedTech = Interactive.selectedTechs();
   const gd = document.getElementById("chart");
 
+  // The steel demand overlay needs demand data and the steel product (demand centres
+  // order steel only).
+  const demand = run.demand || [];
+  document.getElementById("demand-panel").style.display = demand.length ? "" : "none";
+  const demandToggle = document.getElementById("demand-toggle");
+  demandToggle.disabled = product !== "steel";
+  document.getElementById("demand-label").title = product === "steel" ? "" : "Only available for steel";
+  const showDemand = demand.length > 0 && demandToggle.checked && product === "steel";
+
   const years = [...new Set(run.rows.map(r => r.y))].sort((a, b) => a - b);
   const yearIdx = new Map(years.map((y, i) => [y, i]));
   const rows = run.rows.filter(r => r.p === product && selectedGeo.has(r.g) && selectedTech.has(r.t));
@@ -129,7 +141,7 @@ function render() {
   const compare = metricId === "compare";
   const metrics = compare ? [METRICS.capacity, METRICS.production] : [METRICS[metricId]];
   const keys = [...series.keys()].filter(k => metrics.some(m => series.get(k)[m.field].some(v => v !== 0))).sort();
-  if (!keys.length) {
+  if (!keys.length && !showDemand) {
     Interactive.showEmpty(gd, `No ${product} ${compare ? "capacity or production" : metricId} for this selection`, WIDTH, HEIGHT);
     Interactive.summary("0 furnace groups");
     return;
@@ -145,12 +157,35 @@ function render() {
     hovertemplate: m.field === "pr" ? "<b>%{y:.1f} Mt</b> · %{customdata:.0f}% of capacity" : "<b>%{y:.1f} Mt</b>",
   }));
 
+  // Demand centres carry no sub-national geography, so the overlay counts a country's
+  // demand once any of its geo units is selected; "met" compares the chart's own
+  // production total against that demand.
+  let demandLast = null, metLast = null;
+  if (showDemand) {
+    const selCountries = new Set([...selectedGeo].map(Interactive.isoOf));
+    const byYear = new Map(years.map(y => [y, null]));
+    demand.forEach(s => {
+      if (!selCountries.has(s.g) || !byYear.has(s.y)) return;
+      byYear.set(s.y, (byYear.get(s.y) || 0) + s.v);
+    });
+    const values = years.map(y => byYear.get(y));
+    const met = values.map((v, i) => v > 0 ? Math.round(100 * totals.pr[i] / v) : null);
+    demandLast = values[values.length - 1];
+    metLast = met[met.length - 1];
+    traces.push({
+      type: "scatter", mode: "lines", x: years, y: values, customdata: met,
+      name: "Steel demand", line: {width: 2, color: T.ink, dash: "dash"}, fill: "none",
+      legendrank: 2000, hovertemplate: "%{y:.1f} Mt (%{customdata}% met)",
+    });
+  }
+
   const groupLabel = groupBy === "technology" ? "Technology" : "Region";
   const metricTitle = compare ? "capacity vs production" : metricId;
   const runGeos = new Set(run.rows.map(r => r.g));
   const subtitle = [run.title, Interactive.geoNote(runGeos)]
-    .concat(compare ? ["solid = production, lighter = idle capacity, stack top = capacity"] : []).join(" · ");
-  const margin = {...MARGIN, r: 12 + Interactive.legendWidth(keys)};
+    .concat(compare ? ["solid = production, lighter = idle capacity, stack top = capacity"] : [])
+    .concat(showDemand ? ["dashed = steel demand (country-level)"] : []).join(" · ");
+  const margin = {...MARGIN, r: 12 + Interactive.legendWidth(keys.concat(showDemand ? ["Steel demand"] : []))};
   const layout = {
     title: {text: `${capitalise(product)} ${metricTitle} by ${groupLabel}<br><sup>${subtitle}</sup>`,
             font: {color: T.ink, size: 17}, x: 0.05},
@@ -178,13 +213,18 @@ function render() {
   Interactive.summary(
     `${selCountries} of ${nCountries} countries · ${selTechs} of ${productTechs.length} ${product} technologies · ` +
     `${fgs} furnace groups, ${totals.pr[last].toFixed(0)} Mt produced on ${totals.cap[last].toFixed(0)} Mt capacity ` +
-    `(${utilisation[last].toFixed(0)}%) in ${years[last]}\n${run.provenance}`);
+    `(${utilisation[last].toFixed(0)}%) in ${years[last]}` +
+    (demandLast !== null ? ` · ${demandLast.toFixed(0)} Mt steel demand${metLast !== null ? ` (${metLast}% met)` : ""}` : "") +
+    `\n${run.provenance}`);
 }
 
-["product-select", "metric-select", "group-select"].forEach(id =>
+["product-select", "metric-select", "group-select", "demand-toggle"].forEach(id =>
   document.getElementById(id).addEventListener("change", render));
+/* The geography filter lists every country with capacity or steel demand, so the
+   overlay can count demand arising where nothing is produced. */
 const allRows = Object.values(DATA).flatMap(d => d.rows);
-Interactive.init({geoKeys: allRows.map(r => r.g), techs: allRows.map(r => r.t), onChange: render});
+const allGeos = allRows.map(r => r.g).concat(Object.values(DATA).flatMap(d => (d.demand || []).map(s => s.g)));
+Interactive.init({geoKeys: allGeos, techs: allRows.map(r => r.t), onChange: render});
 Interactive.onResize(render);
 render();
 </script>

--- a/src/steelo/utilities/interactive/capacity_production.py
+++ b/src/steelo/utilities/interactive/capacity_production.py
@@ -2,12 +2,16 @@
 
 The viewer shows steel or iron capacity, production, or both on one chart
 (solid production over hatched capacity), stacked by technology or region,
-with the shell's geography and technology filters.
+with the shell's geography and technology filters. An optional overlay
+compares the steel chart against the prepared demand centres' steel demand
+— the demand the trade LP is asked to serve — which is country-level.
 """
 
-from typing import Any
+from typing import Any, Iterable
 
 import pandas as pd
+
+from steelo.domain.models import DemandCenter
 
 from .post_processed import aggregate_furnace_groups
 
@@ -60,3 +64,46 @@ def pack_rows(aggregated: pd.DataFrame) -> list[dict[str, Any]]:
         }
         for row in aggregated.to_dict("records")
     ]
+
+
+def steel_demand_rows(demand_centers: Iterable[DemandCenter], years: set[int]) -> pd.DataFrame:
+    """Steel demand per year and country, from the prepared demand centres.
+
+    The demand centres carry the demand the trade LP is asked to serve, so the sum
+    matches the engine's steel demand even in years where the LP leaves centres
+    unserved (which drop out of the allocation files).
+
+    Args:
+        demand_centers: The prepared demand centres (``fixtures/demand_centers.json``).
+        years: The years to keep (the table's years).
+
+    Returns:
+        Columns ``year, geo, volume_mt``. Demand centres carry no sub-national
+        geography, so ``geo`` is always a country.
+    """
+    rows = [
+        (int(year), centre.center_of_gravity.iso3, float(volume) / 1e6)
+        for centre in demand_centers
+        for year, volume in centre.demand_by_year.items()
+        if int(year) in years
+    ]
+    demand = pd.DataFrame(rows, columns=["year", "geo", "volume_mt"])
+    return demand.groupby(["year", "geo"], as_index=False)[["volume_mt"]].sum()
+
+
+def pack_demand(steel_demand: pd.DataFrame) -> list[dict[str, Any]]:
+    """Compact steel-demand rows for embedding in the viewer.
+
+    Args:
+        steel_demand: Output of :func:`steel_demand_rows`.
+
+    Returns:
+        One short-keyed record per row: ``y`` year, ``g`` country and ``v`` demand
+        (Mt, four decimals). Rows that round to zero are dropped.
+    """
+    rows = []
+    for row in steel_demand.to_dict("records"):
+        volume = round(float(row["volume_mt"]), 4)
+        if volume > 0:
+            rows.append({"y": int(row["year"]), "g": row["geo"], "v": volume})
+    return rows

--- a/src/steelo/utilities/interactive/interactive_plots.py
+++ b/src/steelo/utilities/interactive/interactive_plots.py
@@ -25,7 +25,15 @@ from plotly.offline import get_plotlyjs
 from steelo.domain.models import CountryMapping
 from steelo.utilities.plotting import region2colours, tech2colours
 
-from . import capacity_production, cost_curves, emissions, reductant_use, supply_demand, trade_matrix
+from . import (
+    capacity_production,
+    cost_curves,
+    emissions,
+    metallic_charge_use,
+    reductant_use,
+    supply_demand,
+    trade_matrix,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -105,11 +113,12 @@ class InteractivePlotter:
     Example:
         >>> interactive = InteractivePlotter(plots_dir, country_mappings, run_title="sim_2026")
         >>> interactive.plot_emissions(post_processed_csv)
-        >>> interactive.plot_capacity_and_production(post_processed_csv)
+        >>> interactive.plot_capacity_and_production(post_processed_csv, demand_centers_json)
         >>> interactive.plot_cost_curves(post_processed_csv, market_prices_csv, clearing)
         >>> interactive.plot_trade_matrix(tm_dir)
         >>> interactive.plot_trade_network(tm_dir)
         >>> interactive.plot_reductant_use(post_processed_csv, primary_feedstocks_json)
+        >>> interactive.plot_metallic_charge_use(post_processed_csv, primary_feedstocks_json, suppliers_json)
     """
 
     SUBDIR = "interactive"
@@ -174,16 +183,24 @@ class InteractivePlotter:
         logger.info("Wrote emissions viewer %s (%d aggregated rows)", path, len(aggregated))
         return path
 
-    def plot_capacity_and_production(self, post_processed_csv: Path) -> Optional[Path]:
+    def plot_capacity_and_production(
+        self, post_processed_csv: Path, demand_centers_json: Optional[Path] = None
+    ) -> Optional[Path]:
         """Write the capacity and production viewer (``capacity_and_production.html``).
 
         Args:
             post_processed_csv: The run's ``post_processed_<timestamp>.csv``.
+            demand_centers_json: The prepared ``fixtures/demand_centers.json``, for the
+                steel demand overlay — the demand the trade LP is asked to serve, per
+                year and country. None (or a missing file) omits the overlay with a
+                warning.
 
         Returns:
             The written path, or None when the table is missing or lacks the capacity or
             production column (logged as warnings so the plot stage never fails).
         """
+        from steelo.adapters.repositories.json_repository import DemandCenterJsonRepository
+
         table = self._read_post_processed(post_processed_csv, "capacity and production")
         if table is None:
             return None
@@ -192,11 +209,25 @@ class InteractivePlotter:
         except ValueError as exc:
             logger.warning("%s — skipping the capacity and production viewer", exc)
             return None
+
+        steel_demand = pd.DataFrame(columns=["year", "geo", "volume_mt"])
+        demand_source = ""
+        if demand_centers_json is not None and demand_centers_json.is_file():
+            centres = DemandCenterJsonRepository(demand_centers_json).list()
+            years = {int(year) for year in aggregated["year"]}
+            steel_demand = capacity_production.steel_demand_rows(centres, years)
+            demand_source = "; steel demand from fixtures/demand_centers.json"
+        else:
+            logger.warning(
+                "No demand centres fixture at %s — steel demand omitted from the capacity and production viewer",
+                demand_centers_json,
+            )
         data = {
             self.run_title: {
                 "title": self.run_title,
-                "provenance": f"Furnace-group capacity and production from {post_processed_csv.name}.",
+                "provenance": f"Furnace-group capacity and production from {post_processed_csv.name}{demand_source}.",
                 "rows": capacity_production.pack_rows(aggregated),
+                "demand": capacity_production.pack_demand(steel_demand),
             },
         }
         path = self._write("capacity_and_production.html", self._config("Capacity and production"), data)
@@ -468,6 +499,86 @@ class InteractivePlotter:
         path = self._write("reductant_use.html", config, data)
         logger.info(
             "Wrote reductant-use viewer %s (%d aggregated rows, %d carriers)", path, len(aggregated), len(carriers)
+        )
+        return path
+
+    def plot_metallic_charge_use(
+        self,
+        post_processed_csv: Path,
+        primary_feedstocks_json: Optional[Path] = None,
+        suppliers_json: Optional[Path] = None,
+    ) -> Optional[Path]:
+        """Write the metallic charge use viewer (``metallic_charge_use.html``).
+
+        The viewer shows the metallic charges steelmakers and ironmakers feed into
+        their products, from the table's per-feedstock allocation rows (a furnace
+        group running several charges at different shares contributes each share to
+        its own charge), with an optional local scrap supply overlay.
+
+        Args:
+            post_processed_csv: The run's ``post_processed_<timestamp>.csv``, whose
+                feedstock rows carry each furnace group's per-charge demand.
+            primary_feedstocks_json: The prepared ``fixtures/primary_feedstocks.json``
+                (the Bill of Materials), whose ``metallic_charge`` fields identify
+                which feedstock rows are charges. Required — None (or a missing file)
+                skips the viewer with a warning.
+            suppliers_json: The prepared ``fixtures/suppliers.json``, for the local
+                scrap supply overlay. None (or a missing file) omits the overlay
+                with a warning.
+
+        Returns:
+            The written path, or None when the table or the Bill of Materials is
+            missing, or a required column is absent (logged as warnings so the plot
+            stage never fails).
+        """
+        from steelo.adapters.repositories.json_repository import PrimaryFeedstockJsonRepository, SupplierJsonRepository
+
+        table = self._read_post_processed(post_processed_csv, "metallic-charge")
+        if table is None:
+            return None
+        if primary_feedstocks_json is None or not primary_feedstocks_json.is_file():
+            logger.warning(
+                "No primary feedstocks fixture at %s — skipping the metallic-charge viewer (charges "
+                "cannot be identified without the Bill of Materials)",
+                primary_feedstocks_json,
+            )
+            return None
+        feedstocks = PrimaryFeedstockJsonRepository(primary_feedstocks_json).list()
+        try:
+            aggregated = metallic_charge_use.aggregate_charge_use(table, feedstocks)
+        except ValueError as exc:
+            logger.warning("%s — skipping the metallic-charge viewer", exc)
+            return None
+
+        suppliers = []
+        if suppliers_json is not None and suppliers_json.is_file():
+            suppliers = SupplierJsonRepository(suppliers_json).list()
+        else:
+            logger.warning("No suppliers fixture at %s — local scrap supply overlay omitted", suppliers_json)
+        years = {int(year) for year in aggregated["year"]}
+        supply = metallic_charge_use.scrap_supply_rows(suppliers, self.country_mappings, years)
+
+        data = {
+            self.run_title: {
+                "title": self.run_title,
+                "provenance": f"Per-feedstock charge allocations from {post_processed_csv.name}; charges "
+                "identified by the Bill of Materials (fixtures/primary_feedstocks.json); local scrap "
+                "supply from fixtures/suppliers.json.",
+                "rows": metallic_charge_use.pack_rows(aggregated),
+                "supply": metallic_charge_use.pack_supply(supply),
+            },
+        }
+        config = self._config(
+            "Metallic charge use",
+            chargeColours=metallic_charge_use.CHARGE_COLOURS,
+            chargeOrder=metallic_charge_use.CHARGE_ORDER,
+        )
+        path = self._write("metallic_charge_use.html", config, data)
+        logger.info(
+            "Wrote metallic-charge viewer %s (%d aggregated rows, %d scrap supply rows)",
+            path,
+            len(aggregated),
+            len(supply),
         )
         return path
 

--- a/src/steelo/utilities/interactive/metallic_charge_use.html
+++ b/src/steelo/utilities/interactive/metallic_charge_use.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Metallic charge use</title>
+<style>__COMMON_CSS__</style>
+<style>
+/* Charge tick row, styled like the shell's technology row (#tech-panel). */
+#charge-panel { display: flex; align-items: center; gap: 4px 14px; flex-wrap: wrap; padding: 2px 40px 0; }
+#charge-panel > label { font-size: 12px; color: #52514e; margin: 0; }
+#charge-boxes { display: inline-flex; flex-wrap: wrap; gap: 2px 14px; }
+#charge-boxes label { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: #0b0b0b;
+                      margin: 0; cursor: pointer; white-space: nowrap; }
+</style>
+</head>
+<body>
+<div id="err"></div>
+<script>
+window.addEventListener("error", function(e) {
+  const el = document.getElementById("err");
+  el.style.display = "block";
+  el.textContent = "Load error: " + (e.message || e.type) + (e.filename ? " @ " + e.lineno : "");
+}, true);
+</script>
+<div class="toolbar">
+  <div>
+    <label for="product-select">Product</label>
+    <select id="product-select">
+      <option value="steel">Steel</option>
+      <option value="iron">Iron</option>
+    </select>
+  </div>
+  <div>
+    <label for="group-select">Stack by</label>
+    <select id="group-select">
+      <option value="charge">Charge</option>
+      <option value="technology">Technology</option>
+      <option value="region">Region</option>
+    </select>
+  </div>
+  <div>
+    <label for="display-select">Display</label>
+    <select id="display-select">
+      <option value="absolute">Absolute</option>
+      <option value="share">Share (%)</option>
+    </select>
+  </div>
+  <div id="supply-panel">
+    <label class="inline" id="supply-label"><input type="checkbox" id="supply-toggle">Local scrap supply</label>
+  </div>
+</div>
+<div id="charge-panel">
+  <label>Charges
+    <button id="charge-all" class="small-btn">All</button>
+    <button id="charge-none" class="small-btn">None</button>
+  </label>
+  <div id="charge-boxes"></div>
+</div>
+<div class="toolbar" id="shared-filters"></div>
+<div id="summary"></div>
+<div id="chart"></div>
+<script>__PLOTLYJS__</script>
+<script>
+const CONFIG = __CONFIG__;
+const DATA = __DATA__;
+</script>
+<script>__COMMON_JS__</script>
+<script>
+const MAX_WIDTH = 1280, MAX_HEIGHT = 720;
+const MARGIN = {l: 70, t: 90, b: 60};  // right margin is sized per render to fit the legend
+const FILL_ALPHA = 0.85;
+const T = Interactive.theme;
+const CHARGE_ORDER = CONFIG.chargeOrder || [];
+
+function capitalise(text) { return text.charAt(0).toUpperCase() + text.slice(1); }
+
+/* Charges sort in the house order (grades high → low), unknown ones after, alphabetically. */
+function orderIndex(charge) {
+  const i = CHARGE_ORDER.indexOf(charge);
+  return i === -1 ? CHARGE_ORDER.length : i;
+}
+function chargeSort(a, b) { return orderIndex(a) - orderIndex(b) || a.localeCompare(b); }
+
+/* ---- charge filter: ticks for the charges that contribute to the current product
+   and run, rebuilt on change; unticked choices are remembered across both. ---- */
+const chargeCbs = new Map();
+const untickedCharges = new Set();
+
+function relevantCharges(run, product) {
+  const present = new Set();
+  run.rows.forEach(r => { if (r.p === product && r.v !== 0) present.add(r.c); });
+  return [...present].sort(chargeSort);
+}
+
+function syncChargeBoxes(relevant) {
+  if (relevant.join("|") === [...chargeCbs.keys()].join("|")) return;
+  const boxes = document.getElementById("charge-boxes");
+  boxes.innerHTML = "";
+  chargeCbs.clear();
+  relevant.forEach(name => {
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.checked = !untickedCharges.has(name);
+    cb.addEventListener("change", () => {
+      untickedCharges[cb.checked ? "delete" : "add"](name);
+      render();
+    });
+    const label = document.createElement("label");
+    label.appendChild(cb);
+    label.appendChild(document.createTextNode(name));
+    boxes.appendChild(label);
+    chargeCbs.set(name, cb);
+  });
+}
+
+function selectedCharges() {
+  return new Set([...chargeCbs].filter(([, cb]) => cb.checked).map(([name]) => name));
+}
+
+function setAllCharges(checked) {
+  chargeCbs.forEach((cb, name) => {
+    cb.checked = checked;
+    untickedCharges[checked ? "delete" : "add"](name);
+  });
+  render();
+}
+
+function render() {
+  const {width: WIDTH, height: HEIGHT} = Interactive.plotSize(MAX_WIDTH, MAX_HEIGHT);
+  const run = DATA[Interactive.run()];
+  const product = document.getElementById("product-select").value;
+  const groupBy = document.getElementById("group-select").value;
+  const share = document.getElementById("display-select").value === "share";
+  const selectedGeo = Interactive.selectedGeos(), selectedTech = Interactive.selectedTechs();
+  const gd = document.getElementById("chart");
+
+  // The supply overlay needs supply data and the absolute display (a same-axis line
+  // cannot ride a percent-normalised stack).
+  const supply = run.supply || [];
+  document.getElementById("supply-panel").style.display = supply.length ? "" : "none";
+  const supplyToggle = document.getElementById("supply-toggle");
+  supplyToggle.disabled = share;
+  document.getElementById("supply-label").title = share ? "Only available on the absolute display" : "";
+  const showSupply = supply.length && supplyToggle.checked && !share;
+
+  const relevant = relevantCharges(run, product);
+  syncChargeBoxes(relevant);
+  const selectedCharge = selectedCharges();
+
+  const years = [...new Set(run.rows.map(r => r.y))].sort((a, b) => a - b);
+  const yearIdx = new Map(years.map((y, i) => [y, i]));
+  const rows = run.rows.filter(r =>
+    r.p === product && selectedCharge.has(r.c) && selectedGeo.has(r.g) && selectedTech.has(r.t));
+  const keyOf = {charge: r => r.c, technology: r => r.t, region: r => Interactive.regionOf(r.g)}[groupBy];
+
+  const series = new Map();  // key -> use per year
+  const totals = years.map(() => 0);
+  rows.forEach(r => {
+    const key = keyOf(r), yi = yearIdx.get(r.y);
+    if (!series.has(key)) series.set(key, years.map(() => 0));
+    series.get(key)[yi] += r.v;
+    totals[yi] += r.v;
+  });
+
+  const keys = [...series.keys()].filter(k => series.get(k).some(v => v !== 0))
+    .sort(groupBy === "charge" ? chargeSort : undefined);
+  if (!keys.length && !showSupply) {
+    Interactive.showEmpty(gd, `No ${product} metallic charge use for this selection`, WIDTH, HEIGHT);
+    Interactive.summary("0 furnace groups");
+    return;
+  }
+  const colourHouse = {charge: CONFIG.chargeColours || {}, technology: CONFIG.techColours,
+                       region: CONFIG.regionColours}[groupBy];
+  const colours = Interactive.colourTable(colourHouse, keys);
+
+  const traces = keys.map((key, order) => ({
+    type: "scatter", mode: "lines", x: years, y: series.get(key),
+    name: key, legendgroup: key, legendrank: 1000 - order,
+    stackgroup: "use", groupnorm: share ? "percent" : "",
+    line: {width: 0, color: colours[key]},
+    fillcolor: Interactive.hexToRgba(colours[key], FILL_ALPHA),
+    hovertemplate: share ? "%{y:.1f}%" : "%{y:.1f} Mt",
+  }));
+  if (!share && keys.length) {
+    // Hover-only total; the unified hover orders items by legendrank, so it lists last.
+    traces.push({
+      type: "scatter", mode: "lines", x: years, y: totals,
+      name: "Total", line: {width: 0}, fill: "none", showlegend: false, legendrank: 3000,
+      hovertemplate: "<b>%{y:.1f} Mt</b>",
+    });
+  }
+
+  // Scrap suppliers carry no sub-national geography, so the overlay counts a country's
+  // supply once any of its geo units is selected.
+  let supplyLast = null;
+  if (showSupply) {
+    const selCountries = new Set([...selectedGeo].map(Interactive.isoOf));
+    const byYear = new Map(years.map(y => [y, null]));
+    supply.forEach(s => {
+      if (!selCountries.has(s.g) || !byYear.has(s.y)) return;
+      byYear.set(s.y, (byYear.get(s.y) || 0) + s.v);
+    });
+    const values = years.map(y => byYear.get(y));
+    supplyLast = values[values.length - 1];
+    traces.push({
+      type: "scatter", mode: "lines", x: years, y: values,
+      name: "Local scrap supply", line: {width: 2, color: T.ink, dash: "dash"}, fill: "none",
+      legendrank: 2000, hovertemplate: "%{y:.1f} Mt",
+    });
+  }
+
+  const groupLabel = {charge: "charge", technology: "technology", region: "region"}[groupBy];
+  const runGeos = new Set(run.rows.map(r => r.g));
+  const subtitle = [run.title, Interactive.geoNote(runGeos)]
+    .concat(showSupply ? ["dashed = local scrap supply (country-level)"] : []).join(" · ");
+  const legendLabels = keys.concat(showSupply ? ["Local scrap supply"] : []);
+  const margin = {...MARGIN, r: 12 + Interactive.legendWidth(legendLabels)};
+  const layout = {
+    title: {text: `${capitalise(product)} metallic charge use by ${groupLabel}<br><sup>${subtitle}</sup>`,
+            font: {color: T.ink, size: 17}, x: 0.05},
+    xaxis: {title: {text: "Year"}, range: [years[0], years[years.length - 1]], dtick: years.length > 12 ? 5 : 1,
+            gridcolor: T.grid, zeroline: false, showspikes: true, spikemode: "across", spikethickness: 1,
+            spikecolor: T.inkSecondary},
+    yaxis: {title: {text: share ? "Metallic charge use share (%)" : "Metallic charge use (Mt)"},
+            gridcolor: T.grid, zeroline: true, zerolinecolor: T.ink, zerolinewidth: 1, rangemode: "tozero"},
+    legend: {x: 1 + 12 / (WIDTH - margin.l - margin.r), xanchor: "left", y: 1, yanchor: "top",
+             font: {size: 11}, bgcolor: T.surface},
+    hovermode: "x unified",
+    hoverlabel: {align: "left", font: {size: 11}, bgcolor: "#fff"},
+    font: {family: "Helvetica Neue, Helvetica, Arial", color: T.inkSecondary, size: 11},
+    paper_bgcolor: T.surface, plot_bgcolor: T.surface,
+    width: WIDTH, height: HEIGHT, margin,
+  };
+  Plotly.react(gd, traces, layout, {displaylogo: false, responsive: false});
+
+  const last = years.length - 1;
+  const fgs = rows.filter(r => r.y === years[last]).reduce((s, r) => s + r.n, 0);
+  const nCountries = new Set(Interactive.geoKeys().map(Interactive.isoOf)).size;
+  const selCountries = new Set([...selectedGeo].map(Interactive.isoOf)).size;
+  const productTechs = [...new Set(run.rows.filter(r => r.p === product).map(r => r.t))];
+  const selTechs = productTechs.filter(t => selectedTech.has(t)).length;
+  Interactive.summary(
+    `${selCountries} of ${nCountries} countries · ${selTechs} of ${productTechs.length} ${product} technologies · ` +
+    `${selectedCharge.size} of ${relevant.length} charges · ${fgs} furnace groups, ` +
+    `${totals[last].toFixed(1)} Mt charged in ${years[last]}` +
+    (supplyLast !== null ? ` · ${supplyLast.toFixed(1)} Mt local scrap supply` : "") +
+    `\n${run.provenance}`);
+}
+
+["product-select", "group-select", "display-select", "supply-toggle"].forEach(id =>
+  document.getElementById(id).addEventListener("change", render));
+document.getElementById("charge-all").addEventListener("click", () => setAllCharges(true));
+document.getElementById("charge-none").addEventListener("click", () => setAllCharges(false));
+/* The geography filter lists every country with charge use or scrap supply, so the
+   overlay can count supply arising where nothing is charged. */
+const allRows = Object.values(DATA).flatMap(d => d.rows);
+const allGeos = allRows.map(r => r.g).concat(Object.values(DATA).flatMap(d => (d.supply || []).map(s => s.g)));
+Interactive.init({geoKeys: allGeos, techs: allRows.map(r => r.t), onChange: render});
+Interactive.onResize(render);
+render();
+</script>
+</body>
+</html>

--- a/src/steelo/utilities/interactive/metallic_charge_use.py
+++ b/src/steelo/utilities/interactive/metallic_charge_use.py
@@ -1,0 +1,206 @@
+"""Row packing for the metallic charge use viewer (``metallic_charge_use.html``).
+
+The viewer shows the metallic charges steelmakers and ironmakers feed into
+their products — scrap, hot metal, pig iron and the DRI/HBI grades into
+steel; the iron ore grades into iron — stacked by charge, technology or
+region, with the shell's geography and technology filters. A furnace group
+can run on several charges at different shares, so quantities come from the
+table's per-feedstock allocation rows (one row per furnace group, year and
+feedstock) rather than from the deduplicated furnace-group rows the other
+viewers aggregate.
+
+Which feedstock rows count as metallic charges is decided by the Bill of
+Materials, as the static chart's collector decides it: a row counts when its
+feedstock is the ``metallic_charge`` of one of its technology's primary
+feedstock entries. Reductant procurement rows (e.g. ``bio_pci``) are no
+technology's metallic charge and drop out. An optional overlay compares the
+chart against the local scrap supply — the prepared scrap suppliers'
+capacity, which is country-level.
+"""
+
+import logging
+from typing import Any, Iterable
+
+import pandas as pd
+
+from steelo.domain.models import CountryMapping, PrimaryFeedstock, Supplier
+
+from .post_processed import GEO_COLUMNS
+from .supply_demand import geo_resolver
+
+logger = logging.getLogger(__name__)
+
+AGGREGATION_KEYS = ["year", "geo", "technology", "product", "charge"]
+
+# House colours per charge: the static plotter's metallic-charge palette for the
+# steel-side charges and its ore-quality palette for the iron-side ones. Charges
+# not listed get the shell's stable fallback colours.
+CHARGE_COLOURS = {
+    "scrap": "#708090",
+    "hot_metal": "#696969",
+    "liquid_iron": "#4A4A4A",
+    "pig_iron": "#2F4F4F",
+    "dri_high": "#1F4E79",
+    "dri_mid": "#4682B4",
+    "dri_low": "#B0C4DE",
+    "hbi_high": "#3A8FBF",
+    "hbi_mid": "#87CEEB",
+    "hbi_low": "#CFE7F5",
+    "electrolytic_iron": "#7B68EE",
+    "io_high": "#654321",
+    "io_mid": "#A0522D",
+    "io_low": "#CD853F",
+}
+
+# Tick, stacking and legend order (grades grouped high → low rather than
+# alphabetically); charges not listed follow alphabetically.
+CHARGE_ORDER = list(CHARGE_COLOURS)
+
+
+def technology_charges(primary_feedstocks: Iterable[PrimaryFeedstock]) -> pd.DataFrame:
+    """The Bill of Materials' (technology, metallic charge) pairs, for matching feedstock rows.
+
+    Args:
+        primary_feedstocks: The prepared primary feedstocks (``fixtures/primary_feedstocks.json``).
+
+    Returns:
+        Columns ``technology, feedstock``, one row per distinct pair. Technologies are
+        upper-cased to match the post-processed table (repository-loaded feedstocks
+        carry them lower-cased).
+    """
+    pairs = {(fs.technology.upper(), fs.metallic_charge) for fs in primary_feedstocks if fs.metallic_charge}
+    return pd.DataFrame(sorted(pairs), columns=["technology", "feedstock"])
+
+
+def aggregate_charge_use(post_processed: pd.DataFrame, primary_feedstocks: list[PrimaryFeedstock]) -> pd.DataFrame:
+    """Metallic charge use per year, geography, technology, product and charge.
+
+    Args:
+        post_processed: The post-processed furnace-group table.
+        primary_feedstocks: The prepared primary feedstocks, whose ``metallic_charge``
+            fields identify which feedstock rows are charges.
+
+    Returns:
+        Columns ``year, geo, technology, product, charge, n, use_mt``: the allocated
+        tonnage of each charge (Mt) and the number of furnace groups charging it.
+        Each furnace group's rows already split its demand across its charges, so a
+        group running several charges at different shares contributes each share to
+        its own charge — no per-group deduplication beyond the (furnace group, year,
+        feedstock) grain.
+
+    Raises:
+        ValueError: If a required column is missing, or the Bill of Materials names
+            no metallic charge at all.
+
+    Notes:
+        Feedstock rows that are no technology's metallic charge (e.g. ``bio_pci``
+        procurement rows) are dropped silently; rows whose feedstock is a charge of
+        some *other* technology only are warned about, since they point at a Bill of
+        Materials gap.
+    """
+    required = ["year", "furnace_group_id", "technology", "product", "feedstock", "demand"]
+    missing = [column for column in required if column not in post_processed.columns]
+    if missing:
+        raise ValueError(f"The post-processed table has no {', '.join(missing)} column(s)")
+    geo_column = next((column for column in GEO_COLUMNS if column in post_processed.columns), None)
+    if geo_column is None:
+        raise ValueError(f"The post-processed table has none of the geo columns {', '.join(GEO_COLUMNS)}")
+    charges = technology_charges(primary_feedstocks)
+    if charges.empty:
+        raise ValueError("The primary feedstocks name no metallic charge — cannot identify charge rows")
+
+    table = post_processed.loc[
+        post_processed["feedstock"].notna() & (post_processed["demand"] > 0), [geo_column, *required]
+    ].rename(columns={geo_column: "geo"})
+    table = table.drop_duplicates(subset=["furnace_group_id", "year", "feedstock"])
+    merged = table.merge(charges, on=["technology", "feedstock"], how="left", indicator=True)
+    matched = merged[merged["_merge"] == "both"]
+
+    unmatched = merged[(merged["_merge"] != "both") & merged["feedstock"].isin(set(charges["feedstock"]))]
+    if len(unmatched):
+        combos = unmatched.groupby(["technology", "feedstock"])["demand"].sum()
+        names = ", ".join("_".join(key) for key in list(combos.index)[:8])
+        logger.warning(
+            "%d feedstock row(s) (%.1f Mt) carry a metallic charge their technology has no Bill of "
+            "Materials entry for — omitted: %s",
+            len(unmatched),
+            combos.sum() / 1e6,
+            names,
+        )
+
+    matched = matched.drop(columns="_merge").rename(columns={"feedstock": "charge"})
+    grouped = matched.groupby(AGGREGATION_KEYS, dropna=False)
+    aggregated = (grouped["demand"].sum() / 1e6).to_frame("use_mt")
+    aggregated["n"] = grouped["furnace_group_id"].nunique()
+    return aggregated.reset_index()
+
+
+def scrap_supply_rows(
+    suppliers: Iterable[Supplier], country_mappings: list[CountryMapping], years: set[int]
+) -> pd.DataFrame:
+    """Local scrap supply per year and country, from the prepared suppliers.
+
+    Args:
+        suppliers: The prepared suppliers (``fixtures/suppliers.json``); only the
+            scrap ones count.
+        country_mappings: The run's country mappings, to resolve suppliers placed by
+            country name rather than ISO3.
+        years: The years to keep (the table's years).
+
+    Returns:
+        Columns ``year, geo, supply_mt``. Scrap suppliers carry no sub-national
+        geography, so ``geo`` is always a country.
+    """
+    resolve = geo_resolver(country_mappings)
+    rows = [
+        (int(year), supplier.location.iso3 or resolve(supplier.location.country), float(capacity) / 1e6)
+        for supplier in suppliers
+        if supplier.commodity == "scrap"
+        for year, capacity in supplier.capacity_by_year.items()
+        if int(year) in years
+    ]
+    supply = pd.DataFrame(rows, columns=["year", "geo", "supply_mt"])
+    return supply.groupby(["year", "geo"], as_index=False)[["supply_mt"]].sum()
+
+
+def pack_rows(aggregated: pd.DataFrame) -> list[dict[str, Any]]:
+    """Compact aggregated rows for embedding in the viewer.
+
+    Args:
+        aggregated: Output of :func:`aggregate_charge_use`.
+
+    Returns:
+        One short-keyed record per row: ``y`` year, ``g`` geo, ``t`` technology,
+        ``p`` product, ``c`` charge, ``n`` furnace groups and ``v`` use (Mt, four
+        decimals).
+    """
+    return [
+        {
+            "y": int(row["year"]),
+            "g": row["geo"],
+            "t": row["technology"],
+            "p": row["product"],
+            "c": row["charge"],
+            "n": int(row["n"]),
+            "v": round(float(row["use_mt"]), 4),
+        }
+        for row in aggregated.to_dict("records")
+    ]
+
+
+def pack_supply(supply: pd.DataFrame) -> list[dict[str, Any]]:
+    """Compact scrap-supply rows for embedding in the viewer.
+
+    Args:
+        supply: Output of :func:`scrap_supply_rows`.
+
+    Returns:
+        One short-keyed record per row: ``y`` year, ``g`` country and ``v`` supply
+        (Mt, four decimals). Rows that round to zero are dropped.
+    """
+    rows = []
+    for row in supply.to_dict("records"):
+        volume = round(float(row["supply_mt"]), 4)
+        if volume > 0:
+            rows.append({"y": int(row["year"]), "g": row["geo"], "v": volume})
+    return rows

--- a/tests/unit/test_interactive_capacity_production.py
+++ b/tests/unit/test_interactive_capacity_production.py
@@ -3,6 +3,7 @@
 import pandas as pd
 import pytest
 
+from steelo.domain.models import DemandCenter, Location
 from steelo.utilities.interactive import capacity_production
 
 
@@ -42,3 +43,22 @@ def test_pack_rows_compacts_aggregates() -> None:
 
     deu_2026 = next(row for row in packed if row["g"] == "DEU" and row["y"] == 2026)
     assert deu_2026 == {"y": 2026, "g": "DEU", "t": "EAF", "p": "steel", "n": 1, "cap": 1.2, "pr": 1.1}
+
+
+def test_steel_demand_rows_sums_centres_by_country_within_years() -> None:
+    """Demand centres sum per country; years outside the table's range are excluded."""
+    beijing = Location(lat=1.0, lon=2.0, country="China", region="R", iso3="CHN")
+    centres = [
+        DemandCenter("China_1", beijing, {2025: 1_000_000, 2100: 9e9}),
+        DemandCenter("China_2", beijing, {2025: 500_000}),
+    ]
+
+    demand = capacity_production.steel_demand_rows(centres, {2025})
+
+    assert [(r.year, r.geo, r.volume_mt) for r in demand.itertuples()] == [(2025, "CHN", 1.5)]
+
+
+def test_pack_demand_drops_zero_rows() -> None:
+    """Demand rows carry short keys; rows that round to zero are dropped."""
+    steel_demand = pd.DataFrame([(2025, "CHN", 2.0), (2025, "ABW", 0.00001)], columns=["year", "geo", "volume_mt"])
+    assert capacity_production.pack_demand(steel_demand) == [{"y": 2025, "g": "CHN", "v": 2.0}]

--- a/tests/unit/test_interactive_metallic_charge_use.py
+++ b/tests/unit/test_interactive_metallic_charge_use.py
@@ -1,0 +1,152 @@
+"""Tests for the metallic-charge viewer's row packing (steelo.utilities.interactive.metallic_charge_use)."""
+
+import pandas as pd
+import pytest
+
+from steelo.domain.models import CountryMapping, Location, PrimaryFeedstock, Supplier
+from steelo.utilities.interactive import metallic_charge_use
+
+
+def sample_post_processed() -> pd.DataFrame:
+    """A BF charging two ore grades at shares, an EAF on scrap + pig iron, and a BOF on hot metal."""
+    columns = ["year", "geo_key", "furnace_group_id", "technology", "product", "feedstock", "demand"]
+    rows = [
+        # Same furnace group and year, two charges at different shares → each counts its own demand
+        [2025, "CHN:CN-HE", "P1_0", "BF", "iron", "io_low", 1_500_000.0],
+        [2025, "CHN:CN-HE", "P1_0", "BF", "iron", "io_high", 700_000.0],
+        # Procurement rows are no technology's metallic charge → dropped silently
+        [2025, "CHN:CN-HE", "P1_0", "BF", "iron", "bio_pci", 50_000.0],
+        [2025, "DEU", "P2_0", "EAF", "steel", "scrap", 600_000.0],
+        [2025, "DEU", "P2_0", "EAF", "steel", "pig_iron", 500_000.0],
+        [2025, "DEU", "P3_0", "BOF", "steel", "hot_metal", 1_000_000.0],
+        # Zero demand and missing feedstock rows are excluded
+        [2025, "DEU", "P2_0", "EAF", "steel", "dri_high", 0.0],
+        [2025, "DEU", "P3_0", "BOF", "steel", None, None],
+    ]
+    return pd.DataFrame(rows, columns=columns)
+
+
+def primary_feedstock(technology: str, metallic_charge: str, reductant: str = "") -> PrimaryFeedstock:
+    """A minimal Bill of Materials entry naming a metallic charge."""
+    return PrimaryFeedstock(metallic_charge=metallic_charge, reductant=reductant, technology=technology)
+
+
+def sample_bom() -> list[PrimaryFeedstock]:
+    """BOM entries matching the sample table; technologies lower-cased as the repository loads them."""
+    return [
+        primary_feedstock("bf", "io_low", "coke+pci"),
+        primary_feedstock("bf", "io_high", "coke+pci"),
+        primary_feedstock("eaf", "scrap"),
+        primary_feedstock("eaf", "pig_iron"),
+        primary_feedstock("eaf", "dri_high"),
+        primary_feedstock("bof", "hot_metal"),
+    ]
+
+
+def sample_country_mappings() -> list[CountryMapping]:
+    """Two countries, for resolving suppliers placed by country name."""
+    common = {"irena_name": "", "ssp_region": "", "tiam_ucl_region": ""}
+    return [
+        CountryMapping(country="Germany", iso2="DE", iso3="DEU", region_for_outputs="Europe", **common),
+        CountryMapping(country="China", iso2="CN", iso3="CHN", region_for_outputs="China", **common),
+    ]
+
+
+def test_aggregate_sums_each_charge_separately() -> None:
+    """A furnace group's charges keep their own shares; procurement rows drop out silently."""
+    aggregated = metallic_charge_use.aggregate_charge_use(sample_post_processed(), sample_bom())
+
+    rows = {(r.technology, r.charge): (r.product, r.use_mt, r.n) for r in aggregated.itertuples()}
+    assert rows == {
+        ("BF", "io_low"): ("iron", 1.5, 1),
+        ("BF", "io_high"): ("iron", 0.7, 1),
+        ("EAF", "scrap"): ("steel", 0.6, 1),
+        ("EAF", "pig_iron"): ("steel", 0.5, 1),
+        ("BOF", "hot_metal"): ("steel", 1.0, 1),
+    }
+
+
+def test_aggregate_counts_duplicate_feedstock_rows_once() -> None:
+    """A repeated (furnace group, year, feedstock) row must not double its demand."""
+    table = sample_post_processed()
+    table = pd.concat([table, table.iloc[[0]]], ignore_index=True)
+
+    aggregated = metallic_charge_use.aggregate_charge_use(table, sample_bom())
+
+    io_low = aggregated[aggregated["charge"] == "io_low"].iloc[0]
+    assert io_low["use_mt"] == pytest.approx(1.5)
+    assert io_low["n"] == 1
+
+
+def test_aggregate_warns_on_charge_of_another_technology(caplog) -> None:
+    """A feedstock that is a charge elsewhere but not for its own technology is warned about and omitted."""
+    table = sample_post_processed()
+    table.loc[len(table)] = [2025, "DEU", "P4_0", "BF", "iron", "scrap", 400_000.0]
+
+    with caplog.at_level("WARNING", logger="steelo.utilities.interactive.metallic_charge_use"):
+        aggregated = metallic_charge_use.aggregate_charge_use(table, sample_bom())
+
+    assert "BF_scrap" in caplog.text
+    assert not ((aggregated["technology"] == "BF") & (aggregated["charge"] == "scrap")).any()
+
+
+def test_aggregate_rejects_table_without_required_columns() -> None:
+    """A table missing the feedstock column fails loudly rather than producing an empty chart."""
+    with pytest.raises(ValueError, match="feedstock"):
+        metallic_charge_use.aggregate_charge_use(sample_post_processed().drop(columns=["feedstock"]), sample_bom())
+
+
+def test_aggregate_rejects_bom_without_metallic_charges() -> None:
+    """A Bill of Materials naming no metallic charge cannot identify any row."""
+    with pytest.raises(ValueError, match="no metallic charge"):
+        metallic_charge_use.aggregate_charge_use(sample_post_processed(), [])
+
+
+def test_aggregate_falls_back_to_iso3_without_geo_key() -> None:
+    """Tables from runs that predate the geo_key column are keyed by country."""
+    table = sample_post_processed().rename(columns={"geo_key": "iso3"})
+    aggregated = metallic_charge_use.aggregate_charge_use(table, sample_bom())
+
+    assert set(aggregated["geo"]) == {"CHN:CN-HE", "DEU"}
+
+
+def test_scrap_supply_rows_sums_scrap_by_country_within_years() -> None:
+    """Scrap sub-centres sum per country, other commodities and years are excluded, names resolve to ISO3."""
+    berlin = Location(lat=1.0, lon=2.0, country="Germany", region="R", iso3="DEU")
+    unplaced = Location(lat=1.0, lon=2.0, country="Germany", region="R", iso3="")
+    suppliers = [
+        Supplier("DEU_scrap_1", berlin, "scrap", {2025: 1_000_000, 2030: 9e9}, {}),
+        Supplier("DEU_scrap_2", unplaced, "scrap", {2025: 500_000}, {}),
+        Supplier("mine", berlin, "io_mid", {2025: 400_000}, {}),
+    ]
+
+    supply = metallic_charge_use.scrap_supply_rows(suppliers, sample_country_mappings(), {2025})
+
+    assert [(r.year, r.geo, r.supply_mt) for r in supply.itertuples()] == [(2025, "DEU", 1.5)]
+
+
+def test_pack_rows_compacts_aggregates() -> None:
+    """Rows carry short keys with the charge tonnage to four decimals."""
+    aggregated = metallic_charge_use.aggregate_charge_use(sample_post_processed(), sample_bom())
+    packed = metallic_charge_use.pack_rows(aggregated)
+
+    assert {
+        "y": 2025,
+        "g": "CHN:CN-HE",
+        "t": "BF",
+        "p": "iron",
+        "c": "io_low",
+        "n": 1,
+        "v": 1.5,
+    } in packed
+
+
+def test_pack_supply_drops_zero_rows() -> None:
+    """Supply rows carry short keys; rows that round to zero are dropped."""
+    supply = pd.DataFrame([(2025, "DEU", 1.5), (2025, "CHN", 0.00001)], columns=["year", "geo", "supply_mt"])
+    assert metallic_charge_use.pack_supply(supply) == [{"y": 2025, "g": "DEU", "v": 1.5}]
+
+
+def test_charge_colours_cover_the_house_order() -> None:
+    """Every ordered charge has a house colour, so the legend never falls back mid-list."""
+    assert list(metallic_charge_use.CHARGE_COLOURS) == metallic_charge_use.CHARGE_ORDER

--- a/tests/unit/test_interactive_plots.py
+++ b/tests/unit/test_interactive_plots.py
@@ -7,10 +7,19 @@ import pandas as pd
 
 from steelo.adapters.repositories.json_repository import (
     BiomassAvailabilityJsonRepository,
+    DemandCenterJsonRepository,
     PrimaryFeedstockJsonRepository,
     SupplierJsonRepository,
 )
-from steelo.domain.models import BiomassAvailability, CountryMapping, Location, PrimaryFeedstock, Supplier, Year
+from steelo.domain.models import (
+    BiomassAvailability,
+    CountryMapping,
+    DemandCenter,
+    Location,
+    PrimaryFeedstock,
+    Supplier,
+    Year,
+)
 from steelo.domain.models import Volumes
 from steelo.utilities.interactive import InteractivePlotter, clearing_config, interactive_plots
 from steelo.utilities.interactive import supply_demand
@@ -121,13 +130,20 @@ def test_plot_emissions_writes_self_contained_viewer(tmp_path) -> None:
 
 
 def test_plot_capacity_and_production_writes_self_contained_viewer(tmp_path) -> None:
-    """The capacity and production viewer reuses the table read for the emissions viewer."""
+    """The viewer reuses the table read for the emissions viewer and embeds the steel demand."""
     csv_path = tmp_path / "post_processed_test.csv"
     sample_post_processed().to_csv(csv_path, index=False)
+    fixtures = tmp_path / "fixtures"
+    fixtures.mkdir()
+    centre_location = Location(lat=1.0, lon=2.0, country="China", region="R", iso3="CHN")
+    DemandCenterJsonRepository(fixtures / "demand_centers.json").add_list(
+        # 2100 lies outside the table's years and must not reach the viewer.
+        [DemandCenter("China_2", centre_location, {Year(2025): Volumes(2_500_000), Year(2100): Volumes(9e9)})]
+    )
     plotter = InteractivePlotter(tmp_path / "plots", sample_country_mappings(), run_title="sim_test")
 
     assert plotter.plot_emissions(csv_path) is not None
-    written = plotter.plot_capacity_and_production(csv_path)
+    written = plotter.plot_capacity_and_production(csv_path, fixtures / "demand_centers.json")
 
     assert written == tmp_path / "plots" / "interactive" / "capacity_and_production.html"
     html = written.read_text()
@@ -135,7 +151,12 @@ def test_plot_capacity_and_production_writes_self_contained_viewer(tmp_path) -> 
         assert placeholder not in html
     assert "const Interactive" in html
     assert '"cap": 3.0' in html and '"pr": 2.0' in html
+    assert '"demand": [{"y": 2025, "g": "CHN", "v": 2.5}]' in html
     assert list(plotter._tables) == [csv_path]
+
+    # A missing fixture still produces the viewer, without the overlay data.
+    assert plotter.plot_capacity_and_production(csv_path) == written
+    assert '"demand": []' in written.read_text()
 
 
 def test_plot_cost_curves_writes_self_contained_viewer(tmp_path) -> None:
@@ -426,3 +447,42 @@ def test_plot_reductant_use_writes_self_contained_viewer(tmp_path) -> None:
     bare_csv = tmp_path / "post_processed_bare.csv"
     sample_post_processed().drop(columns=["chosen_reductant"]).to_csv(bare_csv, index=False)
     assert plotter.plot_reductant_use(bare_csv, fixtures / "primary_feedstocks.json") is None
+
+
+def test_plot_metallic_charge_use_writes_self_contained_viewer(tmp_path) -> None:
+    """The metallic-charge viewer embeds the per-charge rows and the scrap supply overlay."""
+    csv_path = tmp_path / "post_processed_test.csv"
+    sample_post_processed().to_csv(csv_path, index=False)
+    fixtures = tmp_path / "fixtures"
+    fixtures.mkdir()
+    PrimaryFeedstockJsonRepository(fixtures / "primary_feedstocks.json").add_list(sample_primary_feedstocks())
+    scrap_location = Location(lat=1.0, lon=2.0, country="Germany", region="R", iso3="DEU")
+    SupplierJsonRepository(fixtures / "suppliers.json").add_list(
+        [Supplier("Germany_scrap", scrap_location, "scrap", {Year(2025): Volumes(2_000_000)}, {})]
+    )
+    plotter = InteractivePlotter(tmp_path / "plots", sample_country_mappings(), run_title="sim_test")
+
+    written = plotter.plot_metallic_charge_use(
+        csv_path, fixtures / "primary_feedstocks.json", fixtures / "suppliers.json"
+    )
+
+    assert written == tmp_path / "plots" / "interactive" / "metallic_charge_use.html"
+    html = written.read_text()
+    for placeholder in ("__PLOTLYJS__", "__COMMON_JS__", "__COMMON_CSS__", "__CONFIG__", "__DATA__"):
+        assert placeholder not in html
+    assert "const Interactive" in html
+    assert '{"y": 2025, "g": "CHN:CN-HE", "t": "BF", "p": "iron", "c": "io_low", "n": 1, "v": 3.0}' in html
+    assert '{"y": 2025, "g": "DEU", "t": "EAF", "p": "steel", "c": "scrap", "n": 1, "v": 1.1}' in html
+    assert '"supply": [{"y": 2025, "g": "DEU", "v": 2.0}]' in html
+    assert '"chargeColours"' in html and '"chargeOrder"' in html
+
+    # A missing suppliers fixture still produces the viewer, without the overlay data.
+    assert plotter.plot_metallic_charge_use(csv_path, fixtures / "primary_feedstocks.json") == written
+    assert '"supply": []' in written.read_text()
+
+    # A missing Bill of Materials, a missing table or a table without the feedstock column skips the viewer.
+    assert plotter.plot_metallic_charge_use(csv_path, fixtures / "absent.json") is None
+    assert plotter.plot_metallic_charge_use(tmp_path / "absent.csv", fixtures / "primary_feedstocks.json") is None
+    bare_csv = tmp_path / "post_processed_bare.csv"
+    sample_post_processed().drop(columns=["feedstock"]).to_csv(bare_csv, index=False)
+    assert plotter.plot_metallic_charge_use(bare_csv, fixtures / "primary_feedstocks.json") is None


### PR DESCRIPTION
- New interactive viewer `metallic_charge_use.html`: charge use per feedstock row (charges identified via the Bill of Materials), steel/iron split, stacking by charge/technology/region, charge tickboxes, local scrap supply overlay
- `capacity_and_production.html`: dashed steel demand line from `fixtures/demand_centers.json`; hover and summary show the share of demand met by the displayed production