### PR TITLE
Make plots/TM and plots/GEO opt-in and turn diagnostics off by default

### DIFF
--- a/docs/domain_simulation_logic/outputs_and_postprocessing.md
+++ b/docs/domain_simulation_logic/outputs_and_postprocessing.md
@@ -68,12 +68,16 @@ Emissions and cost-curve plots write to top-level sibling folders rather than un
 output/
   plots/
     PAM/        # plant-agent plots (capacity, capex, charges, prices)
-    GEO/        # geospatial / new-plant plots (maps on milestone years; power-price histogram and mine map final-year-only)
-    TM/         # trade-model plots
+    GEO/        # opt-in (--plot-geo): geospatial / new-plant plots (maps on milestone years; power-price histogram and mine map final-year-only)
+    TM/         # opt-in (--plot-tm): per-year trade maps, replaced by the interactive trade viewers
     emissions/  # SteelPlotter.plot_emissions_by_technology
     cost_curves/  # SteelPlotter cost-curve methods
     interactive/  # InteractivePlotter viewers (self-contained HTML, see below)
 ```
+
+`plots/GEO/` and `plots/TM/` are written only when `run_simulation` is given `--plot-geo` / `--plot-tm`; without the flag the folder is not created. The trade maps are replaced by the `trade_matrix.html`, `trade_network.html` and `trade_allocations.html` viewers below, which read the per-year `TM/steel_trade_allocations_<year>.csv` files written on every run.
+
+Diagnostics exports under `output/diagnostics/` are off by default; set `STEEL_DIAGNOSTICS=1` to write them (`STEEL_DIAGNOSTICS_DETAIL` and `STEEL_DIAGNOSTICS_PATH` are described in `steelo.domain.diagnostics`).
 
 Cost-curve filenames follow `cost_curve_{product}_by_{aggregation}_{year}.png` (e.g. `cost_curve_iron_by_region_2025.png`); the legacy ordering `{product}_cost_curve_by_{aggregation}_{year}.png` is no longer produced by the new methods. `plot_cost_curve_with_breakdown` retains its previous filename convention.
 
@@ -92,6 +96,7 @@ All viewers share one shell (`common.js` / `common.css`): a run selector, a geog
 | `cost_curves.html` | Per-commodity cost curves with the engine's market-clearing rule (clearing shares and price buffers from the run config) | `post_processed_<timestamp>.csv` + `data/market_prices_<start>_<end>.csv` |
 | `trade_matrix.html` | Steel, iron products, iron ore (mine-labelled origins) and scrap shipped between geographies, per year, each product selectable individually | `TM/steel_trade_allocations_<year>.csv` |
 | `trade_network.html` | The same trade flows as a chord diagram with a map layout | `TM/steel_trade_allocations_<year>.csv` |
+| `trade_allocations.html` | Every year's trade-LP allocations as commodity arcs over a world map, with a year slider and commodity toggles | `TM/steel_trade_allocations_<year>.csv` |
 | `supply_demand.html` | Supply and demand for steel, scrap, iron ore, CO2 storage and biomass | `TM/` allocations + `fixtures/suppliers.json` + `fixtures/biomass_availability.json` |
 | `reductant_use.html` | Iron production and absolute reductant use per reductant | `post_processed_<timestamp>.csv` + `fixtures/primary_feedstocks.json` |
 | `metallic_charge_use.html` | Metallic charges fed into steel (scrap, hot metal, pig iron, DRI/HBI) and iron (ore grades), per charge / technology / region, with a local scrap supply overlay | `post_processed_<timestamp>.csv` + `fixtures/primary_feedstocks.json` + `fixtures/suppliers.json` |

--- a/docs/user_guide/cli_commands.md
+++ b/docs/user_guide/cli_commands.md
@@ -23,6 +23,10 @@ options:
                         Base output directory (default: $STEELO_HOME/output)
   --log-level LOG_LEVEL
                         Logging level (default: WARNING)
+  --plot-tm             Write the per-year trade maps under plots/TM (off by
+                        default; the interactive trade viewers replace them)
+  --plot-geo            Write the geospatial PNGs under plots/GEO (off by
+                        default)
 
 price configuration:
   --peg-iron-to-steel-price

--- a/docs/user_guide/running_simulations_locally.md
+++ b/docs/user_guide/running_simulations_locally.md
@@ -361,6 +361,7 @@ run_simulation --start-year 2025 --end-year 2035 --output-dir ./outputs > /tmp/s
 - `--end-year`: Ending year for simulation (default: 2050)
 - `--output-dir`: Base output directory for results (default: $STEELO_HOME/output)
 - `--log-level`: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL; default: WARNING)
+- `--plot-tm` / `--plot-geo`: Also write the per-year trade maps (`plots/TM/`) and the geospatial PNGs (`plots/GEO/`); both are off by default, and the interactive viewers under `plots/interactive/` replace the trade maps
 
 **Data Files (usually handled automatically via caching):**
 - `--plants-json`: Path to plants JSON file

--- a/src/steelo/bootstrap.py
+++ b/src/steelo/bootstrap.py
@@ -428,14 +428,16 @@ def bootstrap_simulation(
 
         plots_dir = config.output_dir / "plots"
         pam_plots_dir = plots_dir / "PAM"
-        geo_plots_dir = plots_dir / "GEO"
-        tm_plots_dir = plots_dir / "TM"
+        geo_plots_dir = plots_dir / "GEO" if config.plot_geo else None
+        tm_plots_dir = plots_dir / "TM" if config.plot_tm else None
 
         # Create the directories
         plots_dir.mkdir(parents=True, exist_ok=True)
         pam_plots_dir.mkdir(parents=True, exist_ok=True)
-        geo_plots_dir.mkdir(parents=True, exist_ok=True)
-        tm_plots_dir.mkdir(parents=True, exist_ok=True)
+        if geo_plots_dir is not None:
+            geo_plots_dir.mkdir(parents=True, exist_ok=True)
+        if tm_plots_dir is not None:
+            tm_plots_dir.mkdir(parents=True, exist_ok=True)
 
         env.plot_paths = PlotPaths(
             plots_dir=plots_dir,
@@ -464,9 +466,13 @@ def bootstrap_simulation(
         env.geo_paths = GeoDataPaths(
             data_dir=config.data_dir,
             atlite_dir=config.data_dir / "atlite",
-            geo_plots_dir=config.output_dir / "plots" / "GEO"
-            if config.output_dir
-            else config.data_dir / "output" / "plots" / "GEO",
+            geo_plots_dir=(
+                config.output_dir / "plots" / "GEO"
+                if config.output_dir
+                else config.data_dir / "output" / "plots" / "GEO"
+            )
+            if config.plot_geo
+            else None,
             terrain_nc_path=terrain_path,
             rail_distance_nc_path=rail_distance_path,
             railway_capex_csv_path=config.data_dir / "railway_capex.csv",

--- a/src/steelo/domain/diagnostics.py
+++ b/src/steelo/domain/diagnostics.py
@@ -17,7 +17,7 @@ import os
 from pathlib import Path
 from typing import Iterable, Sequence
 
-DIAGNOSTICS_ENABLED = os.getenv("STEEL_DIAGNOSTICS", "1") == "1"
+DIAGNOSTICS_ENABLED = os.getenv("STEEL_DIAGNOSTICS", "0") == "1"
 DIAGNOSTICS_DETAIL = os.getenv("STEEL_DIAGNOSTICS_DETAIL", "summary").lower()
 DIAGNOSTICS_BASE_PATH = Path(os.getenv("STEEL_DIAGNOSTICS_PATH", "output/diagnostics"))
 

--- a/src/steelo/domain/models.py
+++ b/src/steelo/domain/models.py
@@ -340,7 +340,7 @@ class GeoDataPaths:
     # Base directories
     data_dir: Path
     atlite_dir: Path
-    geo_plots_dir: Path
+    geo_plots_dir: Optional[Path]  # None disables the plots/GEO output
 
     # Specific data files
     terrain_nc_path: Path

--- a/src/steelo/economic_models/plant_agent.py
+++ b/src/steelo/economic_models/plant_agent.py
@@ -520,11 +520,7 @@ class AllocationModel:
         if output_dir is None:
             raise ValueError("output_dir must be set on bus.env")
 
-        if non_empty_allocations:
-            # # pickle the allocations for debugging purposes TODO: remove
-            # with open(output_dir / f"steel_trade_allocations_{bus.env.year}.pkl", "wb") as f:
-            #     pickle.dump(non_empty_allocations, f)
-
+        if non_empty_allocations and bus.env.plot_paths is not None and bus.env.plot_paths.tm_plots_dir is not None:
             # Create detailed trade map (existing pydeck visualization)
             plot_detailed_trade_map(
                 allocations_by_commodity=non_empty_allocations, chosen_year=bus.env.year, plot_paths=bus.env.plot_paths

--- a/src/steelo/entrypoints/cli.py
+++ b/src/steelo/entrypoints/cli.py
@@ -149,7 +149,7 @@ def run_full_simulation() -> str:
     parser.add_argument(
         "--plot-tm",
         action="store_true",
-        help="Write the per-year trade maps under plots/TM (off by default)",
+        help="Write the per-year trade maps under plots/TM (off by default; the interactive trade viewers replace them)",
     )
     parser.add_argument(
         "--plot-geo",

--- a/src/steelo/entrypoints/cli.py
+++ b/src/steelo/entrypoints/cli.py
@@ -146,6 +146,16 @@ def run_full_simulation() -> str:
         action="store_true",
         help="Enable furnace group clustering to reduce LP complexity",
     )
+    parser.add_argument(
+        "--plot-tm",
+        action="store_true",
+        help="Write the per-year trade maps under plots/TM (off by default)",
+    )
+    parser.add_argument(
+        "--plot-geo",
+        action="store_true",
+        help="Write the geospatial PNGs under plots/GEO (off by default)",
+    )
 
     parser.add_argument(
         "--clustering-scope",
@@ -300,6 +310,8 @@ def run_full_simulation() -> str:
                 "run_name": args.run_name,
                 "log_level": log_level,
                 "random_seed": args.random_seed,
+                "plot_tm": args.plot_tm,
+                "plot_geo": args.plot_geo,
             }
 
             # Add custom baseload_power_sim_dir if provided
@@ -387,6 +399,8 @@ def run_full_simulation() -> str:
                     "run_name": args.run_name,
                     "log_level": log_level,
                     "random_seed": args.random_seed,
+                    "plot_tm": args.plot_tm,
+                    "plot_geo": args.plot_geo,
                 }
 
                 # Add custom baseload_power_sim_dir if provided
@@ -754,12 +768,13 @@ def show_geo_plots() -> None:
 
     args = parser.parse_args()
 
-    # Create SimulationConfig from data directory
+    # Create SimulationConfig from data directory; this command exists to make the GEO plots
     config = SimulationConfig.from_data_directory(
         data_dir=args.data_dir,
         output_dir=args.output_dir,
         start_year=args.year,
         end_year=args.year,
+        plot_geo=True,
     )
 
     # Create PlotPaths object

--- a/src/steelo/simulation.py
+++ b/src/steelo/simulation.py
@@ -426,6 +426,8 @@ class SimulationConfig:
     # Use InitVar to accept but not store deprecated parameter for backward compatibility
     global_bf_ban: InitVar[bool] = None
     include_tariffs: bool = True  # Whether to include tariffs in trade modeling
+    plot_tm: bool = False  # Write the per-year trade maps under plots/TM
+    plot_geo: bool = False  # Write the geospatial PNGs under plots/GEO
 
     # === Optional paths ===
     # Input data (for locating fixtures)
@@ -614,11 +616,12 @@ class SimulationConfig:
             self.plots_dir = Path(self.plots_dir)
         self.plots_dir.mkdir(parents=True, exist_ok=True)
 
-        if self.geo_plots_dir is None:
+        if self.geo_plots_dir is None and self.plot_geo:
             self.geo_plots_dir = self.plots_dir / "GEO"
-        else:
+        elif self.geo_plots_dir is not None:
             self.geo_plots_dir = Path(self.geo_plots_dir)
-        self.geo_plots_dir.mkdir(parents=True, exist_ok=True)
+        if self.geo_plots_dir is not None:
+            self.geo_plots_dir.mkdir(parents=True, exist_ok=True)
 
         if self.pam_plots_dir is None:
             self.pam_plots_dir = self.plots_dir / "PAM"

--- a/src/steelo/utilities/plotting.py
+++ b/src/steelo/utilities/plotting.py
@@ -2054,6 +2054,9 @@ def plot_screenshot(
     plot_paths: Optional["PlotPaths"] = None,
     show=False,
 ):
+    # Skip entirely when a save is requested but geo plotting is disabled (no geo_plots_dir)
+    if save_name and (plot_paths is None or plot_paths.geo_plots_dir is None):
+        return
     # Select variable to plot
     if var:
         data_to_plot = data[var]
@@ -2153,6 +2156,8 @@ def plot_screenshot(
 
 
 def plot_landtype(data, plot_paths: "PlotPaths", var=None, title=None, save_name=None):
+    if save_name and (plot_paths is None or plot_paths.geo_plots_dir is None):
+        return
     # Initialize plot
     lat_lon_ratio = len(data.lat) / len(data.lon)
     fig = plt.figure(figsize=(10, 10 * lat_lon_ratio))
@@ -2235,6 +2240,8 @@ def plot_bubble_map(
     """
     Plots a bubble map where the size of each bubble corresponds to the weight at that location.
     """
+    if save_name and (plot_paths is None or plot_paths.geo_plots_dir is None):
+        return
     # Initialize plot
     fig = plt.figure(figsize=(10, 6))
     ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
@@ -2290,6 +2297,8 @@ def plot_value_histogram(
     - subtitle (str, optional): Smaller grey caption rendered below the title.
     - xlabel (str, optional): Custom x-axis label; defaults to ``"Values of '{var_name}'"``.
     """
+    if plot_paths is None or plot_paths.geo_plots_dir is None:
+        return
     if var_name is None:
         var_name = list(ds.data_vars)[0]
 
@@ -2347,6 +2356,8 @@ def plot_value_histogram(
 
 
 def plot_global_grid_with_iso3(grid, plot_paths: "PlotPaths") -> None:
+    if plot_paths is None or plot_paths.geo_plots_dir is None:
+        return
     # Visualize the global grid with ISO3 codes
     plt.figure(figsize=(10, 5))
     ax = plt.axes(projection=ccrs.PlateCarree())  # type: ignore[call-arg]

--- a/tests/unit/test_geo_paths.py
+++ b/tests/unit/test_geo_paths.py
@@ -41,13 +41,14 @@ def test_geo_data_paths_creation():
 
 
 def test_simulation_config_geo_paths(tmp_path):
-    """Test that SimulationConfig properly initializes output paths."""
+    """Test that SimulationConfig properly initializes output paths (GEO plots opt-in via plot_geo)."""
     config = SimulationConfig(
         start_year=2025,
         end_year=2030,
         master_excel_path=tmp_path / "master.xlsx",
         output_dir=tmp_path / "output",
         technology_settings=get_default_technology_settings(),
+        plot_geo=True,
     )
 
     # Check that output paths are properly set
@@ -63,6 +64,20 @@ def test_simulation_config_geo_paths(tmp_path):
     assert config.geo_plots_dir.exists()
     assert config.pam_plots_dir.exists()
     assert config.tm_output_dir.exists()
+
+
+def test_simulation_config_geo_plots_off_by_default(tmp_path):
+    """Without plot_geo the GEO plot directory is neither set nor created."""
+    config = SimulationConfig(
+        start_year=2025,
+        end_year=2030,
+        master_excel_path=tmp_path / "master.xlsx",
+        output_dir=tmp_path / "output",
+        technology_settings=get_default_technology_settings(),
+    )
+
+    assert config.geo_plots_dir is None
+    assert not (tmp_path / "output" / "plots" / "GEO").exists()
 
 
 def test_custom_geo_paths_in_config(tmp_path):

--- a/tests/unit/test_simulation_config_from_master_excel.py
+++ b/tests/unit/test_simulation_config_from_master_excel.py
@@ -55,7 +55,7 @@ def test_config_factory_from_master_excel(master_excel_with_minimal_data, tmp_pa
 
         # Should have created derived directories
         assert config.plots_dir is not None
-        assert config.geo_plots_dir is not None
+        assert config.geo_plots_dir is None  # GEO plots are opt-in via plot_geo
 
     except Exception as e:
         # Allow the test to pass if the implementation is incomplete


### PR DESCRIPTION
The per-year trade maps and geospatial PNGs are now written only with --plot-tm / --plot-geo; the interactive viewers replace the trade maps. Diagnostics exports need STEEL_DIAGNOSTICS=1. Docs updated to match.
